### PR TITLE
Remove unused GRPC dependency from DesignCompose

### DIFF
--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: dependabot validate
 
 on:

--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -85,7 +85,6 @@ dependencies {
     api(libs.androidx.lifecycle.livedata.core)
     implementation(libs.accompanist.flowlayout)
     implementation(libs.guavaAndroid)
-    implementation(libs.grpc.stub)
     implementation(libs.javax.annotationApi)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -34,7 +34,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.android.designcompose.common.DocumentServerParams
 import com.google.common.annotations.VisibleForTesting
-import io.grpc.StatusRuntimeException
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.FileInputStream
@@ -218,24 +217,15 @@ internal fun DocServer.initializeLiveUpdate() {
     periodicFetchRunnable =
         Runnable() {
             thread {
-                try {
-                    if (!fetchDocuments(firstFetch)) {
-                        Log.e(TAG, "Error occurred while fetching or decoding documents.")
-                        return@thread
-                    }
-                    firstFetch = false
-                } catch (e: StatusRuntimeException) {
-                    Log.e(TAG, "API error.  $e")
-                    DesignSettings.showMessageInToast(
-                        "Error accessing the Design Compose API.",
-                        Toast.LENGTH_LONG
-                    )
+                if (!fetchDocuments(firstFetch)) {
+                    Log.e(TAG, "Error occurred while fetching or decoding documents.")
                     return@thread
-                } finally {
-                    // Schedule another run after some time even if there were any
-                    // errors.
-                    scheduleLiveUpdate()
                 }
+                firstFetch = false
+
+                // Schedule another run after some time even if there were any
+                // errors.
+                scheduleLiveUpdate()
             }
         }
     // Kickstart periodic updates of documents

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ datastoreCore = "1.0.0"
 datastorePreferences = "1.0.0"
 designcompose = "0.22.0-SNAPSHOT"
 dokka = "1.8.10"
-grpc = "1.54.1"
 gson = "2.10.1"
 guavaAndroid = "31.1-android"
 guavaJre = "31.1-jre"
@@ -91,7 +90,6 @@ appauth = { module = "net.openid:appauth", version.ref = "appauth" }
 designcompose = { module = "com.android.designcompose:designcompose", version.ref = "designcompose" }
 designcompose-codegen = { module = "com.android.designcompose:codegen", version.ref = "designcompose" }
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
-grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 guavaAndroid = { module = "com.google.guava:guava", version.ref = "guavaAndroid" }
 guavaJre = { module = "com.google.guava:guava", version.ref = "guavaJre" }


### PR DESCRIPTION
This should resolve https://github.com/google/automotive-design-compose/security/dependabot/73 and related high priority alerts.