### PR TITLE
Rename SerializedFigmaDoc to SerializedDesignDoc

### DIFF
--- a/common/src/main/java/com/android/designcompose/common/FsaasSession.kt
+++ b/common/src/main/java/com/android/designcompose/common/FsaasSession.kt
@@ -17,4 +17,4 @@
 package com.android.designcompose.common
 
 // Current serialized doc version
-const val FSAAS_DOC_VERSION = 12
+const val FSAAS_DOC_VERSION = 13

--- a/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
+++ b/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
@@ -18,7 +18,7 @@ package com.android.designcompose.common
 
 import com.android.designcompose.serdegen.FigmaDocInfo
 import com.android.designcompose.serdegen.NodeQuery
-import com.android.designcompose.serdegen.SerializedFigmaDoc
+import com.android.designcompose.serdegen.SerializedDesignDoc
 import com.android.designcompose.serdegen.SerializedFigmaDocHeader
 import com.android.designcompose.serdegen.ServerFigmaDoc
 import com.android.designcompose.serdegen.View
@@ -32,7 +32,7 @@ import java.io.InputStream
 class GenericDocContent(
     var docId: String,
     private val header: SerializedFigmaDocHeader,
-    val document: SerializedFigmaDoc,
+    val document: SerializedDesignDoc,
     val variantViewMap: HashMap<String, HashMap<String, View>>,
     val variantPropertyMap: VariantPropertyMap,
     private val imageSessionData: ByteArray,
@@ -95,8 +95,8 @@ fun decodeDiskBaseDoc(doc: InputStream, docId: String, feedback: FeedbackImpl): 
 
     val header = decodeHeader(deserializer, docId, feedback) ?: return null
 
-    // Disk loads are in the format of SerializedFigmaDoc
-    val content = SerializedFigmaDoc.deserialize(deserializer)
+    // Disk loads are in the format of SerializedDesignDoc
+    val content = SerializedDesignDoc.deserialize(deserializer)
     val imageSessionData = decodeImageSession(docBytes, deserializer)
     val variantMap = createVariantViewMap(content.nodes)
     val variantPropertyMap = createVariantPropertyMap(content.nodes)

--- a/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
+++ b/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
@@ -19,7 +19,7 @@ package com.android.designcompose.common
 import com.android.designcompose.serdegen.FigmaDocInfo
 import com.android.designcompose.serdegen.NodeQuery
 import com.android.designcompose.serdegen.SerializedDesignDoc
-import com.android.designcompose.serdegen.SerializedFigmaDocHeader
+import com.android.designcompose.serdegen.SerializedDesignDocHeader
 import com.android.designcompose.serdegen.ServerFigmaDoc
 import com.android.designcompose.serdegen.View
 import com.novi.bincode.BincodeDeserializer
@@ -31,7 +31,7 @@ import java.io.InputStream
 
 class GenericDocContent(
     var docId: String,
-    private val header: SerializedFigmaDocHeader,
+    private val header: SerializedDesignDocHeader,
     val document: SerializedDesignDoc,
     val variantViewMap: HashMap<String, HashMap<String, View>>,
     val variantPropertyMap: VariantPropertyMap,
@@ -193,9 +193,9 @@ private fun decodeHeader(
     deserializer: BincodeDeserializer,
     docId: String,
     feedback: FeedbackImpl
-): SerializedFigmaDocHeader? {
+): SerializedDesignDocHeader? {
     // Now attempt to deserialize the doc)
-    val header = SerializedFigmaDocHeader.deserialize(deserializer)
+    val header = SerializedDesignDocHeader.deserialize(deserializer)
     if (header.version != FSAAS_DOC_VERSION) {
         feedback.documentDecodeVersionMismatch(FSAAS_DOC_VERSION, header.version, docId)
         return null

--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -14,7 +14,7 @@
 
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
-use figma_import::{Document, NodeQuery, SerializedFigmaDoc};
+use figma_import::{Document, NodeQuery, SerializedDesignDoc};
 #[derive(Debug)]
 struct ConvertError(String);
 impl From<figma_import::Error> for ConvertError {
@@ -69,7 +69,7 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
         eprintln!("Warning: {error}");
     }
     // Build the serializable doc structure
-    let serializable_doc = SerializedFigmaDoc {
+    let serializable_doc = SerializedDesignDoc {
         nodes,
         component_sets: doc.component_sets().clone(),
         images: doc.encoded_image_map(),

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Document, ImageContextSession, NodeQuery, SerializedFigmaDoc, SerializedFigmaDocHeader,
+    Document, ImageContextSession, NodeQuery, SerializedDesignDoc, SerializedFigmaDocHeader,
     ServerFigmaDoc,
 };
 
@@ -84,7 +84,7 @@ pub fn fetch_doc(id: &str, rq: ConvertRequest) -> Result<ConvertResponse, crate:
             &mut error_list,
         )?;
 
-        let figma_doc = SerializedFigmaDoc {
+        let figma_doc = SerializedDesignDoc {
             nodes,
             component_sets: doc.component_sets().clone(),
             images: doc.encoded_image_map(),

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Document, ImageContextSession, NodeQuery, SerializedDesignDoc, SerializedFigmaDocHeader,
+    Document, ImageContextSession, NodeQuery, SerializedDesignDoc, SerializedDesignDocHeader,
     ServerFigmaDoc,
 };
 
@@ -93,7 +93,7 @@ pub fn fetch_doc(id: &str, rq: ConvertRequest) -> Result<ConvertResponse, crate:
             version: doc.get_version(),
             id: doc.get_document_id(),
         };
-        let mut response = bincode::serialize(&SerializedFigmaDocHeader::current())?;
+        let mut response = bincode::serialize(&SerializedDesignDocHeader::current())?;
         response.append(&mut bincode::serialize(&ServerFigmaDoc {
             figma_doc,
             errors: error_list,

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -41,7 +41,7 @@ pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse};
 pub use figma_schema::Rectangle;
 pub use image_context::{ImageContextSession, ImageKey};
-pub use serialized_document::{SerializedFigmaDoc, SerializedFigmaDocHeader, ServerFigmaDoc};
+pub use serialized_document::{SerializedDesignDoc, SerializedFigmaDocHeader, ServerFigmaDoc};
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience
 pub use color::Color;

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -41,7 +41,7 @@ pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse};
 pub use figma_schema::Rectangle;
 pub use image_context::{ImageContextSession, ImageKey};
-pub use serialized_document::{SerializedDesignDoc, SerializedFigmaDocHeader, ServerFigmaDoc};
+pub use serialized_document::{SerializedDesignDoc, SerializedDesignDocHeader, ServerFigmaDoc};
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience
 pub use color::Color;

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -167,8 +167,8 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<crate::SerializedFigmaDocHeader>(&samples)
         .expect("couldn't trace SerializedFigmaDocHeader");
     tracer
-        .trace_type::<crate::SerializedFigmaDoc>(&samples)
-        .expect("couldn't trace SerializedFigmaDoc");
+        .trace_type::<crate::SerializedDesignDoc>(&samples)
+        .expect("couldn't trace SerializedDesignDoc");
     tracer.trace_type::<crate::ServerFigmaDoc>(&samples).expect("couldn't trace ServerFigmaDoc");
     tracer.trace_type::<crate::ConvertResponse>(&samples).expect("couldn't trace ConvertResponse");
 

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -164,8 +164,8 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .expect("couldn't trace EncodedImageMap");
     tracer.trace_type::<crate::NodeQuery>(&samples).expect("couldn't trace NodeQuery");
     tracer
-        .trace_type::<crate::SerializedFigmaDocHeader>(&samples)
-        .expect("couldn't trace SerializedFigmaDocHeader");
+        .trace_type::<crate::SerializedDesignDocHeader>(&samples)
+        .expect("couldn't trace SerializedDesignDocHeader");
     tracer
         .trace_type::<crate::SerializedDesignDoc>(&samples)
         .expect("couldn't trace SerializedDesignDoc");

--- a/crates/figma_import/src/serialized_document.rs
+++ b/crates/figma_import/src/serialized_document.rs
@@ -18,16 +18,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{document::FigmaDocInfo, image_context::EncodedImageMap, toolkit_schema, NodeQuery};
 
-static CURRENT_VERSION: u32 = 12;
+static CURRENT_VERSION: u32 = 13;
 
 // This is our serialized document type.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct SerializedFigmaDocHeader {
+pub struct SerializedDesignDocHeader {
     pub version: u32,
 }
-impl SerializedFigmaDocHeader {
-    pub fn current() -> SerializedFigmaDocHeader {
-        SerializedFigmaDocHeader { version: CURRENT_VERSION }
+impl SerializedDesignDocHeader {
+    pub fn current() -> SerializedDesignDocHeader {
+        SerializedDesignDocHeader { version: CURRENT_VERSION }
     }
 }
 

--- a/crates/figma_import/src/serialized_document.rs
+++ b/crates/figma_import/src/serialized_document.rs
@@ -33,7 +33,7 @@ impl SerializedFigmaDocHeader {
 
 // This is our serialized document type.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct SerializedFigmaDoc {
+pub struct SerializedDesignDoc {
     pub last_modified: String,
     pub nodes: HashMap<NodeQuery, toolkit_schema::View>,
     pub images: EncodedImageMap,
@@ -47,7 +47,7 @@ pub struct SerializedFigmaDoc {
 // along with some extra data: document branches, project files, and errors
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ServerFigmaDoc {
-    pub figma_doc: SerializedFigmaDoc,
+    pub figma_doc: SerializedDesignDoc,
     pub branches: Vec<FigmaDocInfo>,
     pub project_files: Vec<FigmaDocInfo>,
     pub errors: Vec<String>,


### PR DESCRIPTION
I mentioned this in the doc_id PR I created so I'll mention it here too so it doesn't get lost.. @iamralpht should we also consier renaming `SerializedFigmaDocHeader`?