### PR TITLE
Fix a bug with rendering arcs that have an inner radius < 1.0

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -110,9 +110,11 @@ private fun calculateParentOffsets(
 private fun computeArcPath(frameSize: Size, shape: ViewShape.Arc): Pair<List<Path>, List<Path>> {
     val fWidth = frameSize.width
     val fHeight = frameSize.height
-    val startAngle = shape.start_angle_degrees
-    val sweepAngle = shape.sweep_angle_degrees
-    val endAngle = startAngle + sweepAngle
+    val positiveSweep = shape.sweep_angle_degrees >= 0
+    val sweepAngle = if (positiveSweep) shape.sweep_angle_degrees else -shape.sweep_angle_degrees
+    val startAngle =
+        if (positiveSweep) shape.start_angle_degrees else shape.start_angle_degrees - sweepAngle
+    val endAngle = if (positiveSweep) startAngle + sweepAngle else shape.start_angle_degrees
     val cornerRadius = shape.corner_radius
     val angleDirection = if (endAngle > startAngle) 1.0F else -1.0F
 


### PR DESCRIPTION
When an arc with an arc meter customization has an inner radius < 1.0, we manually draw a path around the perimeter of the arc using arcs, bezier curves, and lines. The math to calculate all of these paths assumed that the sweep angle (angle going from start to end) was always positive, so when this was not the case the arc rendered incorrectly. This commit fixes this issue by swapping the start and end angles when the sweep angle is negative.

Fixes #147