### PR TITLE
Fix vector rectangles not adhering to constraints

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -450,12 +450,7 @@ internal fun ContentDrawScope.render(
                 getPaths(shape.path, shape.stroke)
             }
             is ViewShape.VectorRect -> {
-                if (!customProgressBar) {
-                    // Render normally with Figma provided fill/stroke path
-                    getPaths(shape.path, shape.stroke)
-                } else {
-                    computeRoundedRect(frameSize, shape.corner_radius, density)
-                }
+                computeRoundedRect(frameSize, shape.corner_radius, density)
             }
             is ViewShape.Arc -> {
                 if (!customArcAngle) {

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -1574,7 +1574,7 @@ interface VectorRenderingTest {
 // Test page for vector rendering support
 @Composable
 fun VectorRenderingTest() {
-    VectorRenderingTestDoc.MainFrame()
+    VectorRenderingTestDoc.MainFrame(modifier = Modifier.fillMaxSize())
 }
 
 // TEST dials and gauges


### PR DESCRIPTION
Render a vector rectangle using the addRect() path function, which uses the size calculated by constraints instead of using the path directly from Figma.

Fixes #61