### PR TITLE
Append release versions to the generated artifacts

### DIFF
--- a/.github/actions/build-figma-resource/action.yml
+++ b/.github/actions/build-figma-resource/action.yml
@@ -29,15 +29,18 @@ runs:
       shell: bash
 
     - name: Package 
-      working-directory: support-figma/
       shell: bash
       run: |
-        zip -r ${{ inputs.resource }}.zip \
-          ${{ inputs.resource }}/manifest.json \
-          ${{ inputs.resource }}/dist/ui.html \
-          ${{ inputs.resource }}/dist/code.js
+        mkdir -p ${{ inputs.resource }}/dist
+
+        mv support-figma/${{ inputs.resource }}/manifest.json \
+          ${{ inputs.resource }} 
+
+        mv support-figma/${{ inputs.resource }}/dist/ui.html \
+          support-figma/${{ inputs.resource }}/dist/code.js \
+          ${{ inputs.resource }}/dist
 
     - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: ${{ inputs.resource }}
-        path: support-figma/${{ inputs.resource }}.zip
+        path: ${{ inputs.resource }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,12 @@ jobs:
       - name: Build Maven repo
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 # v2.4.2
         with:
-          arguments: -PdesignComposeReleaseVersion=${{ github.ref_name}} publishAllPublicationsToLocalDirRepository
+          arguments: -PdesignComposeReleaseVersion=${{ github.ref_name }} publishAllPublicationsToLocalDirRepository
 
       - name: Upload
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: designcompose_m2repo
+          name: designcompose_m2repo-${{ github.ref_name }}
           path: build/designcompose_m2repo
 
   upload-release:
@@ -65,14 +65,18 @@ jobs:
       # Download all artifacts
       - uses: actions/download-artifact@v3
 
-      - name: Zip up maven repo
-        run: zip -q -r designcompose_m2repo.zip designcompose_m2repo/
+      - name: Zip releases
+        run: |
+          zip -q -r designcompose_m2repo-${{ github.ref_name }}.zip designcompose_m2repo/
+          zip -q -r extended-layout-plugin-${{ github.ref_name }}.zip extended-layout-plugin/
+          zip -q -r auto-content-preview-widget-${{ github.ref_name }}.zip auto-content-preview-widget/
+      
 
       - name: Upload release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ github.ref_name }} \
-          extended-layout-plugin/extended-layout-plugin.zip \
-          auto-content-preview-widget/auto-content-preview-widget.zip \
-          designcompose_m2repo.zip
+          extended-layout-plugin-${{ github.ref_name }}.zip \
+          auto-content-preview-widget-${{ github.ref_name }}.zip \
+          designcompose_m2repo-${{ github.ref_name }}.zip


### PR DESCRIPTION
This will make it easier to tell the versions apart, and help with the naming for uploading them to GCS (as part of #101)

Also moves the zipping of the plugin and widget from before the artifact is uploaded to the job result to before uploading them to the release. The upload-artifact job that uploads to the job result already zips up the files, so it was unnecessary there.