### PR TITLE
Closes #471: Fix live update not updating positional changes

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -239,7 +239,7 @@ internal fun DesignText(
     // Keep track of the layout state, which changes whenever this view's layout changes
     val (layoutState, setLayoutState) = remember { mutableStateOf(0) }
     // Subscribe for layout changes whenever the text data changes.
-    DisposableEffect(textMeasureData) {
+    DisposableEffect(textMeasureData, style) {
         val parentLayoutId = parentLayout?.parentLayoutId ?: -1
         val childIndex = parentLayout?.childIndex ?: -1
         Log.d(

--- a/designcompose/src/main/java/com/android/designcompose/Layout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Layout.kt
@@ -672,7 +672,7 @@ internal fun designTextMeasurePolicy(
     val myHeight = renderHeight ?: layout?.height() ?: 0
     val myX = 0
     val myY = renderTop ?: layout?.top() ?: 0
-    Log.d(TAG, "LayoutText $name w $myWidth h $myHeight x $myX y $myY")
+    Log.d(TAG, "LayoutText $name w $myWidth h $myHeight x $myX y $myY left ${layout?.left}")
     layout(myWidth, myHeight) {
         // Text has no children, so placeables is always just a list of 1 for this text, which
         // we place at the calculated offset.


### PR DESCRIPTION
When computing layout and determining nodes that changed, include the parent of the node as well. For text nodes, recompute text layout when the text style changes.