### PR TITLE
Update Dependabot config to try to fix Gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
       github-workflow-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: wednesday
@@ -49,7 +49,7 @@ updates:
       github-action-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: wednesday
@@ -62,7 +62,7 @@ updates:
       rust-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: tuesday
@@ -75,7 +75,7 @@ updates:
       jekyll-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: monday
@@ -88,7 +88,7 @@ updates:
       figma-widget-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: friday
@@ -101,7 +101,7 @@ updates:
       figma-plugin-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 3
     schedule:
       interval: weekly
       day: friday

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,103 +14,6 @@
 
 version: 2
 
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      github-workflow-dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-
-  # A directory of "/" only actually includes .github/workflows.
-  # A separate section is needed for our custom actions
-  - package-ecosystem: github-actions
-    directory: "/.github/actions/"
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      github-action-dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: cargo
-    directory: /
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-    # Only allow updates to the lockfile and
-    # ignore any version updates that affect the manifest
-    versioning-strategy: lockfile-only
-
-  - package-ecosystem: bundler
-    directory: /docs
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /support-figma/auto-content-preview-widget
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      figma-widget-dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: npm
-    directory: /support-figma/extended-layout-plugin
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    groups: 
-      figma-plugin-dependencies:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 2
-    schedule:
-      interval: weekly
-
-  - package-ecosystem: gradle
-    registries:
-      - maven-google
-      - gradle-plugin-portal
-    directory: /
-    assignees:
-      - "timothyfroehlich"
-    reviewers:
-      - "timothyfroehlich"
-    groups:
-      gradle-dependencies:
-        patterns:
-          - "*"
-    schedule:
-      interval: weekly
-    ignore:
-        - dependency-name: "com.android.tools.build"
-        - dependency-name: "com.google.devtools.ksp"
-        - dependency-name: "org.jetbrains.kotlin"
 
 # Required due to https://github.com/dependabot/dependabot-core/issues/6888
 registries:
@@ -120,3 +23,102 @@ registries:
   gradle-plugin-portal:
     type: maven-repository
     url: https://plugins.gradle.org/m2
+
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      github-workflow-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: wednesday
+
+  # A directory of "/" only actually includes .github/workflows.
+  # A separate section is needed for our custom actions
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/build-figma-resource"
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      github-action-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: wednesday
+      
+  - package-ecosystem: cargo
+    directory: /
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      rust-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: tuesday
+
+  - package-ecosystem: bundler
+    directory: /docs
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      jekyll-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: monday
+
+  - package-ecosystem: npm
+    directory: /support-figma/auto-content-preview-widget
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      figma-widget-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: friday
+
+  - package-ecosystem: npm
+    directory: /support-figma/extended-layout-plugin
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    groups: 
+      figma-plugin-dependency-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 2
+    schedule:
+      interval: weekly
+      day: friday
+
+  - package-ecosystem: gradle
+    directory: "/"
+    registries:
+    - maven-google
+    - gradle-plugin-portal
+    assignees: [timothyfroehlich]
+    reviewers: [timothyfroehlich]
+    # Dependabot groups seem to be busted for Gradle. Uncommenting this will prevent
+    # PRs from being created for Gradle dependencies.
+    # groups: 
+    #   gradle-dependencies-patches:
+    #     update-types:
+    #     - "patch"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: daily


### PR DESCRIPTION
The Gradle dependencies haven't been updated by Dependabot in a while and it seems related to some of the `group` and `ignore` options that I tried to enable.  I've filled https://github.com/dependabot/dependabot-core/issues/7804 about iit but haven't seen a response yet. 

In the mean time I've disabled those, so I'll need to manually tell Dependabot to ignore certain dependency updates that need to be done manually or in concert with others. I will try to balance the amount of PR spam by setting the schedule to "daily" but limit it to only 3 PRs open.

I've also set the other package ecosystems to only group together updates that update the patch number (as opposed to major or minor) of the dependency, so that additional scrutiny can be applied to other changes. They're also now spread out over the week, so they don't all open a bunch of PRs every Monday.

(This change has come out of a lot of experimentation on my fork of the Repo, so it should be good to go as is)