### PR TITLE
Update AGP to 8.1.2, partial build script update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,6 @@ buildscript {
     dependencies {
         // These are plugins that are published as external jars, integrating directly into the
         // build scripts
-        classpath(libs.kotlin.gradlePlugin)
-        classpath(libs.android.gradlePlugin)
         classpath(libs.dokka.gradlePlugin)
         classpath(libs.android.gms.strictVersionMatcher)
     }
@@ -35,6 +33,10 @@ buildscript {
 plugins {
     id("designcompose.conventions.base")
     id("designcompose.conventions.android-test-devices") apply false
+    alias(libs.plugins.androidApplication) apply false
+    alias(libs.plugins.androidLibrary) apply false
+    alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.roborazzi) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,9 @@ compileSdk = "33"
 targetSdk = "33"
 
 #Compose and Kotlin Versions - tightly coupled
-kotlin = "1.9.0"
-ksp = "1.9.0-1.0.13"
-androidx-compose-compiler = "1.5.1"
+kotlin = "1.9.10"
+ksp = "1.9.10-1.0.13"
+androidx-compose-compiler = "1.5.3"
 androidx-compose-bom = "2023.06.01"
 androidx-compose-foundation = "1.4.3"
 androidx-compose-runtime = "1.4.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,9 @@
 designcompose = "0.24.0-SNAPSHOT"
 
 #Android Gradle Plugin
-android-gradlePlugin = "8.1.0"
+agp = "8.1.2"
 # The minimum supported AGP version for DesignCompose Apps
-android-gradlePlugin-minSupported = "7.3.1"
+agp-minSupported = "7.3.1"
 
 # SDK Levels
 minSdk = "26"
@@ -52,8 +52,8 @@ roborazzi = "1.7.0-alpha-4"
 [libraries]
 android-car-ui = { module = "com.android.car.ui:car-ui-lib", version.ref = "android-car-ui" } # Used in MediaCompose
 android-gms-strictVersionMatcher = { module = "com.google.android.gms:strict-version-matcher-plugin", version.ref = "android-gms-strictVersionMatcher" }
-android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin" }
-android-gradlePlugin-minimumSupportedVersion = { module = "com.android.tools.build:gradle", version.ref = "android-gradlePlugin-minSupported" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+android-gradlePlugin-minimumSupportedVersion = { module = "com.android.tools.build:gradle", version.ref = "agp-minSupported" }
 androidx-core = { group = "androidx.core", name = "core", version.ref = "androidx-core" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -103,6 +103,10 @@ roborazzi-compose = {module = "io.github.takahirom.roborazzi:roborazzi-compose",
 roborazzi-junit = {module = "io.github.takahirom.roborazzi:roborazzi-junit-rule", version.ref = "roborazzi"}
 
 [plugins]
+androidApplication = { id = "com.android.application", version.ref = "agp" }
+androidLibrary = { id = "com.android.library", version.ref = "agp" }
+kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 designcompose = { id = "com.android.designcompose", version.ref = "designcompose" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }

--- a/integration-tests/validation/build.gradle.kts
+++ b/integration-tests/validation/build.gradle.kts
@@ -88,10 +88,7 @@ dependencies {
     implementation(libs.designcompose)
     ksp(libs.designcompose.codegen)
 
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.compose.ui.tooling.preview)
@@ -111,6 +108,7 @@ dependencies {
 
     androidTestImplementation(testFixtures(project(":designcompose")))
     androidTestImplementation(kotlin("test"))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.google.truth)
     androidTestImplementation(libs.androidx.compose.ui.tooling)

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        // These are plugins that are published as external jars, integrating directly into the
-        // build scripts
-        classpath(libs.kotlin.gradlePlugin)
-    }
+@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
+plugins {
+  id("designcompose.conventions.base")
+  alias(libs.plugins.kotlinJvm) apply false
 }
-
-plugins { id("designcompose.conventions.base") }

--- a/plugins/settings.gradle.kts
+++ b/plugins/settings.gradle.kts
@@ -16,6 +16,20 @@
 
 rootProject.name = "DesignCompose Plugins"
 
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        gradlePluginPortal()
+    }
+    includeBuild("../build-logic")
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -23,14 +37,6 @@ dependencyResolutionManagement {
         mavenCentral()
     }
     versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
-}
-
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
-    includeBuild("../build-logic")
 }
 
 plugins {

--- a/reference-apps/aaos-unbundled/media/build.gradle.kts
+++ b/reference-apps/aaos-unbundled/media/build.gradle.kts
@@ -46,9 +46,7 @@ dependencies {
     implementation(libs.designcompose)
     ksp(libs.designcompose.codegen)
 
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
+    implementation(platform(libs.androidx.compose.bom))
 
     api(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.foundation.layout)
@@ -70,6 +68,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(libs.junit)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espresso.core)
 }

--- a/reference-apps/aaos-unbundled/mediacompose/build.gradle.kts
+++ b/reference-apps/aaos-unbundled/mediacompose/build.gradle.kts
@@ -85,10 +85,7 @@ dependencies {
     ksp(libs.designcompose.codegen)
     implementation(project(":media"))
 
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.legacy.support.v4)
@@ -99,6 +96,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     testImplementation(libs.junit)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espresso.core)
 }

--- a/reference-apps/aaos-unbundled/settings.gradle.kts
+++ b/reference-apps/aaos-unbundled/settings.gradle.kts
@@ -22,13 +22,13 @@ val unbundledAAOSAndroidGradlePluginVer = "7.4.2"
 val aaosLatestSDK = "32"
 
 includeBuild("$unbundledAAOSDir/packages/apps/Car/libs/aaos-apps-gradle-project") {
-  dependencySubstitution {
-    substitute(module("com.android.car-ui-lib:car-ui-lib")).using(project(":car-ui-lib"))
-    substitute(module("com.android.car-apps-common:car-apps-common"))
-        .using(project(":car-apps-common"))
-    substitute(module("com.android.car-media-common:car-media-common"))
-        .using(project(":car-media-common"))
-  }
+    dependencySubstitution {
+        substitute(module("com.android.car-ui-lib:car-ui-lib")).using(project(":car-ui-lib"))
+        substitute(module("com.android.car-apps-common:car-apps-common"))
+            .using(project(":car-apps-common"))
+        substitute(module("com.android.car-media-common:car-media-common"))
+            .using(project(":car-media-common"))
+    }
 }
 
 /* Note about how this project finds the DesignCompose SDK:
@@ -44,51 +44,56 @@ checks for it.
 
 @Suppress("UnstableApiUsage") // For versionCatalogs and repositories
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-  repositories {
-    if (!DesignComposeMavenRepo.isNullOrBlank()) {
-      logger.lifecycle("Using DesignCompose SDK from $DesignComposeMavenRepo")
-      maven(uri(DesignComposeMavenRepo!!)) { content { includeGroup("com.android.designcompose") } }
-      google() { content { excludeGroupByRegex("com\\.android\\.designcompose.*") } }
-    } else {
-      google()
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        if (!DesignComposeMavenRepo.isNullOrBlank()) {
+            logger.lifecycle("Using DesignCompose SDK from $DesignComposeMavenRepo")
+            maven(uri(DesignComposeMavenRepo!!)) {
+                content { includeGroup("com.android.designcompose") }
+            }
+            google() { content { excludeGroupByRegex("com\\.android\\.designcompose.*") } }
+        } else {
+            google()
+        }
+        mavenCentral()
     }
-    mavenCentral()
-  }
-  versionCatalogs {
-    create("unbundledLibs") {
-      from(files("../../gradle/libs.versions.toml"))
-      // Version overrides used for the unbundled apps, which include the Unbundled AAOS repo
-      // and must match certain key versions These versions must match the version of the
-      // Android Gradle Plugin used in the AAOS Unbundled repo Version can be found in
-      // `packages/apps/Car/libs/aaos-apps-gradle-project/build.gradle` of the repo TODO:
-      // parse out the version the version from that file
-      println(
-          "Reminder! Overriding Android Gradle Plugin version to $unbundledAAOSAndroidGradlePluginVer to match the Unbundled AAOS project!")
-      version("android.gradlePlugin", unbundledAAOSAndroidGradlePluginVer)
-      version("aaosLatestSDK", aaosLatestSDK)
+    versionCatalogs {
+        create("unbundledLibs") {
+            from(files("../../gradle/libs.versions.toml"))
+            // Version overrides used for the unbundled apps, which include the Unbundled AAOS repo
+            // and must match certain key versions These versions must match the version of the
+            // Android Gradle Plugin used in the AAOS Unbundled repo Version can be found in
+            // `packages/apps/Car/libs/aaos-apps-gradle-project/build.gradle` of the repo TODO:
+            // parse out the version the version from that file
+            println(
+                "Reminder! Overriding Android Gradle Plugin version to $unbundledAAOSAndroidGradlePluginVer to match the Unbundled AAOS project!"
+            )
+            version("agp", unbundledAAOSAndroidGradlePluginVer)
+            version("aaosLatestSDK", aaosLatestSDK)
+        }
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+            // Use the latest published version of the SDK
+            version("designcompose", "+")
+        }
     }
-    create("libs") {
-      from(files("../../gradle/libs.versions.toml"))
-      // Use the latest published version of the SDK
-      version("designcompose", "+")
-    }
-  }
 }
 
 pluginManagement {
-  // Need to load the property here as well
-  val DesignComposeMavenRepo: String? by settings
+    // Need to load the property here as well
+    val DesignComposeMavenRepo: String? by settings
 
-  repositories {
-    gradlePluginPortal()
-    if (!DesignComposeMavenRepo.isNullOrBlank()) {
-      maven(uri(DesignComposeMavenRepo!!)) { content { includeGroup("com.android.designcompose") } }
-      google() { content { excludeGroupByRegex("com\\.android\\.designcompose.*") } }
-    } else {
-      google()
+    repositories {
+        gradlePluginPortal()
+        if (!DesignComposeMavenRepo.isNullOrBlank()) {
+            maven(uri(DesignComposeMavenRepo!!)) {
+                content { includeGroup("com.android.designcompose") }
+            }
+            google() { content { excludeGroupByRegex("com\\.android\\.designcompose.*") } }
+        } else {
+            google()
+        }
     }
-  }
 }
 // Reference apps
 include(":media")

--- a/reference-apps/helloworld/build.gradle.kts
+++ b/reference-apps/helloworld/build.gradle.kts
@@ -84,9 +84,7 @@ dependencies {
     androidTestImplementation(testFixtures(project(":designcompose")))
     ksp(project(":codegen"))
 
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
+    implementation(platform(libs.androidx.compose.bom))
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.material)
@@ -104,6 +102,7 @@ dependencies {
     testImplementation(libs.androidx.compose.ui.test.junit4)
 
     androidTestImplementation(kotlin("test"))
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.google.truth)
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)

--- a/reference-apps/tutorial/app/build.gradle.kts
+++ b/reference-apps/tutorial/app/build.gradle.kts
@@ -72,10 +72,7 @@ dependencies {
     implementation(libs.designcompose)
     ksp(libs.designcompose.codegen)
 
-    val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.compose.ui.tooling.preview)
@@ -84,6 +81,7 @@ dependencies {
     testImplementation(libs.junit)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,21 @@
  * limitations under the License.
  */
 
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        gradlePluginPortal()
+    }
+    includeBuild("plugins")
+    includeBuild("build-logic")
+}
+
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
@@ -21,15 +36,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
-}
-
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-    }
-    includeBuild("plugins")
-    includeBuild("build-logic")
 }
 
 rootProject.name = "DesignCompose"


### PR DESCRIPTION
Newly generated Android projects have some optimizations and
use the current recommended syntax for plugins. I've updated some of
our base build files to use the new syntax, added their optimizations for
plugin fetching and renamed some libs.versions.toml labels to match
the ones from new projects.