### PR TITLE
Add new Dependabot registries to the Gradle package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,6 +93,9 @@ updates:
       interval: weekly
 
   - package-ecosystem: gradle
+    registries:
+      - maven-google
+      - gradle-plugin-portal
     directory: /
     assignees:
       - "timothyfroehlich"


### PR DESCRIPTION
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/registries' includes the "maven-google" registry which is not used in any of the configurations
The property '#/registries' includes the "gradle-plugin-portal" registry which is not used in any of the configurations