### PR TITLE
Add default ktfmt IntelliJ settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ captures
 node_modules
 # Something in android studio is generating this. Probably related to
 # https://github.com/gradle/gradle/issues/23032
-*/bin 
+*/bin
 # Output of npm build
 /support-figma/*/code.js
 /support-figma/*/dist
@@ -20,7 +20,8 @@ node_modules
 .terragrunt-cache
 
 # User settings dirs
-.idea
+**/.idea/*
+!.idea/ktfmt.xml
 .vscode
 local.properties
 

--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project version="4">
+  <component name="KtfmtSettings">
+    <option name="enabled" value="true" />
+    <option name="uiFormatterStyle" value="Kotlinlang" />
+  </component>
+</project>


### PR DESCRIPTION
These settings will enable the ktfmt plugin and set it to use the correct format.

Note: This will override your default ktfmt plugin settings, however, the only settings offered are off/on and which style to use. The plugin should be on and it should be using the KotlinLang style.

(Also caught some whitespace formatting in the .gitignore).