### PR TITLE
Fixing the JNI No Network test

### DIFF
--- a/designcompose/src/androidTest/AndroidManifest.xml
+++ b/designcompose/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -46,13 +46,13 @@ class JniNoNetworkTests {
 
         // Wait until the network is disabled
         val startTime = SystemClock.elapsedRealtime()
-        while (connectivityManager.isDefaultNetworkActive) {
-            assertThat(
-                "Network shut down before timeout",
+        while (
+            connectivityManager.activeNetwork != null &&
                 SystemClock.elapsedRealtime() - startTime < 2000
-            )
+        ) {
             SystemClock.sleep(100)
         }
+        assertThat("Network is still active", connectivityManager.activeNetwork == null)
     }
     @Test
     fun networkFailure() {

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -31,6 +31,7 @@ import org.hamcrest.core.IsInstanceOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import com.android.designcompose.dummyFigmaTokenJson
 
 class JniNoNetworkTests {
     @Before

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -43,12 +43,10 @@ class JniNoNetworkTests {
 
         instrumentation.uiAutomation.executeShellCommand("cmd connectivity airplane-mode enable")
         val startTime = SystemClock.elapsedRealtime()
-        do {
-            assertThat(
-                "We've waited less than 2 seconds",
-                SystemClock.elapsedRealtime() - startTime < 2000
-            )
-        } while (connectivityManager.isDefaultNetworkActive)
+        while (!connectivityManager.isDefaultNetworkActive) {
+            assertThat("Network is disabled", SystemClock.elapsedRealtime() - startTime < 2000)
+            SystemClock.sleep(100)
+        }
     }
     @Test
     fun networkFailure() {

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -41,10 +41,16 @@ class JniNoNetworkTests {
                 getSystemService(instrumentation.context, ConnectivityManager::class.java)
             )
 
+        // Disable the network by enabling airplane mode
         instrumentation.uiAutomation.executeShellCommand("cmd connectivity airplane-mode enable")
+
+        // Wait until the network is disabled
         val startTime = SystemClock.elapsedRealtime()
-        while (!connectivityManager.isDefaultNetworkActive) {
-            assertThat("Network is disabled", SystemClock.elapsedRealtime() - startTime < 2000)
+        while (connectivityManager.isDefaultNetworkActive) {
+            assertThat(
+                "Network shut down before timeout",
+                SystemClock.elapsedRealtime() - startTime < 2000
+            )
             SystemClock.sleep(100)
         }
     }

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -31,7 +31,6 @@ import org.hamcrest.core.IsInstanceOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import com.android.designcompose.dummyFigmaTokenJson
 
 class JniNoNetworkTests {
     @Before

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/JniNoNetworkTests.kt
@@ -17,12 +17,14 @@
 package com.android.designcompose
 
 import android.net.ConnectivityManager
+import android.os.SystemClock
 import androidx.core.content.ContextCompat.getSystemService
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketException
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.anyOf
 import org.hamcrest.core.IsInstanceOf
@@ -33,19 +35,20 @@ import org.junit.Test
 class JniNoNetworkTests {
     @Before
     fun setup() {
-        InstrumentationRegistry.getInstrumentation()
-            .uiAutomation
-            .executeShellCommand("cmd connectivity airplane-mode enable")
-        // Add a sleep to make sure the connection goes down.
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
         val connectivityManager =
-            getSystemService(
-                InstrumentationRegistry.getInstrumentation().context,
-                ConnectivityManager::class.java
+            assertNotNull(
+                getSystemService(instrumentation.context, ConnectivityManager::class.java)
             )
-        println(connectivityManager?.isDefaultNetworkActive)
-        println("Hii")
 
-        wait
+        instrumentation.uiAutomation.executeShellCommand("cmd connectivity airplane-mode enable")
+        val startTime = SystemClock.elapsedRealtime()
+        do {
+            assertThat(
+                "We've waited less than 2 seconds",
+                SystemClock.elapsedRealtime() - startTime < 2000
+            )
+        } while (connectivityManager.isDefaultNetworkActive)
     }
     @Test
     fun networkFailure() {


### PR DESCRIPTION
Accidentally merged the no-network test without finishing an enhancement to it. This should fix it.

This fix is also included in #105, which is adding CI emulator tests