### PR TITLE
Add support for injecting fake key events to trigger Figma interactions

### DIFF
--- a/annotation/src/main/java/com/android/designcompose/annotation/Builder.kt
+++ b/annotation/src/main/java/com/android/designcompose/annotation/Builder.kt
@@ -86,3 +86,25 @@ annotation class PreviewNode(
 @Repeatable
 @Target(AnnotationTarget.VALUE_PARAMETER)
 annotation class DesignPreviewContent(val name: String, val nodes: Array<PreviewNode>)
+
+/**
+ * Meta keys that can be used with a character key to form a DesignKeyAction. For example, a list of
+ * two DesignMetaKeys MetaCtrl and MetaAlt with the character 'C' represents a key event of the
+ * letter 'C' with the control and alt keys held down.
+ */
+enum class DesignMetaKey {
+    MetaShift,
+    MetaCtrl,
+    MetaMeta,
+    MetaAlt,
+}
+
+/**
+ * Generate a function that, when called, injects a key event with the given key and list of meta
+ * keys.
+ *
+ * @param key the key to inject
+ * @param metaKeys the list of meta keys held down when the key inject event occurs
+ */
+@Target(AnnotationTarget.FUNCTION)
+annotation class DesignKeyAction(val key: Char, val metaKeys: Array<DesignMetaKey>)

--- a/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/InteractionTests.kt
+++ b/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/InteractionTests.kt
@@ -45,6 +45,7 @@ class InteractionTests {
 
         // Navigate to the Triggers -> Timeouts menu
         composeTestRule.onNodeWithText("Triggers").performClick()
+        composeTestRule.onNodeWithText("While Pressed").assertIsDisplayed().performClick()
         composeTestRule.onNodeWithText("Timeouts").assertIsDisplayed().performClick()
 
         // Confirm initial state

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -59,7 +59,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -82,6 +85,8 @@ import com.android.designcompose.annotation.Design
 import com.android.designcompose.annotation.DesignComponent
 import com.android.designcompose.annotation.DesignContentTypes
 import com.android.designcompose.annotation.DesignDoc
+import com.android.designcompose.annotation.DesignKeyAction
+import com.android.designcompose.annotation.DesignMetaKey
 import com.android.designcompose.annotation.DesignPreviewContent
 import com.android.designcompose.annotation.DesignVariant
 import com.android.designcompose.annotation.PreviewNode
@@ -437,13 +442,27 @@ fun VConstraintsTest() {
 // TEST Interactions
 @DesignDoc(id = "8Zg9viyjYTnyN29pbkR1CE")
 interface InteractionTest {
-    @DesignComponent(node = "Start Here") fun MainFrame()
+    @DesignComponent(node = "Start Here")
+    fun MainFrame(
+        @Design(node = "#KeyButtonB") onTapKeyButtonB: TapCallback,
+        @Design(node = "#KeyButtonC") onTapKeyButtonC: TapCallback,
+    )
+
+    // Inject a ctrl-shift-B key when the 'clickedB()' function is called
+    @DesignKeyAction(key = 'B', metaKeys = [DesignMetaKey.MetaShift, DesignMetaKey.MetaCtrl])
+    fun clickedB()
+    // Inject a meta-C key when the 'clickedC()' function is called
+    @DesignKeyAction(key = 'C', metaKeys = [DesignMetaKey.MetaMeta]) fun clickedC()
 }
 
 @Preview
 @Composable
 fun InteractionTest() {
-    InteractionTestDoc.MainFrame()
+    val rootView = LocalView.current
+    InteractionTestDoc.MainFrame(
+        onTapKeyButtonB = { InteractionTestDoc.clickedB() },
+        onTapKeyButtonC = { InteractionTestDoc.clickedC() }
+    )
 }
 
 // TEST Shadows

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -62,7 +62,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -446,22 +445,40 @@ interface InteractionTest {
     fun MainFrame(
         @Design(node = "#KeyButtonB") onTapKeyButtonB: TapCallback,
         @Design(node = "#KeyButtonC") onTapKeyButtonC: TapCallback,
+        @Design(node = "#KeyInjectA") onTapInjectA: TapCallback,
+        @Design(node = "#KeyInjectB") onTapInjectB: TapCallback,
+        @Design(node = "#KeyInjectC") onTapInjectC: TapCallback,
+        @Design(node = "#KeyInjectAB") onTapInjectAB: TapCallback,
+        @Design(node = "#KeyInjectBC") onTapInjectBC: TapCallback,
     )
 
     // Inject a ctrl-shift-B key when the 'clickedB()' function is called
     @DesignKeyAction(key = 'B', metaKeys = [DesignMetaKey.MetaShift, DesignMetaKey.MetaCtrl])
-    fun clickedB()
+    fun clickedShiftCtrlB()
     // Inject a meta-C key when the 'clickedC()' function is called
-    @DesignKeyAction(key = 'C', metaKeys = [DesignMetaKey.MetaMeta]) fun clickedC()
+    @DesignKeyAction(key = 'C', metaKeys = [DesignMetaKey.MetaMeta]) fun clickedMetaC()
+    @DesignKeyAction(key = 'A', metaKeys = []) fun clickedA()
+    @DesignKeyAction(key = 'B', metaKeys = []) fun clickedB()
+    @DesignKeyAction(key = 'C', metaKeys = []) fun clickedC()
 }
 
 @Preview
 @Composable
 fun InteractionTest() {
-    val rootView = LocalView.current
     InteractionTestDoc.MainFrame(
-        onTapKeyButtonB = { InteractionTestDoc.clickedB() },
-        onTapKeyButtonC = { InteractionTestDoc.clickedC() }
+        onTapKeyButtonB = { InteractionTestDoc.clickedShiftCtrlB() },
+        onTapKeyButtonC = { InteractionTestDoc.clickedMetaC() },
+        onTapInjectA = { InteractionTestDoc.clickedA() },
+        onTapInjectB = { InteractionTestDoc.clickedB() },
+        onTapInjectC = { InteractionTestDoc.clickedC() },
+        onTapInjectAB = {
+            InteractionTestDoc.clickedA()
+            InteractionTestDoc.clickedB()
+        },
+        onTapInjectBC = {
+            InteractionTestDoc.clickedB()
+            InteractionTestDoc.clickedC()
+        },
     )
 }
 


### PR DESCRIPTION
Figma's interaction tools give us key input as a way to trigger an action. This commit adds a function to inject one of these key events, which consists of a key and a list of optional metakeys (shift, alt, control, meta). There are two ways to use this key injection function.

1. Call it directly with the DesignInjectKey() function.
2. Create a new function annotated with the @DesignKeyAction() annotation. This generates a function that calls the DesignInjectKey() function with the parameters specified in the annotation.

An example of this has been added to the Interaction validation document.

The way this works is that when a node with key reactions is rendered, we register a function with the node as a listener for the key events it is interested in. When the key injection happens, listeners are notified and their interactions are dispatched.

Issue https://github.com/google/automotive-design-compose/issues/8