### PR TITLE
Add Figma Doc ID to the SerializableFigmaDoc struct.

### DIFF
--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -76,6 +76,7 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
         last_modified: doc.last_modified().clone(),
         name: doc.get_name(),
         version: doc.get_version(),
+        id: doc.get_document_id(),
     };
     // We don't bother with serialization headers or image sessions with
     // this tool.

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -91,6 +91,7 @@ pub fn fetch_doc(id: &str, rq: ConvertRequest) -> Result<ConvertResponse, crate:
             last_modified: doc.last_modified().clone(),
             name: doc.get_name(),
             version: doc.get_version(),
+            id: doc.get_document_id(),
         };
         let mut response = bincode::serialize(&SerializedFigmaDocHeader::current())?;
         response.append(&mut bincode::serialize(&ServerFigmaDoc {

--- a/crates/figma_import/src/serialized_document.rs
+++ b/crates/figma_import/src/serialized_document.rs
@@ -40,6 +40,7 @@ pub struct SerializedFigmaDoc {
     pub name: String,
     pub component_sets: HashMap<String, String>,
     pub version: String,
+    pub id: String,
 }
 
 // This is the struct we send over to the client. It contains the serialized document


### PR DESCRIPTION
This change will facilitate loading locally saved Figma docs for the renderer, or anything using the renderer library.