### PR TITLE
Add presubmits for the SDK

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,9 +17,9 @@ jobs:
         cache: "gradle"
 
 
-    - name: ktlintCheck
+    - name: ktfmtCheck
       shell: bash
-      run: ./gradlew ktlint
+      run: ./gradlew ktfmtCheck
   # Rust-Lint:
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,9 +15,25 @@ jobs:
           java-version: "11"
           cache: "gradle"
 
-      - name: ktfmtCheck
-        shell: bash
-        run: ./gradlew ktfmtCheck
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: ktfmtCheck
+
+  lint-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Rust lint
+        run: cargo-fmt --all --check
+
+  rust-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build all
+        run: cargo build --all-targets --all-features
+      - name: Test all
+        run: test --all-targets --all-features
 
   sdk-build:
     runs-on: ubuntu-latest
@@ -33,13 +49,71 @@ jobs:
         run: bash install-rust-toolchains.sh
 
       - name: Run local tests
-        run: ./gradlew test
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: test
 
       - name: Build debug
-        run: ./gradlew assembleDebug
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleDebug
 
       - name: Build release
-        run: ./gradlew assembleRelease
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleRelease
 
       - name: Final check
-        run: ./gradlew check
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: check
+
+  build-maven-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "gradle"
+
+      - name: Install Rust dependencies
+        run: bash install-rust-toolchains.sh
+
+      - name: Build Maven repo
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishAllPublicationsToLocalDirRepository
+
+      - name: Zip repo
+        run: cd build; zip -q -r designcompose_m2repo.zip designcompose_m2repo/
+
+      - name: Upload zipped repo
+        uses: actions/upload-artifacts@v3
+        with:
+          name: designcompose-m2-repo-zip
+          path: build/designcompose_m2repo.zip
+
+  validation-standalone-test:
+    runs-on: ubuntu-latest
+    needs: build-maven-repo
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "gradle"
+      - uses: actions/download-artifact@v3
+        with:
+          name: designcompose-m2-repo-zip
+
+      - name: Unpack repo
+        run: unzip designcompose_m2repo.zip
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PDesignComposeMavenRepo=designcompose_m2repo
+            check

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
       - name: Build all
         run: cargo build --all-targets --all-features
       - name: Test all
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
 
       - name: Install Rust toolchains
         run: bash install-rust-toolchains.sh
@@ -80,7 +80,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
 
       - name: Install Rust toolchains
         run: bash install-rust-toolchains.sh
@@ -103,16 +103,12 @@ jobs:
   figma-resources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5
-      - uses: bahmutov/npm-install@v1
-        with:
-          working-directory: |
-            support-figma/extended-layout-plugin
-            support-figma/auto-content-preview-widget
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
 
       - name: Build Plugin
         working-directory: support-figma/extended-layout-plugin
-        run: npm run build
+        run: npm ci; npm run build
       
       - name: Package Plugin
         working-directory: support-figma
@@ -130,7 +126,7 @@ jobs:
 
       - name: Build Widget
         working-directory: support-figma/auto-content-preview-widget
-        run: npm run build
+        run: npm ci; npm run build
 
       - name: Package Widget
         working-directory: support-figma

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "gradle"
 
       - uses: gradle/gradle-build-action@v2
         with:
@@ -43,13 +42,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "gradle"
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh
 
       - name: Run local tests
-      - uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: test
 
@@ -76,7 +74,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "gradle"
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh
@@ -104,7 +101,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-          cache: "gradle"
+
       - uses: actions/download-artifact@v3
         with:
           name: designcompose-m2-repo-zip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-kotlin:
     runs-on: ubuntu-latest
@@ -29,10 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: rust-cache@v2
       - name: Build all
         run: cargo build --all-targets --all-features
       - name: Test all
-        run: test --all-targets --all-features
+        run: cargo test --all-targets --all-features
 
   sdk-build:
     runs-on: ubuntu-latest
@@ -42,6 +47,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
+      - uses: rust-cache@v2
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh
@@ -74,6 +80,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
+      - uses: rust-cache@v2
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh
@@ -87,7 +94,7 @@ jobs:
         run: cd build; zip -q -r designcompose_m2repo.zip designcompose_m2repo/
 
       - name: Upload zipped repo
-        uses: actions/upload-artifacts@v3
+        uses: actions/upload-artifact@v3
         with:
           name: designcompose-m2-repo-zip
           path: build/designcompose_m2repo.zip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  Kotlin-Lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -17,7 +17,11 @@ jobs:
         cache: "gradle"
 
 
-    - name: ktlint
+    - name: ktlintCheck
       shell: bash
       run: ./gradlew ktlint
+  # Rust-Lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,12 +9,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Java 11
-      uses: actions/setup-java@v1.4.3
+    - uses: actions/setup-java@v3
       with:
+        distribution: "temurin"
         java-version: '11'
-        java-package: jdk
-        architecture: x64
+        cache: "gradle"
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -116,10 +116,11 @@ jobs:
       
       - name: Package Plugin
         working-directory: support-figma
-        run: zip -q -r extended-layout-plugin.zip |
-          extended-layout-plugin/manifest.json
-          extended-layout-plugin/ui.htm
-          extended-layout-plugin/code.js
+        run: |
+          zip -r extended-layout-plugin.zip \
+            extended-layout-plugin/manifest.json \
+            extended-layout-plugin/ui.html \
+            extended-layout-plugin/code.js
 
       - uses: actions/upload-artifact@v3
         with:
@@ -133,10 +134,11 @@ jobs:
 
       - name: Package Widget
         working-directory: support-figma
-        run: zip -q -r auto-content-preview-widget.zip |
-          auto-content-preview-widget/manifest.json
-          auto-content-preview-widget/ui.htm
-          auto-content-preview-widget/code.js
+        run: |
+          zip -r auto-content-preview-widget.zip \
+            auto-content-preview-widget/manifest.json \
+            auto-content-preview-widget/ui.html \
+            auto-content-preview-widget/code.js
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,4 +1,3 @@
-
 name: Presubmit
 
 on:
@@ -9,37 +8,38 @@ jobs:
   lint-kotlin:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: "temurin"
-        java-version: '11'
-        cache: "gradle"
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "gradle"
 
-
-    - name: ktfmtCheck
-      shell: bash
-      run: ./gradlew ktfmtCheck
+      - name: ktfmtCheck
+        shell: bash
+        run: ./gradlew ktfmtCheck
 
   sdk-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        distribution: "temurin"
-        java-version: '11'
-        cache: "gradle"
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "11"
+          cache: "gradle"
 
-    - name: Run local tests
-      run: ./gradlew test
+      - name: Install Rust dependencies
+        run: bash install-rust-toolchains.sh
 
-    - name: Build debug
-      run: ./gradlew assembleDebug
+      - name: Run local tests
+        run: ./gradlew test
 
-    - name: Build release
-      run: ./gradlew assembleRelease
+      - name: Build debug
+        run: ./gradlew assembleDebug
 
-    - name: Final check
-      run: ./gradlew check
+      - name: Build release
+        run: ./gradlew assembleRelease
 
+      - name: Final check
+        run: ./gradlew check

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Rust lint
         run: cargo-fmt --all --check
 
-  rust-build:
+  rust-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
           java-version: "11"
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install Rust dependencies
+      - name: Install Rust toolchains
         run: bash install-rust-toolchains.sh
 
       - name: Run local tests
@@ -82,7 +82,7 @@ jobs:
           java-version: "11"
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install Rust dependencies
+      - name: Install Rust toolchains
         run: bash install-rust-toolchains.sh
 
       - name: Build Maven repo
@@ -91,7 +91,8 @@ jobs:
           arguments: publishAllPublicationsToLocalDirRepository
 
       - name: Zip repo
-        run: cd build; zip -q -r designcompose_m2repo.zip designcompose_m2repo/
+        working-directory: build
+        run: zip -q -r designcompose_m2repo.zip designcompose_m2repo/
 
       - name: Upload zipped repo
         uses: actions/upload-artifact@v3
@@ -99,25 +100,45 @@ jobs:
           name: designcompose-m2-repo-zip
           path: build/designcompose_m2repo.zip
 
-  validation-standalone-test:
+  figma-resources:
     runs-on: ubuntu-latest
-    needs: build-maven-repo
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: bahmutov/npm-install@v1
         with:
-          distribution: "temurin"
-          java-version: "11"
+          working-directory: |
+            support-figma/extended-layout-plugin
+            support-figma/auto-content-preview-widget
 
-      - uses: actions/download-artifact@v3
+      - name: Build Plugin
+        working-directory: support-figma/extended-layout-plugin
+        run: npm run build
+      
+      - name: Package Plugin
+        working-directory: support-figma
+        run: zip -q -r extended-layout-plugin.zip |
+          extended-layout-plugin/manifest.json
+          extended-layout-plugin/ui.htm
+          extended-layout-plugin/code.js
+
+      - uses: actions/upload-artifact@v3
         with:
-          name: designcompose-m2-repo-zip
+          name: figma-plugin-zip
+          path: support-figma/extended-layout-plugin.zip
 
-      - name: Unpack repo
-        run: unzip designcompose_m2repo.zip
 
-      - uses: gradle/gradle-build-action@v2
+      - name: Build Widget
+        working-directory: support-figma/auto-content-preview-widget
+        run: npm run build
+
+      - name: Package Widget
+        working-directory: support-figma
+        run: zip -q -r auto-content-preview-widget.zip |
+          auto-content-preview-widget/manifest.json
+          auto-content-preview-widget/ui.htm
+          auto-content-preview-widget/code.js
+
+      - uses: actions/upload-artifact@v3
         with:
-          arguments: |
-            -PDesignComposeMavenRepo=designcompose_m2repo
-            check
+          name: figma-widget-zip
+          path: support-figma/auto-content-preview-widget.zip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -103,7 +103,7 @@ jobs:
   figma-resources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5
       - uses: bahmutov/npm-install@v1
         with:
           working-directory: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
       - name: Build all
         run: cargo build --all-targets --all-features
       - name: Test all
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - uses: rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh
@@ -80,7 +80,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - uses: rust-cache@v2
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Rust dependencies
         run: bash install-rust-toolchains.sh

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,13 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
         distribution: "temurin"
         java-version: '11'
         cache: "gradle"
 
-    - uses: actions/checkout@v3
 
     - name: ktlint
       shell: bash

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,24 @@
+
+name: Presubmit
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Java 11
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '11'
+        java-package: jdk
+        architecture: x64
+
+    - uses: actions/checkout@v3
+
+    - name: ktlint
+      shell: bash
+      run: ./gradlew ktlint
+

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  Kotlin-Lint:
+  lint-kotlin:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -20,8 +20,26 @@ jobs:
     - name: ktfmtCheck
       shell: bash
       run: ./gradlew ktfmtCheck
-  # Rust-Lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
 
+  sdk-build:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: "temurin"
+        java-version: '11'
+        cache: "gradle"
+
+    - name: Run local tests
+      run: ./gradlew test
+
+    - name: Build debug
+      run: ./gradlew assembleDebug
+
+    - name: Build release
+      run: ./gradlew assembleRelease
+
+    - name: Final check
+      run: ./gradlew check
 


### PR DESCRIPTION
I've brought over all of the main presubmits from Kokoro, with the exception of AAOS Unbundled related builds. Those will be handled in a separate CL later.

The presubmits have had caching enabled which should speed up things nicely. 