### PR TITLE
Prepare SDK for publishing to gMaven

### DIFF
--- a/annotation/build.gradle.kts
+++ b/annotation/build.gradle.kts
@@ -20,3 +20,12 @@ plugins {
     id("designcompose.conventions.java-toolchain")
     id("designcompose.conventions.publish.jvm")
 }
+
+publishing {
+    publications.named<MavenPublication>("release") {
+        pom {
+            name.set("Automotive Design for Compose Annotations")
+            description.set("Annotations for describing how a generated Composable maps data to design elements")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/designcompose/conventions/publish/BasePomConfig.kt
+++ b/buildSrc/src/main/kotlin/designcompose/conventions/publish/BasePomConfig.kt
@@ -1,0 +1,29 @@
+package designcompose.conventions.publish
+
+import org.gradle.api.publish.maven.MavenPom
+
+fun MavenPom.basePom() {
+    url.set("https://github.com/google/automotive-design-compose")
+    licenses {
+        license {
+            name.set("The Apache License, Version 2.0")
+            url.set("http://www.apache.org/licenses/LICENSE-2.0")
+        }
+    }
+    developers {
+        developer {
+            id.set("designCompose")
+            name.set("The Automotive Design for Compose team")
+            url.set("aae-design-compose@google.com")
+        }
+    }
+    scm {
+        connection.set(
+            "scm:git:https://github.com/google/automotive-design-compose.git"
+        )
+        developerConnection.set(
+            "scm:git:git@github.com:google/automotive-design-compose.git"
+        )
+        url.set("https://github.com/google/automotive-design-compose")
+    }
+}

--- a/buildSrc/src/main/kotlin/designcompose/conventions/publish/android.gradle.kts
+++ b/buildSrc/src/main/kotlin/designcompose/conventions/publish/android.gradle.kts
@@ -33,10 +33,11 @@ android {
     }
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            register<MavenPublication>("release") { afterEvaluate { from(components["default"]) } }
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            pom { basePom() }
+            afterEvaluate { from(components["default"]) }
         }
     }
 }

--- a/buildSrc/src/main/kotlin/designcompose/conventions/publish/jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/designcompose/conventions/publish/jvm.gradle.kts
@@ -29,6 +29,11 @@ java {
 
 publishing {
     publications {
-        register<MavenPublication>("release") { afterEvaluate { from(components["kotlin"]) } }
+        register<MavenPublication>("release") {
+            afterEvaluate {
+                from(components["kotlin"])
+                pom { basePom() }
+            }
+        }
     }
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -21,6 +21,15 @@ plugins {
     id("designcompose.conventions.publish.jvm")
 }
 
+publishing {
+    publications.named<MavenPublication>("release") {
+        pom {
+            name.set("Automotive Design for Compose Code Generation")
+            description.set("Code generation library")
+        }
+    }
+}
+
 dependencies {
     api(project(":annotation"))
     api(libs.ksp)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,14 @@ plugins {
     id("designcompose.conventions.publish.jvm")
 }
 
+publishing {
+    publications.named<MavenPublication>("release") {
+        pom {
+            name.set("Automotive Design for Compose Common Library")
+            description.set("Common code used by other DesignCompose libraries")
+        }
+    }
+}
 /**
  * Serde gen task
  *

--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -95,8 +95,6 @@ dependencies {
     implementation(libs.androidx.datastore.core)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.lifecycle.livedata.ktx)
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
     api(libs.androidx.compose.foundation)
     api(libs.androidx.compose.foundation.layout)
     api(libs.androidx.compose.runtime)

--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -80,6 +80,15 @@ tasks.withType<com.android.build.gradle.tasks.MergeSourceSetFolders>().configure
     }
 }
 
+publishing {
+    publications.named<MavenPublication>("release") {
+        pom {
+            name.set("Automotive Design for Compose")
+            description.set("Core library for the SDK")
+        }
+    }
+}
+
 dependencies {
     api(project(":common"))
     api(project(":annotation"))

--- a/dev-scripts/run-kokoro-jobs-locally.sh
+++ b/dev-scripts/run-kokoro-jobs-locally.sh
@@ -32,5 +32,5 @@ dc_main_project_job
 dc_aaos_apps_job
 dc_test_release_job
 
-echo "Test run complete, everything appears to have passed. Artifacts dir:"
+echo "Test run complete, everything appears to have passed. Work directory:"
 echo "$KOKORO_ARTIFACTS_DIR"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,10 @@ androidx-activity-compose = "1.6.1"
 androidx-appcompat = "1.6.1"
 androidx-compose-bom = "2023.01.00"
 # @keep Non-`dependency` constant
-androidx-compose-compiler = "1.4.3"
+androidx-compose-compiler = "1.4.4"
+androidx-compose-foundation = "1.4.2"
+androidx-compose-runtime = "1.4.2"
+androidx-compose-ui = "1.4.2"
 androidx-constraintlayout = "2.1.4"
 androidx-legacy-support-v4 = "1.0.0"
 androidx-lifecycle = "2.6.0"
@@ -24,7 +27,7 @@ appauth = "0.11.1"
 compileSdk = "33"
 datastoreCore = "1.0.0"
 datastorePreferences = "1.0.0"
-designcompose = "0.19.0"
+designcompose = "0.19.0-alpha02"
 dokka = "1.8.10"
 google-cloud-sql = "1.4.4"
 google-crypto-tink = "1.7.0"
@@ -70,17 +73,17 @@ android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref 
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
-androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
-androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose-foundation" }
+androidx-compose-foundation-layout = { module = "androidx.compose.foundation:foundation-layout", version.ref = "androidx-compose-foundation" }
 androidx-compose-material = { module = "androidx.compose.material:material" }
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
-androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui" }
-androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
-androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
-androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose-runtime" }
+androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "androidx-compose-runtime" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-compose-ui" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastoreCore" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }

--- a/reference-apps/aaos-unbundled/buildSrc/src/main/kotlin/designcompose/conventions/publish
+++ b/reference-apps/aaos-unbundled/buildSrc/src/main/kotlin/designcompose/conventions/publish
@@ -1,0 +1,1 @@
+../../../../../../../../buildSrc/src/main/kotlin/designcompose/conventions/publish


### PR DESCRIPTION
gMaven doesn't support Maven BOMs yet, so I had to replace the Compose BOM in DesignCompose with individual versions for each library.

Needed to add a few fields to the POM config as well

This config was already used to publish 0.19.0-alpha01 so I'm setting DesignCompose's version to 0.19.0-alpha02