### PR TITLE
Clean up unused method of setting Figma Token

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -16,7 +16,6 @@
 
 package com.android.designcompose
 
-import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -30,7 +29,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
-import androidx.core.util.Consumer
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -44,14 +42,12 @@ import java.net.SocketException
 import java.time.Instant
 import java.util.Optional
 import kotlin.concurrent.thread
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 
 internal const val TAG = "DesignCompose"
 

--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -101,8 +101,6 @@ object DesignSettings {
     private var fontDb: HashMap<String, FontFamily> = HashMap()
     internal var fileFetchStatus: HashMap<String, DesignDocStatus> = HashMap()
 
-    @VisibleForTesting internal var defaultIODispatcher = Dispatchers.IO
-
     @VisibleForTesting
     @RestrictTo(RestrictTo.Scope.TESTS)
     fun testOnlyFigmaFetchStatus(fileId: String) = fileFetchStatus[fileId]
@@ -133,37 +131,12 @@ object DesignSettings {
                 latestKey != null && liveUpdatesEnabled
             }
 
-        // Start listening for the setApiKey intent on the main activity
-        activity.addOnNewIntentListener(setApiKeyListener)
-
         DocServer.initializeLiveUpdate()
     }
 
     fun disableToasts() {
         toastsEnabled = false
     }
-
-    // Intent consumer that checks for a new API Key and stores it.
-    private val setApiKeyListener =
-        Consumer<Intent> { intent ->
-            if (intent?.action == ACTION_SET_API_KEY) {
-                val activity = parentActivity.get()
-                if (activity == null) {
-                    Log.e(TAG, "Cannot set API Key, LiveUpdate not fully initialized")
-                    return@Consumer
-                } else {
-                    intent.getStringExtra(EXTRA_SET_API_KEY)?.let { newKey ->
-                        // Launch the coroutine to save the new value
-                        activity.lifecycleScope.launch(defaultIODispatcher) {
-                            // Grab an instance and set the key
-                            activity.applicationContext.let {
-                                liveUpdateSettings?.setFigmaApiKey(newKey)
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
     fun addFontFamily(name: String, family: FontFamily) {
         fontDb[name] = family

--- a/dev-scripts/test-all.sh
+++ b/dev-scripts/test-all.sh
@@ -18,6 +18,8 @@ usage() {
 cat  <<END
 This script should run all of the tests that CI will run. (It'll need to be kept up to date though)
 Options:
+  -f: Run a basic format of the Kotlin code before testing. 
+    Won't catch everything but shouldn't cause everything to rebuild either.
   -s: Skip emulator tests
   -u: Set Unbundled AAOS path
 Pre-requisites: 
@@ -29,13 +31,17 @@ END
 
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
 run_emulator_tests=1
-while getopts "su:" opt; do
+RUN_FORMAT=false
+while getopts "fsu:" opt; do
   case "$opt" in
     s)
       run_emulator_tests=0
       ;;
     u)
       ORG_GRADLE_PROJECT_unbundledAAOSDir=$(realpath "${OPTARG}")
+      ;;
+    f)
+      RUN_FORMAT=true
       ;;
     *)
       usage
@@ -67,6 +73,9 @@ fi
 export ORG_GRADLE_PROJECT_DesignComposeMavenRepo="$GIT_ROOT/build/test-all/designcompose_m2repo"
 
 cd "$GIT_ROOT" || exit
+
+if [[ $RUN_FORMAT == "true" ]]; then ./gradlew ktfmtFormat; fi
+
 # if https://github.com/rhysd/actionlint is installed then run it. This is a low priority check so it's fine to not run it
 if which actionlint > /dev/null; then actionlint; fi
 cargo-fmt --all --check


### PR DESCRIPTION
I realized we still had two ways of setting the key, one from the app's main activity and the other from the ApiKeyService. The main activity method is undocumented, and it's essentially duplicate functionality that's still there because I couldn't decide between the two methods for setting the key.

Ended up adding a new "format" option to the test-all script because I was getting annoyed by too many formatting lint errors