### PR TITLE
Enable presubmits to run on pull requests targeting working branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,9 @@ on:
       - main
   merge_group:
   pull_request:
-    branches: [main]
+    branches: 
+      - main
+      - 'wb/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
This will make it easier to stack pull requests. This is where you've uploaded a pull request, then create a branch from that pull request, make changes, and upload that pull request, with the merge base being the pull request that was branched from.

With this change, the presubmits will properly run on the stacked PR.