### PR TITLE
Remove testing trigger for Nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,6 @@ name: Nightly
 on: 
   schedule:
     - cron: "0 0 * * *"
-  pull_request: #DO_NOT_SUBMIT
 
 permissions:  # added using https://github.com/step-security/secure-repo
   contents: read


### PR DESCRIPTION
Accidentally left a trigger for the Nightly build, causing it to run for every PR. Fixing that