### PR TITLE
Split the Gradle profile jobs into a separate workflow

### DIFF
--- a/.github/workflows/gradle-profile.yml
+++ b/.github/workflows/gradle-profile.yml
@@ -1,0 +1,82 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Gradle Build Profile
+
+on:
+  push:
+    branches:
+    - main
+    - 'stable/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gradle-build-profile:
+    strategy:
+      matrix:
+        task: [assembleDebug, publishAllPublicationsToLocalDirRepository]
+        cache: [cache-enabled, cache-disabled]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
+
+      - name: Set up Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          cache-disabled: ${{matrix.cache == 'cache-disabled'}}
+
+      - name: Set up Rust Cache
+        if: ${{matrix.cache == 'cache-enabled'}}
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
+        with:
+          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
+          shared-key: "gradle-rust"
+
+      - name: Update Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Install Rust toolchains
+        run: ./install-rust-toolchains.sh
+
+      - name: Run the profiled build
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          arguments:
+            ${{matrix.task}} --profile
+
+      - name: Parse the results
+        run: |
+            ./dev-scripts/parse-profile-data.sh
+
+      - name: Upload profile info
+        uses: actions/upload-artifact@v3
+        with:
+          name: gradle-profile-${{matrix.task}}-${{matrix.cache}}
+          path: |
+            **/build/reports/profile
+          if-no-files-found: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,63 +361,6 @@ jobs:
         arguments: |
           check
 
-  gradle-build-profile:
-    strategy:
-      matrix:
-        task: [assembleDebug, publishAllPublicationsToLocalDirRepository]
-        cache: [cache-enabled, cache-disabled]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
-
-      - name: Set up Java
-        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          cache-disabled: ${{matrix.cache == 'cache-disabled'}}
-
-      - name: Set up Rust Cache
-        if: ${{matrix.cache == 'cache-enabled'}}
-        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
-        with:
-          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
-          shared-key: "gradle-rust"
-
-      - name: Update Rust
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Install Rust toolchains
-        run: ./install-rust-toolchains.sh
-
-      - name: Run the profiled build
-        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
-        with:
-          arguments:
-            ${{matrix.task}} --profile
-
-      - name: Parse the results
-        run: |
-            ./dev-scripts/parse-profile-data.sh
-
-      - name: Upload profile info
-        uses: actions/upload-artifact@v3
-        with:
-          name: gradle-profile-${{matrix.task}}-${{matrix.cache}}
-          path: |
-            **/build/reports/profile
-          if-no-files-found: error
-
-
 ############# Rust
   rust-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will make it easier to fetch and compare the
differences between builds.