### PR TITLE
Remove out of date suppression

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ buildscript {
     }
 }
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     id("designcompose.conventions.base")
     id("designcompose.conventions.android-test-devices") apply false

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     id("designcompose.conventions.base")
     alias(libs.plugins.kotlinJvm) apply false

--- a/plugins/gradle-plugin/build.gradle.kts
+++ b/plugins/gradle-plugin/build.gradle.kts
@@ -16,7 +16,6 @@
 
 import designcompose.conventions.publish.basePom
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     kotlin("jvm")
     `java-gradle-plugin`


### PR DESCRIPTION
[KTIJ-19369 is fixed.](https://youtrack.jetbrains.com/issue/KTIJ-19369/False-positive-cant-be-called-in-this-context-by-implicit-receiver-with-plugins-in-Gradle-version-catalogs-as-a-TOML-file)