### PR TITLE
Support a @Composable () -> Meter @Design customization type

### DIFF
--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -122,6 +122,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             file += "import com.android.designcompose.setImage\n"
             file += "import com.android.designcompose.setImageWithContext\n"
             file += "import com.android.designcompose.setMeterValue\n"
+            file += "import com.android.designcompose.setMeterFunction\n"
             file += "import com.android.designcompose.setModifier\n"
             file += "import com.android.designcompose.setTapCallback\n"
             file += "import com.android.designcompose.setOpenLinkCallback\n"
@@ -204,6 +205,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         TextStyle,
         VariantProperty,
         Meter,
+        MeterFunction,
         Unknown
     }
 
@@ -232,6 +234,8 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         private var textStyleCustomizations: HashMap<String, Vector<Pair<String, String>>> =
             HashMap()
         private var meterCustomizations: HashMap<String, Vector<Pair<String, String>>> = HashMap()
+        private var meterFunctionCustomizations: HashMap<String, Vector<Pair<String, String>>> =
+            HashMap()
         private var nodeNameBuilder: ArrayList<String> = ArrayList()
         private var variantProperties: HashMap<String, String> = HashMap()
 
@@ -721,6 +725,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 "Boolean" -> CustomizationType.Visibility
                 "TextStyle" -> CustomizationType.TextStyle
                 "com.android.designcompose.Meter" -> CustomizationType.Meter
+                "com.android.designcompose.MeterFunction" -> CustomizationType.MeterFunction
                 else -> CustomizationType.Unknown
             }
         }
@@ -909,6 +914,12 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 out.appendText("        customizations.setMeterValue(\"$node\", $value)\n")
             }
 
+            val meterFunctionCustom =
+                meterFunctionCustomizations[function.toString()] ?: Vector<Pair<String, String>>()
+            for ((node, value) in meterFunctionCustom) {
+                out.appendText("        customizations.setMeterFunction(\"$node\", $value)\n")
+            }
+
             out.appendText("\n")
 
             // Generate code to set variant properties if there are any @DesignVariant parameters
@@ -1014,6 +1025,8 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                     addCustomization(valueParameter, annotation, textStyleCustomizations)
                 CustomizationType.Meter ->
                     addCustomization(valueParameter, annotation, meterCustomizations)
+                CustomizationType.MeterFunction ->
+                    addCustomization(valueParameter, annotation, meterFunctionCustomizations)
                 else ->
                     logger.error(
                         "Invalid @Design parameter type ${getParamTypeString(valueParameter)}"

--- a/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
+++ b/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
@@ -61,6 +61,8 @@ fun EmptyListContent(): ListContent {
 
 typealias TapCallback = () -> Unit
 
+typealias MeterFunction = @Composable () -> Meter
+
 typealias Meter = Float
 
 // A Customization changes the way a node is presented, or changes the content of a node.
@@ -90,7 +92,9 @@ data class Customization(
     // Open link callback function
     var openLinkCallback: Optional<OpenLinkCallback> = Optional.empty(),
     // Meter (dial, gauge, progress bar) customization as a percentage 0-100
-    var meterValue: Optional<Float> = Optional.empty()
+    var meterValue: Optional<Float> = Optional.empty(),
+    // Meter (dial, gauge, progress bar) customization as a function that returns a percentage 0-100
+    var meterFunction: Optional<@Composable () -> Float> = Optional.empty()
 )
 
 private fun Customization.clone(): Customization {
@@ -107,6 +111,7 @@ private fun Customization.clone(): Customization {
     c.textStyle = textStyle
     c.openLinkCallback = openLinkCallback
     c.meterValue = meterValue
+    c.meterFunction = meterFunction
 
     return c
 }
@@ -264,6 +269,10 @@ fun CustomizationContext.setMeterValue(nodeName: String, value: Float) {
     customize(nodeName) { c -> c.meterValue = Optional.ofNullable(value) }
 }
 
+fun CustomizationContext.setMeterFunction(nodeName: String, value: @Composable () -> Float) {
+    customize(nodeName) { c -> c.meterFunction = Optional.ofNullable(value) }
+}
+
 fun CustomizationContext.setVariantProperties(vp: HashMap<String, String>) {
     variantProperties = vp
 }
@@ -394,7 +403,14 @@ fun CustomizationContext.getOpenLinkCallback(nodeName: String): OpenLinkCallback
 
 fun CustomizationContext.getMeterValue(nodeName: String): Float? {
     val c = cs[nodeName] ?: return null
-    if (c.meterValue.isPresent) return c.meterValue.get()
+    var value = if (c.meterValue.isPresent) c.meterValue.get() else return null
+    if (value?.isNaN() == true) value = 0F
+    return value
+}
+
+fun CustomizationContext.getMeterFunction(nodeName: String): (@Composable () -> Float)? {
+    val c = cs[nodeName] ?: return null
+    if (c.meterFunction.isPresent) return c.meterFunction.get()
     return null
 }
 

--- a/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
@@ -85,6 +85,10 @@ internal fun DesignFrame(
             )
     }
 
+    // Since the meter function is a composable, we need to call it here even though we don't need
+    // it until frameRender() since that function is not a composable.
+    val meterValue = customizations.getMeterFunction(name)?.let { it() }
+    meterValue?.let { customizations.setMeterValue(name, it) }
     var m =
         Modifier.layoutStyle(name, style)
             .frameRender(style, shape, customImage, document, name, customizations)
@@ -566,7 +570,7 @@ internal fun Modifier.frameRender(
                 customImageWithContext,
                 document,
                 name,
-                customizations
+                customizations,
             )
         }
     )

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -437,8 +437,8 @@ internal fun ContentDrawScope.render(
     var frameSize = size
     var shape = frameShape
     var customArcAngle = false
-    var meterValue = customizations.getMeterValue(name)
 
+    val meterValue = customizations.getMeterValue(name)
     if (meterValue != null) {
         // Check if there is meter data for a dial/gauge/progress bar
         if (style.meter_data.isPresent) {

--- a/reference-apps/aaos-unbundled/media/src/main/java/com/android/designcompose/reference/media/MediaAdapter.kt
+++ b/reference-apps/aaos-unbundled/media/src/main/java/com/android/designcompose/reference/media/MediaAdapter.kt
@@ -613,8 +613,9 @@ class MediaAdapter(
         val nowPlaying = MediaNowPlayingProgress()
         // Observe the current track progress
         val progress: PlaybackProgress? by playbackViewModel.progress.observeAsState()
+        val maxProgress = progress?.maxProgress?.toFloat() ?: 0F
         nowPlaying.progressWidth =
-            (progress?.progress?.toFloat() ?: 0F) / (progress?.maxProgress?.toFloat() ?: 0F)
+            if (maxProgress == 0F) 0F else (progress?.progress?.toFloat() ?: 0F) / maxProgress
         nowPlaying.currentTimeText = progress?.currentTimeText as String? ?: ""
         nowPlaying.maxTimeText = progress?.maxTimeText as String? ?: ""
         return nowPlaying

--- a/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MainActivity.kt
+++ b/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MainActivity.kt
@@ -21,10 +21,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -37,6 +34,7 @@ import com.android.designcompose.ComponentReplacementContext
 import com.android.designcompose.DesignSettings
 import com.android.designcompose.ImageReplacementContext
 import com.android.designcompose.ListContent
+import com.android.designcompose.MeterFunction
 import com.android.designcompose.TapCallback
 import com.android.designcompose.annotation.Design
 import com.android.designcompose.annotation.DesignComponent
@@ -90,8 +88,7 @@ interface CenterDisplay : com.android.designcompose.reference.media.MediaInterfa
         // are functions so that we don't need to recompose the whole main frame
         @Design(node = "#media/now-playing/time-elapsed") timeElapsed: @Composable () -> String,
         @Design(node = "#media/now-playing/time-duration") timeDuration: @Composable () -> String,
-        @Design(node = "#media/now-playing/progress-bar")
-        progress: @Composable (ComponentReplacementContext) -> Unit,
+        @Design(node = "#media/now-playing/progress-bar") progress: MeterFunction,
 
         // Playback controls
         @DesignVariant(property = "#media/now-playing/play-state-button") playState: PlayState,
@@ -345,16 +342,7 @@ class MainActivity : ComponentActivity() {
             appName = mediaSource?.displayName as String,
             timeElapsed = { mediaAdapter.getNowPlayingProgress().currentTimeText },
             timeDuration = { mediaAdapter.getNowPlayingProgress().maxTimeText },
-            progress = { context ->
-                val progress = mediaAdapter.getNowPlayingProgress()
-                val progressWidth =
-                    if (progress.progressWidth.isFinite()) {
-                        progress.progressWidth
-                    } else {
-                        0.0f
-                    }
-                Row(Modifier.fillMaxHeight().fillMaxWidth(progressWidth)) { context.Content() }
-            },
+            progress = { mediaAdapter.getNowPlayingProgress().progressWidth * 100F },
             playState = if (nowPlaying.showPlay) PlayState.Play else PlayState.Pause,
             onPlayPauseTap = {
                 if (nowPlaying.showPlay) nowPlaying.playController?.play()


### PR DESCRIPTION
Since meters may be frequently updated, support a @Composable () -> Meter customization type in addition to the simple Meter customization type. This will allow progress bars and other meters to only recompose themselves instead of their parent composables as well.

This commit also updates the mediacompose project to use progress bars created from the dials & gauges plugin.

Fixes #60