### PR TITLE
Minor fix to make the ATD test plugin apply more consistently

### DIFF
--- a/build-logic/src/main/kotlin/designcompose/conventions/AndroidTestDevicesPlugin.kt
+++ b/build-logic/src/main/kotlin/designcompose/conventions/AndroidTestDevicesPlugin.kt
@@ -28,7 +28,7 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.maybeCreate
 
 // We want to apply this to both android libraries and applications, so we can't
-// just use the DLS here. Instead we ...
+// just use the DSL here. Instead we ...
 class ATDPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // Hook into the project when the base Android plugin is applied

--- a/build-logic/src/main/kotlin/designcompose/conventions/android-test-devices.gradle.kts
+++ b/build-logic/src/main/kotlin/designcompose/conventions/android-test-devices.gradle.kts
@@ -18,11 +18,15 @@ package designcompose.conventions
 
 apply<ATDPlugin>()
 
-// AGP consideres Tasks to be an implementation detail, so there's no accessors for them.
+// AGP considers Tasks to be an implementation detail, so there's no accessors for them.
 // Have to look them up the old fashioned way
-afterEvaluate {
-    tasks.named("tabletAtdApi30DebugAndroidTest").configure { group = "DesignCompose Developer" }
-    tasks.named("tabletAllApisGroupDebugAndroidTest").configure {
-        group = "DesignCompose Developer"
+project.plugins.withType(com.android.build.gradle.BasePlugin::class.java) {
+    afterEvaluate {
+        tasks.named("tabletAtdApi30DebugAndroidTest").configure {
+            group = "DesignCompose Developer"
+        }
+        tasks.named("tabletAllApisGroupDebugAndroidTest").configure {
+            group = "DesignCompose Developer"
+        }
     }
 }


### PR DESCRIPTION
The script for it would apply the plugin that adds the ATD tests, then try to add some extra configuration to the tasks that were created. The tasks are created by the Android Gradle Plugin, so to add that configuration they have to be looked up manually. In some cases this plugin was being applied to the project before the Android Gradle Plugin was being applied, so the tasks were trying to be configured before they were created. This fixes it to apply the configuration inside the `withType()` function, which waits to apply the configuration until the plugin with that type is applied to the project.