### PR TITLE
Fix Tutorial app standalone build

### DIFF
--- a/reference-apps/tutorial/settings.gradle.kts
+++ b/reference-apps/tutorial/settings.gradle.kts
@@ -32,5 +32,11 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+    }
+}
 
 include("app")


### PR DESCRIPTION
Add missing pluginManagement block to allow the Tutorial app to fetch the DesignCompose plugin from gMaven.