### PR TITLE
Support progress bars where an element just moves along the bar

### DIFF
--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -457,11 +457,21 @@ pub struct ArcMeterData {
 #[serde(rename_all = "camelCase")]
 pub struct ProgressBarMeterData {
     pub enabled: bool,
-    pub start: f32,
-    pub end: f32,
     pub discrete: bool,
     pub discrete_value: f32,
-    pub vertical: bool,
+    pub end_x: f32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressMarkerMeterData {
+    pub enabled: bool,
+    pub discrete: bool,
+    pub discrete_value: f32,
+    pub start_x: f32,
+    pub start_y: f32,
+    pub end_x: f32,
+    pub end_y: f32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -470,6 +480,7 @@ pub enum MeterData {
     ArcData(ArcMeterData),
     RotationData(RotationMeterData),
     ProgressBarData(ProgressBarMeterData),
+    ProgressMarkerData(ProgressMarkerMeterData),
 }
 
 /// ToolkitStyle contains all of the styleable parameters accepted by the Rect and Text components.

--- a/designcompose/src/main/java/com/android/designcompose/MathUtils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/MathUtils.kt
@@ -105,6 +105,11 @@ internal fun Matrix.decompose(): DecomposedMatrix2D {
     return result
 }
 
+internal fun Matrix.setTranslation(x: Float, y: Float) {
+    this[3, 0] = x
+    this[3, 1] = y
+}
+
 // Hypotenuse of right triangle with sides x and y
 internal fun hypot(x: Float, y: Float): Float {
     return sqrt(x * x + y * y)

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -1585,6 +1585,7 @@ interface DialsGaugesTest {
         @Design(node = "#arc-angle") arcAngle: Meter,
         @Design(node = "#needle-rotation") needleRotation: Meter,
         @Design(node = "#progress-bar") progressBar: Meter,
+        @Design(node = "#progress-indicator") progressIndicator: Meter,
     )
 }
 
@@ -1593,10 +1594,12 @@ fun DialsGaugesTest() {
     val angle = remember { mutableStateOf(50f) }
     val rotation = remember { mutableStateOf(50f) }
     val progress = remember { mutableStateOf(50f) }
+    val progressIndicator = remember { mutableStateOf(50f) }
     DialsGaugesTestDoc.MainFrame(
         arcAngle = angle.value,
         needleRotation = rotation.value,
         progressBar = progress.value,
+        progressIndicator = progressIndicator.value,
     )
 
     Row(
@@ -1622,6 +1625,14 @@ fun DialsGaugesTest() {
         Text("Progress Bar: ", Modifier.width(120.dp), fontSize = 20.sp)
         Slider(progress, 0f, 100f)
         Text(progress.value.toString(), fontSize = 20.sp)
+    }
+    Row(
+        Modifier.absoluteOffset(0.dp, 1560.dp).height(50.dp),
+        horizontalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        Text("Progress Indicator: ", Modifier.width(120.dp), fontSize = 20.sp)
+        Slider(progressIndicator, 0f, 100f)
+        Text(progressIndicator.value.toString(), fontSize = 20.sp)
     }
 }
 

--- a/support-figma/extended-layout-plugin/code.ts
+++ b/support-figma/extended-layout-plugin/code.ts
@@ -147,8 +147,9 @@ function clippyCheckUnusedKeywords(
   function findKeywordsRecurse(node: BaseNode, keywords: Set<String>, found: Map<String, number>) {
     if (!node) return;
     if (keywords.has(node.name)) {
-      if (found.has(node.name)) {
-        found.set(node.name, found.get(node.name) + 1);
+      const num = found.get(node.name)
+      if (num) {
+        found.set(node.name, num + 1);
       } else {
         found.set(node.name, 1);
       }
@@ -166,15 +167,17 @@ function clippyCheckUnusedKeywords(
     let component = topLevelComponentDefns.get(nodeName);
     // Skip root frames because customizations within a root frame are often passed down to
     // customized children, so they don't show up in the root node of Figma.
-    if (component.isRoot)
+    if (!component || component.isRoot)
       continue;
     let keywords: Set<string> = new Set();
     component.customizations.forEach( c => {
-      if (DesignCustomizationKind[c.kind] != DesignCustomizationKind.VariantProperty)
+      if (c.kind != DesignCustomizationKind.VariantProperty)
         keywords.add(c.node);
     });
     if (topLevelComponents.has(nodeName)) {
       let components = topLevelComponents.get(nodeName);
+      if (!components)
+        continue;
       let componentSet = components.find(node => node.type == "COMPONENT_SET");
       components.forEach(node => {
         // If there are multiple components with the same name and at least one is a COMPONENT_SET,
@@ -215,7 +218,7 @@ function clippyCheckKeywords(
   for (const topLevelComponentName of topLevelComponentDefns.keys()) {
     if (topLevelComponents.has(topLevelComponentName)) {
       let components = topLevelComponents.get(topLevelComponentName);
-      if (components.length > 1) {
+      if (components && components.length > 1) {
         // 3. Warn for duplicated top level keywords
         // If there's one node that's a COMPONENT or COMPONENT_SET, and everything else is
         // a FRAME or INSTANCE then that's fine because the service scores the components higher.
@@ -275,20 +278,22 @@ function clippyCheckVariants(
     let component = topLevelComponentDefns.get(nodeName);
     // Skip root frames because customizations within a root frame are often passed down to
     // customized children, so they don't show up in the root node of Figma.
-    if (component.isRoot)
+    if (!component || component.isRoot)
       continue;
 
     // `variants` maps a property name to variant names within a node
     let variants: Map<string, Set<string>> = new Map();
     component.customizations.forEach( c => {
-      if (DesignCustomizationKind[c.kind] == DesignCustomizationKind.VariantProperty) {
+      if (c.kind == DesignCustomizationKind.VariantProperty) {
         let customizationVariant = c as DesignCustomizationVariantProperty
         if (!variants.has(c.node)) {
           variants.set(c.node, new Set());
         }
         let variantNames = variants.get(c.node);
-        for (const variantName of customizationVariant.values)
-          variantNames.add(variantName);
+        if (variantNames) {
+          for (const variantName of customizationVariant.values)
+            variantNames.add(variantName);
+        }
       }
     });
 
@@ -358,7 +363,7 @@ function clipyCheckTypeMismatches(
       //   - If text customization is not on a text node
       //   - If content replacement customization is not on a frame node
       //   - If image customization is not on a frame node
-      var kind = DesignCustomizationKind[customization.kind];
+      var kind = customization.kind;
       switch (kind) {
         case DesignCustomizationKind.Text:
         case DesignCustomizationKind.TextStyle:
@@ -450,8 +455,9 @@ function clippy(json: DesignDocSpec): ClippyWarning[] {
     if (!node) return;
     if (topLevelComponentDefns.has(node.name)) {
       // Store this ref in our list of topLevelComponents.
-      if (topLevelComponents.has(node.name)) {
-        topLevelComponents.get(node.name).push(node);
+      let list = topLevelComponents.get(node.name)
+      if (list) {
+        list.push(node);
       } else {
         topLevelComponents.set(node.name, [node]);
       }
@@ -489,14 +495,16 @@ function clippyRefresh() {
   // Get the json plugin data from our root node
   let clippyFile = figma.root.getSharedPluginData(SHARED_PLUGIN_NAMESPACE, 'clippy-json-file');
   let clippyData = figma.root.getSharedPluginData(SHARED_PLUGIN_NAMESPACE, 'clippy-json');
+  /*
   var reviver = function(key, value) {
     return value;
   };
+  */
 
   var errors = null;
   try {
     // Parse the string into a JSON tree
-    let json = JSON.parse(clippyData, reviver);
+    let json = JSON.parse(clippyData);
 
     // Check for errors
     errors = clippy(json);
@@ -507,21 +515,24 @@ function clippyRefresh() {
   figma.ui.postMessage({ msg: 'clippy', errors, clippyFile });
 }
 
-function loadClippy(): DesignDocSpec {
+function loadClippy(): DesignDocSpec | null {
   // Get the json plugin data from our root node
   let clippyData = figma.root.getSharedPluginData(SHARED_PLUGIN_NAMESPACE, 'clippy-json');
   if (!clippyData)
     return null;
 
+    /*
   var reviver = function(key, value) {
     return value;
   };
+  */
 
   try {
-    return JSON.parse(clippyData, reviver);
+    return JSON.parse(clippyData);
   } catch(e) {
     console.log("Error parsing clippy JSON: " + e);
   }
+  return null;
 }
 
 // If we were invoked with the "sync" command then run our sync logic and quit.
@@ -707,12 +718,93 @@ else if (figma.command === "move-plugin-data") {
     ]
   }
 
+  function deltaTransformPoint(transform: Transform, point: Vector)  {
+    var x = point.x * transform[0][0] + point.y * transform[0][1];
+    var y = point.x * transform[1][0] + point.y * transform[1][1];
+    return { x, y };
+  }
+
+  // Hypotenuse of right triangle with sides x and y
+  function hypot(x: number, y: number): number {
+    return Math.sqrt(x * x + y * y)
+  }
+
+  function decomposeTransform(t: Transform) {
+    let result: any = {};
+    let row0x = t[0][0];
+    let row0y = t[0][1];
+    let row1x = t[1][0];
+    let row1y = t[1][1];
+    result.translateX = t[0][2];
+    result.translateY = t[1][2];
+
+    // Compute scaling factors.
+    result.scaleX = hypot(row0x, row0y)
+    result.scaleY = hypot(row1x, row1y)
+
+    // If determinant is negative, one axis was flipped.
+    const determinant = row0x * row1y - row0y * row1x
+    if (determinant < 0) {
+        // Flip axis with minimum unit vector dot product.
+        if (row0x < row1y) result.scaleX = -result.scaleX 
+        else result.scaleY = -result.scaleY
+    }
+
+    // Renormalize matrix to remove scale.
+    if (result.scaleX != 1) {
+        row0x *= 1 / result.scaleX
+        row0y *= 1 / result.scaleX
+    }
+    if (result.scaleY != 1) {
+        row1x *= 1 / result.scaleY
+        row1y *= 1 / result.scaleY
+    }
+
+    // Compute rotation and renormalize matrix.
+    result.angle = Math.atan2(row0y, row0x)
+
+    if (result.angle != 0) {
+        // Rotate(-angle) = [cos(angle), sin(angle), -sin(angle), cos(angle)]
+        //                = [row0x, -row0y, row0y, row0x]
+        // Thanks to the normalization above.
+        const sn = -row0y
+        const cs = row0x
+        const m11 = row0x
+        const m12 = row0y
+        const m21 = row1x
+        const m22 = row1y
+
+        row0x = cs * m11 + sn * m21
+        row0y = cs * m12 + sn * m22
+        row1x = -sn * m11 + cs * m21
+        row1y = -sn * m12 + cs * m22
+    }
+
+    result.m11 = row0x
+    result.m12 = row0y
+    result.m21 = row1x
+    result.m22 = row1y
+
+    // Convert into degrees because our rotation functions expect it.
+    result.angle = radiansToDegrees(result.angle);
+
+		// calculate delta transform point
+		const px = deltaTransformPoint(t, { x: 0, y: 1 });
+  	const py = deltaTransformPoint(t, { x: 1, y: 0 });
+
+		// calculate skew
+		result.skewX = ((180 / Math.PI) * Math.atan2(px.y, px.x) - 90);
+		result.skewY = ((180 / Math.PI) * Math.atan2(py.y, py.x));
+
+    return result
+  }
+
   function getMeterData(node: SceneNode) {
     let meterDataStr = node.getSharedPluginData(SHARED_PLUGIN_NAMESPACE, 'vsw-meter-data');
     return (meterDataStr && meterDataStr.length) ? JSON.parse(meterDataStr) : {};
   }
 
-  function saveMeterData(meterData) {
+  function saveMeterData(meterData: any) {
     let node = figma.currentPage.selection[0];
     node.setSharedPluginData(SHARED_PLUGIN_NAMESPACE, 'vsw-meter-data', JSON.stringify(meterData));
   }
@@ -741,18 +833,26 @@ else if (figma.command === "move-plugin-data") {
     rotation = (node as FrameNode).rotation;
 
     if (node.type == "FRAME" || node.type == "RECTANGLE") {
-      if (meterData && meterData.progressBarData && meterData.progressBarData.vertical)
-        progress = node.height;
-      else
-        progress = node.width;
+      // Calculate current progress bar position based on node position and size
+      if (meterData.progressMarkerData) {
+        const { startX = 0, endX = 0 } = meterData.progressMarkerData;
+        progress = (node.x - startX) / (endX - startX) * 100;
+      } else if (meterData.progressBarData) {
+        const { endX = 0 } = meterData.progressBarData;
+        progress = node.width / endX * 100;
+      }
     }
 
     // If we just selected a node with arc data, save the corner radius if it has changed
     saveArcCornerRadius();
 
+    let parent = node.parent as FrameNode;
+
     figma.ui.postMessage({
       msg: 'meters-selection',
       nodeType: node.type,
+      parentType: parent.type,
+      parentSize: { width: parent.width, height: parent.height },
       meterData,
       ellipseAngle,
       rotation,
@@ -872,33 +972,90 @@ else if (figma.command === "move-plugin-data") {
     saveMeterData(meterData);
   }
 
-  function barChanged(msg: any) {
-    let start = clamp(msg.start, 0.01, msg.end);
-    let end = clamp(msg.end, 0.01, msg.end);
-    let value = percentToValue(msg.value, start, end);
+  function flipRect(r: Rect): Rect {
+    return {
+      x: r.x,
+      y: r.y,
+      width: r.height,
+      height: r.width
+    }
+  }
+
+  function progressChanged(msg: any, progressMarker: boolean) {
+    const node = figma.currentPage.selection[0] as FrameNode;
+
+    // Use the parent of the progress bar to determine the extents to which the
+    // progress bar moves.
+    // Rotate bounding boxes if parent is rotated; we only support 90 degree rotations
+    const parent = node.parent as FrameNode;
+    let nodeBB = node.absoluteBoundingBox;
+    let parentBB = parent.absoluteBoundingBox;
+    if (!nodeBB)
+      nodeBB = { x: 0, y: 0, width: 0, height: 0 }
+    if (!parentBB)
+      parentBB = { x: 0, y: 0, width: 0, height: 0 }
+    if (Math.abs(parent.rotation) == 90) {
+      nodeBB = flipRect(nodeBB);
+      parentBB = flipRect(parentBB);
+    }
+
+    // Decompose the transform to obtain the skew angles, which are used to calculate
+    // offsets needed to determine the amount that a skewed progress bar moves.
+    const decomposed = decomposeTransform(node.relativeTransform);
+    const skewX = node.height * Math.abs(Math.sin(degreesToRadians(decomposed.skewX)));
+    const skewY = node.width * Math.abs(Math.sin(degreesToRadians(decomposed.skewY)));
+
+    // Calculate the progress bar value if discrete values are specified
+    let value = msg.value;
     if (msg.discrete)
-      value = clamp(value - (value % msg.discreteValue), 0.01, msg.end);
+      value = clamp(value - (value % msg.discreteValue), 0, 100);
 
-    let node = figma.currentPage.selection[0] as FrameNode;
-    if (msg.vertical) {
-      node.resize(node.width, value);
-      node.y = msg.end - value;
-    }
-    else {
-      node.resize(value, node.height);
-    }
-
-    let progressBarData = {
+    let barData: any = {
       enabled: msg.enabled,
-      start: msg.start,
-      end: msg.end,
       discrete: msg.discrete,
       discreteValue: msg.discreteValue,
-      vertical: msg.vertical,
+    }
+    
+    let meterData: any = {};
+    if (progressMarker) {
+      // The progress marker means we don't resize the node; we just move it along an axis
+      // within the parent frame. We calculate this axis by taking the difference between
+      // the parent bounding box and our bounding box, offseting by the skew of this node.
+      const parentWidth = parentBB ? parentBB.width : 0;
+      const parentHeight = parentBB ? parentBB.height : 0;
+      const startX = skewX;
+      const startY = parentBB.height - nodeBB.height + skewY;
+      const endX = parentBB.width - nodeBB.width + skewX;
+      const endY = skewY; 
+      let moveX = percentToValue(value, startX, endX);
+      let moveY = percentToValue(value, startY, endY);
+      node.x = moveX;
+      node.y = moveY;
+
+      barData.startX = startX;
+      barData.startY = startY;
+      barData.endX = endX;
+      barData.endY = endY;
+      meterData.progressMarkerData = barData;
+    }
+    else {
+      // Normal progress bar mode means we resize the progress bar between a width of 0.01
+      // and a max size that we calculate based on the hypotenuse of our parent's bounding
+      // box, adjusted by our own size and the skew. We currently only support progress bars
+      // that are either X or Y axis aligned -- that is, either the left is parallel with the
+      // Y axis or the top is parallel with the X axis.
+      let boundsWidth = parentBB.width - skewX;
+      let boundsHeight = parentBB.height;
+      if (Math.abs(node.rotation) < 45)
+        boundsHeight -= node.height;
+      let boundsMax = hypot(boundsWidth, boundsHeight);
+      let width = percentToValue(value, 0.01, boundsMax); // Min size must be at least 0.01
+      node.resize(width, node.height);
+
+      barData.endX = boundsMax;
+      meterData.progressBarData = barData;
     }
 
-    let meterData: any = {};
-    meterData.progressBarData = progressBarData;
     saveMeterData(meterData);
   }
 
@@ -912,7 +1069,9 @@ else if (figma.command === "move-plugin-data") {
     } else if (msg.msg == 'rotation-changed') {
       rotationChanged(msg);
     } else if (msg.msg == 'bar-changed') {
-      barChanged(msg);
+      progressChanged(msg, false);
+    } else if (msg.msg == 'marker-changed') {
+      progressChanged(msg, true);
     }
   }
 } else if (figma.command === "clippy") {

--- a/support-figma/extended-layout-plugin/ui.html
+++ b/support-figma/extended-layout-plugin/ui.html
@@ -24,6 +24,54 @@
     font-weight: normal;
     font-size: 12;
   }
+
+  /* Tooltip container */
+  .tooltip {
+    position: relative;
+    display: inline-block;
+  }
+
+  /* Tooltip text */
+  .tooltip .tooltiptext {
+    visibility: hidden;
+    font-size: 12;
+    width: 200px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    padding: 5px;
+    border-radius: 1px;
+
+    /* Position the tooltip text */
+    position: absolute;
+    z-index: 1;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -100px;
+    margin-bottom: 5px;
+
+    /* Fade in tooltip */
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  /* Tooltip arrow */
+  .tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+  }
+
+  /* Show the tooltip text when you mouse over the tooltip container */
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
 </style>
 
 <div id="text" style="margin: 8px; display: none;">
@@ -133,31 +181,42 @@
     <div class="switch">
       <input id="barSwitch" type="checkbox" class="switch__toggle">
       <label for="barSwitch" class="switch__label">Progress Bar Customization</label>
+      <div class="tooltip">
+        <label>&#9432</label>
+        <span class="tooltiptext">Progress bars must be in a parent frame, which is used as the bounds for the progress bar.</span>
+      </div>
     </div>
     <div id="barControls" style="margin-left:20; display:none">
-      <div style="display: flex; align-items: center">
-        <label for="barStart" class="sublabel" style="width:120">Progress Bar Start</label>
-        <input id="barStart" type="input" style="width: 40;" class="input__field" value="0">
-      </div>
-      <div style="display: flex; align-items: center">
-        <label for="barEnd" class="sublabel" style="width:120">Progress Bar End</label>
-        <input id="barEnd" type="input" style="width: 40;" class="input__field" value="360">
-      </div>
       <div style="display: flex">
         <div class="switch">
           <input id="barDiscreteSwitch" type="checkbox" class="switch__toggle">
-          <label for="barDiscreteSwitch" class="switch__label" style="font-weight:normal">Discrete Values (pixels)</label>
+          <label for="barDiscreteSwitch" class="switch__label" style="font-weight:normal">Discrete Values (percentage)</label>
         </div>
         <input id="barDiscreteValue" type="input" style="width: 40;" class="input__field" value="1" disabled>
       </div>
-      <div style="display: flex">
-        <div class="switch">
-          <input id="barVerticalSwitch" type="checkbox" class="switch__toggle">
-          <label for="barVerticalSwitch" class="switch__label" style="font-weight:normal">Vertical</label>
-        </div>
-      </div>
       <div class="slidecontainer">
         <input id="barValue" type="range" min="0" max="100" class="slider" id="myRange" oninput="barChanged();">
+      </div>
+    </div>
+  </div><div id="progressMarkerSection" onchange="markerChanged()">
+    <div class="switch">
+      <input id="markerSwitch" type="checkbox" class="switch__toggle">
+      <label for="markerSwitch" class="switch__label">Progress Marker Customization</label>
+      <div class="tooltip">
+        <label>&#9432</label>
+        <span class="tooltiptext">Progress bars must be in a parent frame, which is used as the bounds for the progress bar.</span>
+      </div>
+    </div>
+    <div id="markerControls" style="margin-left:20; display:none">
+      <div style="display: flex">
+        <div class="switch">
+          <input id="markerDiscreteSwitch" type="checkbox" class="switch__toggle">
+          <label for="markerDiscreteSwitch" class="switch__label" style="font-weight:normal">Discrete Values (percentage)</label>
+        </div>
+        <input id="markerDiscreteValue" type="input" style="width: 40;" class="input__field" value="1" disabled>
+      </div>
+      <div class="slidecontainer">
+        <input id="markerValue" type="range" min="0" max="100" class="slider" id="myRange" oninput="markerChanged();">
       </div>
     </div>
   </div>
@@ -184,6 +243,8 @@
   let pluginMode = PluginMode.Text;
   let currentSelection = null;
   let currentNodeType = null;
+  let parentNodeType = null;
+  let parentSize = { width: 0, height: 0 };
 
   function toNumber(str, def) {
     let num = parseInt(str, 10);
@@ -258,12 +319,17 @@
   }
 
   function updateMeterDisabledStates() {
-    let allowRotation = !arcSwitch.checked && !barSwitch.checked;
-    let allowArc = currentNodeType == "ELLIPSE" && !rotationSwitch.checked && !barSwitch.checked;
-    let allowBar = (currentNodeType == "FRAME" || currentNodeType == "RECTANGLE") && !rotationSwitch.checked && !arcSwitch.checked;
+    let allowRotation = !arcSwitch.checked && !barSwitch.checked && !markerSwitch.checked;
+    let allowArc = currentNodeType == "ELLIPSE" && !rotationSwitch.checked && !barSwitch.checked && !markerSwitch.checked;
+    let hasParentFrame = parentNodeType == "FRAME";
+    let allowProgress = (currentNodeType == "FRAME" || currentNodeType == "RECTANGLE") && hasParentFrame
+    let allowBar = hasParentFrame && allowProgress && !rotationSwitch.checked && !arcSwitch.checked && !markerSwitch.checked;
+    let allowMarker = hasParentFrame && allowProgress && !rotationSwitch.checked && !arcSwitch.checked && !barSwitch.checked;
+
     rotationSwitch.disabled = !allowRotation;
     arcSwitch.disabled = !allowArc;
     barSwitch.disabled = !allowBar;
+    markerSwitch.disabled = !allowMarker;
   }
 
   function arcChanged() {
@@ -303,12 +369,22 @@
     parent.postMessage({ pluginMessage: {
         msg: 'bar-changed',
         enabled: barSwitch.checked,
-        start: toNumber(barStart.value, 0),
-        end: toNumber(barEnd.value, 0),
         value: toNumber(barValue.value, 0),
         discrete: barDiscreteSwitch.checked,
         discreteValue: toNumber(barDiscreteValue.value, 1),
-        vertical: barVerticalSwitch.checked,
+      }}, '*');
+  }
+
+  function markerChanged() {
+    updateMeterDisabledStates();
+    markerControls.style.display = markerSwitch.checked ? 'block' : 'none';
+    markerDiscreteValue.disabled = !markerDiscreteSwitch.checked;
+    parent.postMessage({ pluginMessage: {
+        msg: 'marker-changed',
+        enabled: markerSwitch.checked,
+        value: toNumber(markerValue.value, 0),
+        discrete: markerDiscreteSwitch.checked,
+        discreteValue: toNumber(markerDiscreteValue.value, 1),
       }}, '*');
   }
 
@@ -318,10 +394,14 @@
 
   function setMeterData(msg) {
     currentNodeType = msg.nodeType;
+    parentNodeType = msg.parentType;
+    parentSize = msg.parentSize;
+
     let meterData = msg.meterData;
     let ellipseAngle = msg.ellipseAngle;
     let rotation = msg.rotation;
     let progress = msg.progress;
+    let marker = msg.marker;
 
     let sd = meterData.arcData;
     arcSwitch.disabled = msg.nodeType != "ELLIPSE";
@@ -355,16 +435,21 @@
     barSwitch.disabled = (msg.nodeType != "FRAME" && msg.nodeType != "RECTANGLE");
     barControls.style.display = (bd && bd.enabled) ? 'block' : 'none';
     barSwitch.checked = bd && bd.enabled;
-    let bdStart = bd ? bd.start : 0;
-    let bdEnd = bd ? bd.end : (progress ? progress : 100);
-    barStart.value = bdStart;
-    barEnd.value = bdEnd;
     if (progress)
-      barValue.value = valueToPercent(progress, bdStart, bdEnd);
+      barValue.value = progress;
     barDiscreteSwitch.checked = bd && bd.discrete;
     barDiscreteValue.value = bd ? bd.discreteValue : 1;
     barDiscreteValue.disabled = !bd || !bd.discrete;
-    barVerticalSwitch.checked = bd && bd.vertical;
+
+    let md = meterData.progressMarkerData;
+    markerSwitch.disabled = (msg.nodeType != "FRAME" && msg.nodeType != "RECTANGLE");
+    markerControls.style.display = (md && md.enabled) ? 'block' : 'none';
+    markerSwitch.checked = md && md.enabled;
+    if (progress)
+      markerValue.value = progress;
+    markerDiscreteSwitch.checked = md && md.discrete;
+    markerDiscreteValue.value = md ? md.discreteValue : 1;
+    markerDiscreteValue.disabled = !md || !md.discrete;
 
     updateMeterDisabledStates();
   }
@@ -494,6 +579,9 @@
     }
     if (msg.msg == 'meters-selection-cleared') {
       currentSelection = null;
+      currentNodeType = null;
+      parentNodeType = null;
+      parentSize = null;
 
       arcControls.style.display = 'none';
       arcSwitch.checked = false;
@@ -506,6 +594,10 @@
       barControls.style.display = 'none';
       barSwitch.checked = false;
       barSwitch.disabled = true;
+
+      markerControls.style.display = 'none';
+      markerSwitch.checked = false;
+      markerSwitch.disabled = true;
     }
     else if (msg.msg == 'meters-selection') {
       setMeterData(msg);


### PR DESCRIPTION
Add a new plugin option to the dials and gauges plugin to move a frame or rect along a progress bar instead of adjusting the size like a normal progress bar. Write this new boolean into the plugin data, parse it, and render it in FrameRender.

Fix #58