### PR TITLE
Fix: Release builds crash trying to find DesignTextMeasure class

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DesignTextMeasure.java
+++ b/designcompose/src/main/java/com/android/designcompose/DesignTextMeasure.java
@@ -14,14 +14,17 @@
 
 package com.android.designcompose;
 
+import androidx.annotation.Keep;
+
 import kotlin.Pair;
 
 // JNI function called from Rust as a measure function for text
+@Keep
 public class DesignTextMeasure {
-  public static TextSize measureTextSize(int layoutId, float width, float height, float availableWidth, float availableHeight) {
-    Pair<Float, Float> size = com.android.designcompose.DesignTextKt.measureTextBoundsFunc(layoutId, width, height, availableWidth, availableHeight);
-    float outWidth = size.component1().floatValue();
-    float outHeight = size.component2().floatValue();
-    return new TextSize(outWidth, outHeight);
-  }
+    public static TextSize measureTextSize(int layoutId, float width, float height, float availableWidth, float availableHeight) {
+        Pair<Float, Float> size = com.android.designcompose.DesignTextKt.measureTextBoundsFunc(layoutId, width, height, availableWidth, availableHeight);
+        float outWidth = size.component1().floatValue();
+        float outHeight = size.component2().floatValue();
+        return new TextSize(outWidth, outHeight);
+    }
 }

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -16,6 +16,7 @@
 
 package com.android.designcompose
 
+import androidx.annotation.Keep
 import androidx.annotation.VisibleForTesting
 
 // HTTP Proxy configuration.
@@ -28,6 +29,7 @@ internal class ProxyConfig {
     var httpProxyConfig: HttpProxyConfig? = null
 }
 
+@Keep
 internal class TextSize(
     var width: Float = 0F,
     var height: Float = 0F,


### PR DESCRIPTION
Fixes #406

We can and should use the @Keep annotation for any functions and structures that will be called only from the Rust code.