### PR TITLE
#315 Include original relative_transform in serialized output.

### DIFF
--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -496,6 +496,7 @@ pub struct ViewStyle {
     pub stroke: Stroke,
     pub opacity: Option<f32>,
     pub transform: Option<LayoutTransform>,
+    pub relative_transform: Option<LayoutTransform>,
     pub text_align: TextAlign,
     pub text_align_vertical: TextAlignVertical,
     pub text_overflow: TextOverflow,
@@ -558,6 +559,7 @@ impl Default for ViewStyle {
             stroke: Stroke::default(),
             opacity: None,
             transform: None,
+            relative_transform: None,
             text_align: TextAlign::Left,
             text_align_vertical: TextAlignVertical::Top,
             text_overflow: TextOverflow::Clip,
@@ -644,6 +646,9 @@ impl ViewStyle {
         }
         if self.transform != other.transform {
             delta.transform = other.transform;
+        }
+        if self.relative_transform != other.relative_transform {
+            delta.relative_transform = other.relative_transform;
         }
         if self.text_align != other.text_align {
             delta.text_align = other.text_align;

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -549,9 +549,16 @@ fn compute_background(
 }
 
 // We have a 1:1 correspondence between Nodes and Views which is super nice.
+// NOTE: We carry round the immediate parent AND a relative_transform parent as we visit nodes.
+// The reason for this is that in some cases the `relative_transform` data is NOT relative to
+// the immediate parent. Please see:
+// https://www.figma.com/plugin-docs/api/properties/nodes-relativetransform/#:~:text=The%20relative%20transform%20of%20a,group%20or%20a%20boolean%20operation.
+// So in other words, `parent` will always be this node's immediate parent. But `relative_transform_parent` may
+// be a parent further up the tree.
 fn visit_node(
     node: &Node,
     parent: Option<&Node>,
+    relative_transform_parent: Option<&Node>,
     component_map: &HashMap<String, Component>,
     component_set_map: &HashMap<String, ComponentSet>,
     component_context: &mut ComponentContext,
@@ -615,7 +622,7 @@ fn visit_node(
 
     // Check relative transform to see if there is a rotation.
     if let Some(transform) = node.relative_transform {
-        let parent_bounding_box = parent.and_then(|p| p.absolute_bounding_box);
+        let parent_bounding_box = relative_transform_parent.and_then(|p| p.absolute_bounding_box);
         let bounds = node.absolute_bounding_box;
 
         fn get(transform: [[Option<f32>; 3]; 2], a: usize, b: usize) -> f32 {
@@ -633,6 +640,10 @@ fn visit_node(
                 get(transform, 0, 2),
                 get(transform, 1, 2),
             );
+
+            // Provide an unaltered transform from the last relevant parent.
+            style.relative_transform = Some(r.clone());
+            // And an additional transform with translation removed.
             let r = r.post_translate(euclid::vec3(
                 -(bounds.x() - parent_bounds.x()),
                 -(bounds.y() - parent_bounds.y()),
@@ -1228,8 +1239,16 @@ fn visit_node(
         RenderMethod::None,
     );
 
+    // If the current node is a Group or a Boolean operation, it does
+    // not become the new parent used for `relative_transform` calculations.
+    let relative_transform_node = match node.data {
+        NodeData::Group { .. } => relative_transform_parent,
+        NodeData::BooleanOperation { .. } => relative_transform_parent,
+        _ => Some(node),
+    };
+
     // Iterate over our visible children, but not vectors because they always
-    // present their childrens content themselves (e.g.: they are boolean products
+    // present their children's content themselves (e.g.: they are boolean products
     // of their children).
     if node.vector().is_none() {
         for child in node.children.iter() {
@@ -1237,6 +1256,7 @@ fn visit_node(
                 view.add_child(visit_node(
                     child,
                     Some(node),
+                    relative_transform_node,
                     component_map,
                     component_set_map,
                     component_context,
@@ -1266,6 +1286,7 @@ pub fn create_component_flexbox(
 ) -> View {
     visit_node(
         component,
+        None,
         None,
         component_map,
         component_set_map,

--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -275,6 +275,12 @@ internal fun mergeStyles(base: ViewStyle, override: ViewStyle): ViewStyle {
         } else {
             base.transform
         }
+    style.relative_transform =
+        if (override.relative_transform.isPresent) {
+            override.relative_transform
+        } else {
+            base.relative_transform
+        }
     style.text_align =
         if (override.text_align !is TextAlign.Left) {
             override.text_align


### PR DESCRIPTION
This is to address the issue I saw and filed as #315.

The primary change is to include the original unaltered `relative_transform` in the serialized figma output. Since this addition is merely additive, that change should not break anything.

~~**However** I'm also making a correction to the `transform` calculation which I believe to be correct, but which could break downstream clients. Maybe we can talk about how to test this.~~

The addition of the original `relative_transform` in the serialzied document has allowed me to decrease the complexity of of our renderer (slighly) and also fixes the original issue. I'll attach a screenshot of our (non-flattened) telltales below.

![Screenshot from 2023-08-24 23-37-05](https://github.com/google/automotive-design-compose/assets/2950232/54c2fbe4-f8f8-4d96-9c93-ac2d43ced24f)
