### PR TITLE
Enable continuous builds for our main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,12 @@
 name: Presubmit
 
 on:
+  label:
+    types:
+      - created
+  push:
+    branches:
+      - main
   merge_group:
   pull_request:
     branches: [main]


### PR DESCRIPTION
The Gradle action only writes to the cache from main builds (by default) so in order to set up the cache we need to start running our workflow on main. 

As such, I'm renaming "presubmit.yml" to "main.yml"