### PR TITLE
Add support for apps to provide a callback that gets called with the document byte data when the document is updated.

### DIFF
--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -108,6 +108,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             file += "import com.android.designcompose.ImageReplacementContext\n"
             file += "import com.android.designcompose.CustomizationContext\n"
             file += "import com.android.designcompose.DesignDoc\n"
+            file += "import com.android.designcompose.DesignComposeCallbacks\n"
             file += "import com.android.designcompose.DesignSwitcherPolicy\n"
             file += "import com.android.designcompose.OpenLinkCallback\n"
             file += "import com.android.designcompose.DesignNodeData\n"
@@ -753,9 +754,9 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             val defaultOpenLink = if (override) "" else " = null"
             args.add(Pair("openLinkCallback", "OpenLinkCallback?$defaultOpenLink"))
 
-            // Add an optional callback function to be called when the doc is ready to be rendered
-            val defaultDocReady = if (override) "" else " = null"
-            args.add(Pair("designDocReadyCallback", "((String) -> Unit)?$defaultDocReady"))
+            // Add optional callbacks to be called on certain document events
+            val defaultCallbacks = if (override) "" else " = null"
+            args.add(Pair("designComposeCallbacks", "DesignComposeCallbacks?$defaultCallbacks"))
 
             // Add optional key that can be used to uniquely identify this particular instance
             val keyDefault = if (override) "" else " = null"
@@ -964,7 +965,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 if (hideDesignSwitcher) "DesignSwitcherPolicy.HIDE"
                 else "DesignSwitcherPolicy.SHOW_IF_ROOT"
             out.appendText("                designSwitcherPolicy = $switchPolicy,\n")
-            out.appendText("                designDocReadyCallback = designDocReadyCallback,\n")
+            out.appendText("                designComposeCallbacks = designComposeCallbacks,\n")
             out.appendText("            )\n")
             out.appendText("        }\n")
             out.appendText("    }\n\n")

--- a/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
+++ b/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
@@ -43,17 +43,25 @@ class GenericDocContent(
     fun save(filepath: File, feedback: FeedbackImpl) {
         feedback.documentSaveTo(filepath.absolutePath, docId)
         try {
-            val serializer = BincodeSerializer()
-            header.serialize(serializer)
-            document.serialize(serializer)
+            val bytes = toSerializedBytes(feedback)
             val output = FileOutputStream(filepath)
-            output.write(serializer._bytes)
-            output.write(imageSessionData)
+            output.write(bytes)
             output.close()
             feedback.documentSaveSuccess(docId)
         } catch (error: Throwable) {
             feedback.documentSaveError(error.toString(), docId)
         }
+    }
+    fun toSerializedBytes(feedback: FeedbackImpl): ByteArray? {
+        try {
+            val serializer = BincodeSerializer()
+            header.serialize(serializer)
+            document.serialize(serializer)
+            return serializer._bytes.toUByteArray().toByteArray() + imageSessionData
+        } catch (error: Throwable) {
+            feedback.documentSaveError(error.toString(), docId)
+        }
+        return null
     }
 }
 

--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -58,6 +58,7 @@ internal class LiveDocSubscription(
     val id: String,
     val docId: String,
     val onUpdate: (DocContent?) -> Unit,
+    val docUpdateCallback: ((ByteArray?) -> Unit)?,
 )
 
 internal class LiveDocSubscriptions(
@@ -321,6 +322,7 @@ internal fun DocServer.fetchDocuments(
                     SpanCache.clear()
                     for (subscriber in subs) {
                         subscriber.onUpdate(doc)
+                        subscriber.docUpdateCallback?.invoke(doc?.c?.toSerializedBytes(Feedback))
                     }
                 }
                 Feedback.documentUpdated(id, subs.size)
@@ -394,6 +396,7 @@ internal fun DocServer.doc(
     resourceName: String,
     docId: String,
     serverParams: DocumentServerParams,
+    docUpdateCallback: ((ByteArray?) -> Unit)?,
     disableLiveMode: Boolean,
 ): DocContent? {
     // Check that the document ID is valid
@@ -447,12 +450,13 @@ internal fun DocServer.doc(
                 }
                 targetDoc
             }
+        docUpdateCallback?.invoke(targetDoc?.c?.toSerializedBytes(Feedback))
         setLiveDoc(targetDoc)
 
         // Subscribe to live updates, if we have an access token.
         var subscription: LiveDocSubscription? = null
         if (!disableLiveMode) {
-            subscription = LiveDocSubscription(id, docId, setLiveDoc)
+            subscription = LiveDocSubscription(id, docId, setLiveDoc, docUpdateCallback)
             subscribe(subscription, serverParams, saveFile)
         }
         onDispose { if (subscription != null) unsubscribe(subscription) }
@@ -460,7 +464,10 @@ internal fun DocServer.doc(
 
     // Don't return a doc with the wrong ID.
     if (liveDoc != null && liveDoc.c.docId == docId) return liveDoc
-    if (preloadedDoc != null && preloadedDoc.c.docId == docId) return preloadedDoc
+    if (preloadedDoc != null && preloadedDoc.c.docId == docId) {
+        docUpdateCallback?.invoke(preloadedDoc.c.toSerializedBytes(Feedback))
+        return preloadedDoc
+    }
 
     // Use the LocalContext to locate this doc in the precompiled serializedDesignDocuments
     val assetManager = context.assets
@@ -469,6 +476,7 @@ internal fun DocServer.doc(
         val decodedDoc = decodeDiskDoc(assetDoc, null, docId, Feedback)
         if (decodedDoc != null) {
             synchronized(documents) { documents[docId] = decodedDoc }
+            docUpdateCallback?.invoke(decodedDoc.c.toSerializedBytes(Feedback))
             return decodedDoc
         }
     } catch (error: Throwable) {

--- a/docs/_docs/modifiers/modifiers.md
+++ b/docs/_docs/modifiers/modifiers.md
@@ -813,7 +813,7 @@ generated @DesignComponent function generates these three optional parameters:
          name = "Test Name",
          openLinkCallback = OpenLinkCallback { url -> Log.i("DesignCompose", "Open Link: $url") }
      )
-   ```
+    ```
 
 *   `key: String? = null`. Use the `key` parameter to uniquely identify an
     element. This is typically needed only on an element that has multiple
@@ -842,6 +842,12 @@ generated @DesignComponent function generates these three optional parameters:
         )
     }
     ```
+
+*   `designComposeCallbacks: DesignComposeCallbacks? = null`. Set this parameter to register callbacks for a certain events. The `DesignComposeCallbacks` class supports the following event callbacks:
+    * `docReadyCallback: ((String) -> Unit)? = null` \
+    This callback is called when the Figma document has loaded is ready to be rendered.
+    * `newDocDataCallback: ((ByteArray?) -> Unit)? = null` \
+    This callback is called both when the Figma document has first loaded and whenever it updates from live update changes. The ByteArray passed in contains the serialized Figma file.
 
 This example illustrates the use of unique keys to ensure all `#ButtonVariant`
 instances are unique:

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -59,8 +59,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -71,6 +69,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.designcompose.ComponentReplacementContext
+import com.android.designcompose.DesignComposeCallbacks
 import com.android.designcompose.DesignSettings
 import com.android.designcompose.GetDesignNodeData
 import com.android.designcompose.ImageReplacementContext
@@ -160,7 +159,15 @@ interface HelloWorld {
 fun HelloWorld() {
     HelloWorldDoc.Main(
         name = "World",
-        designDocReadyCallback = { id -> Log.i("DesignCompose", "HelloWorld Ready: doc ID = $id") },
+        designComposeCallbacks =
+            DesignComposeCallbacks(
+                docReadyCallback = { id ->
+                    Log.i("DesignCompose", "HelloWorld Ready: doc ID = $id")
+                },
+                newDocDataCallback = { data ->
+                    Log.i("DesignCompose", "HelloWorld Updated: ${data?.size ?: 0} bytes")
+                },
+            )
     )
 }
 

--- a/reference-apps/aaos-unbundled/media/src/main/java/com/android/designcompose/reference/media/MainActivity.kt
+++ b/reference-apps/aaos-unbundled/media/src/main/java/com/android/designcompose/reference/media/MainActivity.kt
@@ -19,6 +19,7 @@ package com.android.designcompose.reference.media
 import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.android.designcompose.DesignComposeCallbacks
 import com.android.designcompose.DesignNodeData
 import com.android.designcompose.ImageReplacementContext
 import com.android.designcompose.ListContent
@@ -62,7 +63,7 @@ interface MediaInterface {
     fun CustomActionButton(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         icon: @Composable (ImageReplacementContext) -> Bitmap?,
         onTap: TapCallback,
@@ -75,7 +76,7 @@ interface MediaInterface {
     fun BrowsePage(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         pageHeaderType: PageHeaderType,
         showHeader: Boolean,
@@ -92,7 +93,7 @@ interface MediaInterface {
     fun LoadingPage(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
     ) {}
     fun LoadingPageDesignNodeData(): DesignNodeData {
@@ -103,7 +104,7 @@ interface MediaInterface {
     fun GroupHeader(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         title: String,
     ) {}
@@ -115,7 +116,7 @@ interface MediaInterface {
     fun SourceButton(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         sourceButtonType: SourceButtonType,
         onTap: TapCallback,
@@ -132,7 +133,7 @@ interface MediaInterface {
     fun PageHeaderNavButton(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         navButtonType: NavButtonType,
         onTap: TapCallback,
@@ -147,7 +148,7 @@ interface MediaInterface {
     fun BrowseItem(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         browseType: BrowseItemType,
         currentlyPlaying: CurrentlyPlaying,
@@ -168,7 +169,7 @@ interface MediaInterface {
     fun ErrorFrame(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
         errorMessage: String,
         errorButtonText: String,
@@ -183,7 +184,7 @@ interface MediaInterface {
     fun BrowseHeaderNav(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
     ) {}
     fun BrowseHeaderNavDesignNodeData(): DesignNodeData {
@@ -194,7 +195,7 @@ interface MediaInterface {
     fun BrowseHeaderDrillDown(
         modifier: Modifier = Modifier,
         openLinkCallback: OpenLinkCallback? = null,
-        designDocReadyCallback: ((String) -> Unit)? = null,
+        designComposeCallbacks: DesignComposeCallbacks? = null,
         key: String? = null,
     ) {}
     fun BrowseHeaderDrillDownDesignNodeData(): DesignNodeData {


### PR DESCRIPTION
The content provided is the content that is serialzed to disk. The callback is called when the document is loaded from disk and whenever the document is updated live from Figma changes.

Fixes #135