### PR TITLE
Set version number for DesignCompose widget during release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,18 @@ jobs:
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.2
 
+      - name: Set version for Widget
+        working-directory: support-figma/auto-content-preview-widget
+        run: |
+          sed -i -e 's/\("name":.*\)",/\1 ${{ github.ref_name }}",/' manifest.json
+
       - uses: ./.github/actions/build-figma-resource
         with:
             resource: auto-content-preview-widget
       - uses: ./.github/actions/build-figma-resource
         with:
             resource: extended-layout-plugin
+
 
   build-maven-repo:
     runs-on: ubuntu-latest

--- a/support-figma/auto-content-preview-widget/manifest.json
+++ b/support-figma/auto-content-preview-widget/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Auto content preview for DesignCompose v1.0.1",
+  "name": "Auto content preview for DesignCompose",
   "id": "1124100520827492306",
   "api": "1.0.0",
   "main": "dist/code.js",


### PR DESCRIPTION
Tested via https://github.com/timothyfroehlich/automotive-design-compose/releases/tag/v0.4.3test