### PR TITLE
Reference app not found on device when setting up figma token

### DIFF
--- a/build-logic/src/main/kotlin/designcompose/features/figma-token-task.kt
+++ b/build-logic/src/main/kotlin/designcompose/features/figma-token-task.kt
@@ -77,7 +77,7 @@ abstract class FigmaTokenTask @Inject constructor(private val executor: DefaultE
         val execResult =
             executor.exec {
                 executable = adbPath.get().toString()
-                args("shell", "pm", "list", "packages", "--user", "current", appID.get())
+                args("shell", "pm", "list", "packages", appID.get())
                 standardOutput = stdOut
                 errorOutput = stdErr
                 isIgnoreExitValue = true // Handle it ourselves


### PR DESCRIPTION
This PR tries to solve an issue when running the `figma-token-task` using:
```
FIGMA_ACCESS_TOKEN=<YOUR_ACCESS_TOKEN> \
    ./gradlew setFigmaTokenDebug
```

Without this change, Gradle would just show the following output:
```
> Task :tutorial-app:setFigmaTokenDebug
Skipping setFigmaTokenDebug, com.android.designcompose.tutorial not found on device
```

This makes it impossible to set the Figma token.

I've tried this on different targets:
- Polestar 2 emulator
- Several pixel phones

This seems to be related to the changes introduced [here](https://github.com/google/automotive-design-compose/pull/124/files#diff-8c18816857b5d7b270c84e0854c09cf3844caede95d3cf47fcd1007c815d198fR80)