### PR TITLE
Remove repeated ProxyConfig Log print

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -308,7 +308,6 @@ internal fun DocServer.fetchDocuments(
     }
 
     val proxyConfig = getProxyConfig()
-    Log.i(TAG, "HTTP Proxy: ${proxyConfig.httpProxyConfig?.proxySpec ?: "not set"}")
 
     val docIds =
         synchronized(subscriptions) {


### PR DESCRIPTION
Seems unnecessary to print it for every fetch attempt.