### PR TITLE
Closes #486, #487, #488, #490: Performance improvements

### DIFF
--- a/crates/figma_import/src/layout.rs
+++ b/crates/figma_import/src/layout.rs
@@ -19,7 +19,7 @@
 //! The goal of this crate is to perform the mapping from Figma to the toolkit; it does
 //! not provide any kind of UI logic mapping.
 
-use crate::toolkit_schema;
+use crate::{toolkit_schema::Layout, toolkit_style::ViewStyle};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LayoutChangedResponse {
     pub layout_state: i32,
-    pub changed_layouts: HashMap<i32, toolkit_schema::Layout>,
+    pub changed_layouts: HashMap<i32, Layout>,
 }
 impl LayoutChangedResponse {
     pub fn unchanged(layout_state: i32) -> Self {
@@ -42,8 +42,8 @@ pub struct LayoutNode {
     pub layout_id: i32,
     pub parent_layout_id: i32,
     pub child_index: i32,
-    pub view: toolkit_schema::View,
-    pub base_view: Option<toolkit_schema::View>,
+    pub style: ViewStyle,
+    pub name: String,
     pub use_measure_func: bool,
 }
 

--- a/crates/figma_import/src/layout.rs
+++ b/crates/figma_import/src/layout.rs
@@ -45,6 +45,8 @@ pub struct LayoutNode {
     pub style: ViewStyle,
     pub name: String,
     pub use_measure_func: bool,
+    pub fixed_width: Option<i32>,
+    pub fixed_height: Option<i32>,
 }
 
 // A list of Figma nodes to register for layout

--- a/crates/figma_import/src/layout.rs
+++ b/crates/figma_import/src/layout.rs
@@ -21,6 +21,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::toolkit_schema;
+
 // The layout response sent back to client which contains a layout state ID and
 // a list of layout IDs that have changed.
 #[derive(Serialize, Deserialize, Debug)]
@@ -32,4 +34,21 @@ impl LayoutChangedResponse {
     pub fn unchanged(layout_state: i32) -> Self {
         LayoutChangedResponse { layout_state, changed_layout_ids: vec![] }
     }
+}
+
+// A representation of a Figma node to register for layout.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LayoutNode {
+    pub layout_id: i32,
+    pub parent_layout_id: i32,
+    pub child_index: i32,
+    pub view: toolkit_schema::View,
+    pub base_view: Option<toolkit_schema::View>,
+    pub use_measure_func: bool,
+}
+
+// A list of Figma nodes to register for layout
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LayoutNodeList {
+    pub layout_nodes: Vec<LayoutNode>,
 }

--- a/crates/figma_import/src/layout.rs
+++ b/crates/figma_import/src/layout.rs
@@ -19,20 +19,20 @@
 //! The goal of this crate is to perform the mapping from Figma to the toolkit; it does
 //! not provide any kind of UI logic mapping.
 
-use serde::{Deserialize, Serialize};
-
 use crate::toolkit_schema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // The layout response sent back to client which contains a layout state ID and
 // a list of layout IDs that have changed.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct LayoutChangedResponse {
     pub layout_state: i32,
-    pub changed_layout_ids: Vec<i32>,
+    pub changed_layouts: HashMap<i32, toolkit_schema::Layout>,
 }
 impl LayoutChangedResponse {
     pub fn unchanged(layout_state: i32) -> Self {
-        LayoutChangedResponse { layout_state, changed_layout_ids: vec![] }
+        LayoutChangedResponse { layout_state, changed_layouts: HashMap::new() }
     }
 }
 

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -171,6 +171,10 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
     tracer
         .trace_type::<crate::layout::LayoutChangedResponse>(&samples)
         .expect("couldn't trace LayoutChangedResponse");
+    tracer.trace_type::<crate::layout::LayoutNode>(&samples).expect("couldn't trace LayoutNode");
+    tracer
+        .trace_type::<crate::layout::LayoutNodeList>(&samples)
+        .expect("couldn't trace LayoutNodeList");
 
     tracer
         .trace_type::<crate::image_context::EncodedImageMap>(&samples)

--- a/crates/jni/src/jni.rs
+++ b/crates/jni/src/jni.rs
@@ -17,7 +17,6 @@ use std::ffi::c_void;
 use crate::error_map::map_err_to_exception;
 use android_logger::Config;
 use figma_import::layout::{LayoutChangedResponse, LayoutNodeList};
-use figma_import::toolkit_style::ViewStyle;
 use figma_import::{fetch_doc, ConvertRequest, ProxyConfig};
 use jni::objects::{JByteArray, JClass, JObject, JString, JValue, JValueGen};
 use jni::sys::{jboolean, jint, JNI_VERSION_1_6};
@@ -204,9 +203,10 @@ fn jni_remove_node<'local>(
     env: JNIEnv<'local>,
     _class: JClass,
     layout_id: jint,
+    root_layout_id: jint,
     compute_layout: jboolean,
 ) -> JByteArray<'local> {
-    let layout_response = remove_view(layout_id, compute_layout != 0);
+    let layout_response = remove_view(layout_id, root_layout_id, compute_layout != 0);
     layout_response_to_bytearray(env, &layout_response)
 }
 
@@ -309,7 +309,7 @@ pub extern "system" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
                 },
                 jni::NativeMethod {
                     name: "jniRemoveNode".into(),
-                    sig: "(IZ)[B".into(),
+                    sig: "(IIZ)[B".into(),
                     fn_ptr: jni_remove_node as *mut c_void,
                 },
             ],

--- a/crates/jni/src/jni.rs
+++ b/crates/jni/src/jni.rs
@@ -182,6 +182,8 @@ fn jni_add_nodes<'local>(
                             node.child_index,
                             node.style,
                             node.name,
+                            node.fixed_width,
+                            node.fixed_height,
                         );
                     }
                 }

--- a/crates/layout/src/bin/fetch_layout.rs
+++ b/crates/layout/src/bin/fetch_layout.rs
@@ -20,7 +20,7 @@ use figma_import::{
     Document, NodeQuery, ProxyConfig, SerializedDesignDoc, ViewData,
 };
 use layout::{
-    add_view, add_view_measure, compute_node_layout, print_layout, remove_view, set_node_size,
+    add_style, add_style_measure, compute_node_layout, print_layout, remove_view, set_node_size,
 };
 use std::collections::HashMap;
 use std::io;
@@ -135,21 +135,40 @@ fn test_layout(
             }
         }
         if use_measure_func {
-            add_view_measure(my_id, parent_layout_id, child_index, view.clone(), measure_func);
+            add_style_measure(
+                my_id,
+                parent_layout_id,
+                child_index,
+                view.style.clone(),
+                view.name.clone(),
+                measure_func,
+            );
         } else {
             let mut fixed_view = view.clone();
             fixed_view.style.width = Dimension::Points(view.style.bounding_box.width);
             fixed_view.style.height = Dimension::Points(view.style.bounding_box.height);
-            add_view(my_id, parent_layout_id, child_index, fixed_view, None);
+            add_style(
+                my_id,
+                parent_layout_id,
+                child_index,
+                fixed_view.style.clone(),
+                fixed_view.name.clone(),
+            );
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
         if view.name.starts_with("#Replacement") {
             let square = views.get(&NodeQuery::NodeName("#BlueSquare".to_string()));
             if let Some(square) = square {
-                add_view(my_id, parent_layout_id, child_index, square.clone(), Some(view.clone()));
+                add_style(
+                    my_id,
+                    parent_layout_id,
+                    child_index,
+                    square.style.clone(),
+                    square.name.clone(),
+                );
             }
         } else {
-            add_view(my_id, parent_layout_id, child_index, view.clone(), None);
+            add_style(my_id, parent_layout_id, child_index, view.style.clone(), view.name.clone());
         }
         let mut index = 0;
         for child in children {
@@ -159,7 +178,7 @@ fn test_layout(
     }
 
     if parent_layout_id == -1 {
-        compute_node_layout(*id);
+        compute_node_layout(my_id);
     }
 }
 fn fetch_impl(args: Args) -> Result<(), ConvertError> {

--- a/crates/layout/src/bin/fetch_layout.rs
+++ b/crates/layout/src/bin/fetch_layout.rs
@@ -153,6 +153,8 @@ fn test_layout(
                 child_index,
                 fixed_view.style.clone(),
                 fixed_view.name.clone(),
+                Some(view.style.bounding_box.width as i32),
+                Some(view.style.bounding_box.height as i32),
             );
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
@@ -165,10 +167,20 @@ fn test_layout(
                     child_index,
                     square.style.clone(),
                     square.name.clone(),
+                    None,
+                    None,
                 );
             }
         } else {
-            add_style(my_id, parent_layout_id, child_index, view.style.clone(), view.name.clone());
+            add_style(
+                my_id,
+                parent_layout_id,
+                child_index,
+                view.style.clone(),
+                view.name.clone(),
+                None,
+                None,
+            );
         }
         let mut index = 0;
         for child in children {

--- a/crates/layout/src/bin/fetch_layout.rs
+++ b/crates/layout/src/bin/fetch_layout.rs
@@ -20,7 +20,7 @@ use figma_import::{
     Document, NodeQuery, ProxyConfig, SerializedDesignDoc, ViewData,
 };
 use layout::{
-    add_view, add_view_measure, compute_layout, print_layout, remove_view, set_node_size,
+    add_view, add_view_measure, compute_node_layout, print_layout, remove_view, set_node_size,
 };
 use std::collections::HashMap;
 use std::io;
@@ -135,35 +135,21 @@ fn test_layout(
             }
         }
         if use_measure_func {
-            add_view_measure(
-                my_id,
-                parent_layout_id,
-                child_index,
-                view.clone(),
-                measure_func,
-                false,
-            );
+            add_view_measure(my_id, parent_layout_id, child_index, view.clone(), measure_func);
         } else {
             let mut fixed_view = view.clone();
             fixed_view.style.width = Dimension::Points(view.style.bounding_box.width);
             fixed_view.style.height = Dimension::Points(view.style.bounding_box.height);
-            add_view(my_id, parent_layout_id, child_index, fixed_view, None, false);
+            add_view(my_id, parent_layout_id, child_index, fixed_view, None);
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
         if view.name.starts_with("#Replacement") {
             let square = views.get(&NodeQuery::NodeName("#BlueSquare".to_string()));
             if let Some(square) = square {
-                add_view(
-                    my_id,
-                    parent_layout_id,
-                    child_index,
-                    square.clone(),
-                    Some(view.clone()),
-                    false,
-                );
+                add_view(my_id, parent_layout_id, child_index, square.clone(), Some(view.clone()));
             }
         } else {
-            add_view(my_id, parent_layout_id, child_index, view.clone(), None, false);
+            add_view(my_id, parent_layout_id, child_index, view.clone(), None);
         }
         let mut index = 0;
         for child in children {
@@ -173,7 +159,7 @@ fn test_layout(
     }
 
     if parent_layout_id == -1 {
-        compute_layout();
+        compute_node_layout(*id);
     }
 }
 fn fetch_impl(args: Args) -> Result<(), ConvertError> {

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -17,6 +17,6 @@ extern crate log;
 mod layout;
 
 pub use layout::{
-    add_view, add_view_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
+    add_style, add_style_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
     remove_view, set_node_size, unchanged_response,
 };

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -17,6 +17,6 @@ extern crate log;
 mod layout;
 
 pub use layout::{
-    add_view, add_view_measure, clear_views, compute_layout, get_node_layout, print_layout,
+    add_view, add_view_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
     remove_view, set_node_size, unchanged_response,
 };

--- a/crates/layout/tests/layout_tests.rs
+++ b/crates/layout/tests/layout_tests.rs
@@ -29,7 +29,7 @@ use figma_import::{
     NodeQuery, SerializedDesignDoc, ViewData,
 };
 use layout::{
-    add_view, add_view_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
+    add_style, add_style_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
     remove_view, set_node_size,
 };
 use std::collections::HashMap;
@@ -82,15 +82,28 @@ fn add_view_to_layout(
             }
         }
         if use_measure_func {
-            add_view_measure(my_id, parent_layout_id, child_index, view.clone(), measure_func);
+            add_style_measure(
+                my_id,
+                parent_layout_id,
+                child_index,
+                view.style.clone(),
+                view.name.clone(),
+                measure_func,
+            );
         } else {
             let mut fixed_view = view.clone();
             fixed_view.style.width = Dimension::Points(view.style.bounding_box.width);
             fixed_view.style.height = Dimension::Points(view.style.bounding_box.height);
-            add_view(my_id, parent_layout_id, child_index, fixed_view, None);
+            add_style(
+                my_id,
+                parent_layout_id,
+                child_index,
+                fixed_view.style.clone(),
+                fixed_view.name.clone(),
+            );
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
-        add_view(my_id, parent_layout_id, child_index, view.clone(), None);
+        add_style(my_id, parent_layout_id, child_index, view.style.clone(), view.name.clone());
         let mut index = 0;
         for child in children {
             add_view_to_layout(child, id, my_id, index, replacements, views);

--- a/crates/layout/tests/layout_tests.rs
+++ b/crates/layout/tests/layout_tests.rs
@@ -250,8 +250,8 @@ fn test_vertical_fill_resize() {
 
     // Increase fixed left node height by 30 pixels
     let result = set_node_size(1, 0, 50, 140);
-    assert!(result.changed_layout_ids.contains(&2));
-    assert!(result.changed_layout_ids.contains(&3));
+    assert!(result.changed_layouts.contains_key(&2));
+    assert!(result.changed_layouts.contains_key(&3));
 
     // Right node should be taller by 30 pixels
     let right_layout_result = get_node_layout(2);
@@ -310,8 +310,8 @@ fn test_horizontal_fill_resize() {
 
     // Increase fixed top node width by 30 pixels
     let result = set_node_size(1, 0, 140, 50);
-    assert!(result.changed_layout_ids.contains(&2));
-    assert!(result.changed_layout_ids.contains(&3));
+    assert!(result.changed_layouts.contains_key(&2));
+    assert!(result.changed_layouts.contains_key(&3));
 
     // Bottom node should be wider by 30 pixels
     let bottom_layout_result = get_node_layout(2);

--- a/crates/layout/tests/layout_tests.rs
+++ b/crates/layout/tests/layout_tests.rs
@@ -100,10 +100,20 @@ fn add_view_to_layout(
                 child_index,
                 fixed_view.style.clone(),
                 fixed_view.name.clone(),
+                None,
+                None,
             );
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
-        add_style(my_id, parent_layout_id, child_index, view.style.clone(), view.name.clone());
+        add_style(
+            my_id,
+            parent_layout_id,
+            child_index,
+            view.style.clone(),
+            view.name.clone(),
+            None,
+            None,
+        );
         let mut index = 0;
         for child in children {
             add_view_to_layout(child, id, my_id, index, replacements, views);

--- a/crates/layout/tests/layout_tests.rs
+++ b/crates/layout/tests/layout_tests.rs
@@ -29,7 +29,7 @@ use figma_import::{
     NodeQuery, SerializedDesignDoc, ViewData,
 };
 use layout::{
-    add_view, add_view_measure, clear_views, compute_layout, get_node_layout, print_layout,
+    add_view, add_view_measure, clear_views, compute_node_layout, get_node_layout, print_layout,
     remove_view, set_node_size,
 };
 use std::collections::HashMap;
@@ -82,22 +82,15 @@ fn add_view_to_layout(
             }
         }
         if use_measure_func {
-            add_view_measure(
-                my_id,
-                parent_layout_id,
-                child_index,
-                view.clone(),
-                measure_func,
-                false,
-            );
+            add_view_measure(my_id, parent_layout_id, child_index, view.clone(), measure_func);
         } else {
             let mut fixed_view = view.clone();
             fixed_view.style.width = Dimension::Points(view.style.bounding_box.width);
             fixed_view.style.height = Dimension::Points(view.style.bounding_box.height);
-            add_view(my_id, parent_layout_id, child_index, fixed_view, None, false);
+            add_view(my_id, parent_layout_id, child_index, fixed_view, None);
         }
     } else if let ViewData::Container { shape: _, children } = &view.data {
-        add_view(my_id, parent_layout_id, child_index, view.clone(), None, false);
+        add_view(my_id, parent_layout_id, child_index, view.clone(), None);
         let mut index = 0;
         for child in children {
             add_view_to_layout(child, id, my_id, index, replacements, views);
@@ -106,7 +99,7 @@ fn add_view_to_layout(
     }
 
     if parent_layout_id == -1 {
-        compute_layout();
+        compute_node_layout(my_id);
     }
 }
 
@@ -256,7 +249,7 @@ fn test_vertical_fill_resize() {
     load_view("VerticalFill", &figma_doc_result.unwrap());
 
     // Increase fixed left node height by 30 pixels
-    let result = set_node_size(1, 50, 140);
+    let result = set_node_size(1, 0, 50, 140);
     assert!(result.changed_layout_ids.contains(&2));
     assert!(result.changed_layout_ids.contains(&3));
 
@@ -316,7 +309,7 @@ fn test_horizontal_fill_resize() {
     load_view("HorizontalFill", &figma_doc_result.unwrap());
 
     // Increase fixed top node width by 30 pixels
-    let result = set_node_size(1, 140, 50);
+    let result = set_node_size(1, 0, 140, 50);
     assert!(result.changed_layout_ids.contains(&2));
     assert!(result.changed_layout_ids.contains(&3));
 

--- a/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
+++ b/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
@@ -61,6 +61,7 @@ fun EmptyListContent(): ListContent {
 
 data class ContentReplacementContext(
     val parentLayoutId: Int,
+    val rootLayoutId: Int,
 )
 
 data class ReplacementContent(

--- a/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
@@ -170,7 +170,7 @@ internal fun DesignFrame(
             // there are no other parent frames performing layout, layout computation can be
             // performed.
             DisposableEffect(view) {
-                LayoutManager.finishLayout(layoutId)
+                LayoutManager.finishLayout(layoutId, parentLayout?.rootLayoutId ?: layoutId)
                 onDispose {}
             }
         }
@@ -186,6 +186,7 @@ internal fun DesignFrame(
     // row or column (with or without wrapping/flow), or absolute positioning (similar to the CSS2
     // model).
     val layout = LayoutManager.getLayout(layoutId)
+    val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
     when (layoutInfo) {
         is LayoutInfoRow -> {
             if (lazyContent != null) {
@@ -205,7 +206,7 @@ internal fun DesignFrame(
                 val rowModifier =
                     if (hugContents)
                         Modifier.onSizeChanged {
-                            LayoutManager.setNodeSize(layoutId, it.width, it.height)
+                            LayoutManager.setNodeSize(layoutId, rootLayoutId, it.width, it.height)
                         }
                     else Modifier.layoutSizeToModifier(layout)
                 Row(
@@ -263,7 +264,7 @@ internal fun DesignFrame(
                 val columnModifier =
                     if (hugContents)
                         Modifier.onSizeChanged {
-                            LayoutManager.setNodeSize(layoutId, it.width, it.height)
+                            LayoutManager.setNodeSize(layoutId, rootLayoutId, it.width, it.height)
                         }
                     else Modifier.layoutSizeToModifier(layout)
                 Column(

--- a/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
@@ -154,14 +154,21 @@ internal fun DesignFrame(
         )
         onDispose {}
     }
+
+    var rootLayoutId = parentLayout?.rootLayoutId ?: -1
+    if (rootLayoutId == -1) rootLayoutId = layoutId
     DisposableEffect(Unit) {
         onDispose {
             // Unsubscribe to layout changes when the view is removed
             Log.d(
                 TAG,
-                "Unsubscribe ${view.name} layoutId $layoutId isWidgetChild ${parentLayout?.isWidgetChild}"
+                "Unsubscribe ${view.name} layoutId $layoutId rootLayoutId $rootLayoutId isWidgetAncestor ${parentLayout?.isWidgetAncestor}"
             )
-            LayoutManager.unsubscribe(layoutId)
+            LayoutManager.unsubscribe(
+                layoutId,
+                rootLayoutId,
+                parentLayout?.isWidgetAncestor == true
+            )
         }
     }
 
@@ -172,8 +179,6 @@ internal fun DesignFrame(
             // there are no other parent frames performing layout, layout computation can be
             // performed.
             DisposableEffect(view) {
-                var rootLayoutId = parentLayout?.rootLayoutId ?: -1
-                if (rootLayoutId == -1) rootLayoutId = layoutId
                 LayoutManager.finishLayout(layoutId, rootLayoutId)
                 onDispose {}
             }
@@ -190,7 +195,6 @@ internal fun DesignFrame(
     // row or column (with or without wrapping/flow), or absolute positioning (similar to the CSS2
     // model).
     val layout = LayoutManager.getLayout(layoutId)
-    val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
     when (layoutInfo) {
         is LayoutInfoRow -> {
             if (lazyContent != null) {

--- a/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
@@ -141,7 +141,7 @@ internal fun DesignFrame(
         val childIndex = parentLayout?.childIndex ?: -1
         Log.d(
             TAG,
-            "Subscribe Frame ${view.name} layoutId $layoutId parent $parentLayoutId index $childIndex"
+            "Subscribe Frame ${view.name} layoutId $layoutId parent $parentLayoutId index $childIndex isWidgetChild ${parentLayout?.isWidgetChild}"
         )
         // Subscribe to layout changes when the view changes or is added
         LayoutManager.subscribeFrame(
@@ -157,7 +157,10 @@ internal fun DesignFrame(
     DisposableEffect(Unit) {
         onDispose {
             // Unsubscribe to layout changes when the view is removed
-            Log.d(TAG, "Unsubscribe ${view.name} layoutId $layoutId")
+            Log.d(
+                TAG,
+                "Unsubscribe ${view.name} layoutId $layoutId isWidgetChild ${parentLayout?.isWidgetChild}"
+            )
             LayoutManager.unsubscribe(layoutId)
         }
     }
@@ -375,8 +378,7 @@ internal fun DesignFrame(
 
             // Content for the lazy content parameter. This uses the grid layout but also supports
             // limiting the number of children to style.max_children, and using an overflow node if
-            // one
-            // is specified.
+            // one is specified.
             val lazyItemContent: LazyGridScope.() -> Unit = {
                 val lContent = lazyContent { nodeData ->
                     getSpan(layoutInfo.gridSpanContent, nodeData)
@@ -453,8 +455,7 @@ internal fun DesignFrame(
             }
 
             // Given the frame size, number of columns/rows, and spacing between them, return a list
-            // of
-            // column/row widths/heights
+            // of column/row widths/heights
             fun calculateCellsCrossAxisSizeImpl(
                 gridSize: Int,
                 slotCount: Int,

--- a/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignFrame.kt
@@ -87,7 +87,6 @@ internal fun DesignFrame(
     // (row/column/etc) to the replacement component at some point.
     val replacementComponent = customizations.getComponent(name)
     if (replacementComponent != null) {
-        val myParentLayout = parentLayout?.withBaseView(view)
         replacementComponent(
             object : ComponentReplacementContext {
                 override val layoutModifier = layoutInfo.selfModifier
@@ -99,7 +98,7 @@ internal fun DesignFrame(
                 }
 
                 override val textStyle: TextStyle? = null
-                override val parentLayout = myParentLayout
+                override val parentLayout = parentLayout
             }
         )
         return true
@@ -150,8 +149,8 @@ internal fun DesignFrame(
             setLayoutState,
             parentLayoutId,
             childIndex,
-            view,
-            parentLayout?.baseView
+            style,
+            view.name
         )
         onDispose {}
     }
@@ -170,7 +169,9 @@ internal fun DesignFrame(
             // there are no other parent frames performing layout, layout computation can be
             // performed.
             DisposableEffect(view) {
-                LayoutManager.finishLayout(layoutId, parentLayout?.rootLayoutId ?: layoutId)
+                var rootLayoutId = parentLayout?.rootLayoutId ?: -1
+                if (rootLayoutId == -1) rootLayoutId = layoutId
+                LayoutManager.finishLayout(layoutId, rootLayoutId)
                 onDispose {}
             }
         }

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -253,11 +253,19 @@ internal fun DesignText(
                 parentLayoutId,
                 parentLayout?.rootLayoutId ?: layoutId,
                 childIndex,
-                view,
+                style,
+                view.name,
                 textMeasureData
             )
         } else
-            LayoutManager.subscribeText(layoutId, setLayoutState, parentLayoutId, childIndex, view)
+            LayoutManager.subscribeText(
+                layoutId,
+                setLayoutState,
+                parentLayoutId,
+                childIndex,
+                style,
+                view.name
+            )
         onDispose {}
     }
     // Unsubscribe to layout changes when the composable is no longer in view.

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -246,16 +246,18 @@ internal fun DesignText(
             TAG,
             "Subscribe TEXT $nodeName  layoutId $layoutId parent $parentLayoutId index $childIndex"
         )
-        if (useMeasure)
+        if (useMeasure) {
             LayoutManager.subscribeWithMeasure(
                 layoutId,
                 setLayoutState,
                 parentLayoutId,
+                parentLayout?.rootLayoutId ?: layoutId,
                 childIndex,
                 view,
                 textMeasureData
             )
-        else LayoutManager.subscribeText(layoutId, setLayoutState, parentLayoutId, childIndex, view)
+        } else
+            LayoutManager.subscribeText(layoutId, setLayoutState, parentLayoutId, childIndex, view)
         onDispose {}
     }
     // Unsubscribe to layout changes when the composable is no longer in view.
@@ -277,8 +279,8 @@ internal fun DesignText(
     val (renderHeight, setRenderHeight) = remember { mutableStateOf<Int?>(null) }
     val (renderTop, setRenderTop) = remember { mutableStateOf<Int?>(null) }
     LaunchedEffect(style, textLayoutData, density, layout) {
-        // Only set the size if autoWidthHeight is false, because otherwise the measureFunc is used
-        if (!isAutoHeightFillWidth(style)) {
+        // Only set the size if useMeasure is false, because otherwise the measureFunc is used
+        if (!useMeasure) {
             val textBounds = measureTextBounds(style, textLayoutData, density)
             Log.d(
                 TAG,
@@ -289,6 +291,7 @@ internal fun DesignText(
 
             LayoutManager.setNodeSize(
                 layoutId,
+                parentLayout?.rootLayoutId ?: layoutId,
                 textBounds.width,
                 textBounds.layoutHeight,
             )

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -243,10 +243,10 @@ internal fun DesignText(
     // slightly different than Figma text.
     val (renderHeight, setRenderHeight) = remember { mutableStateOf<Int?>(null) }
     val (renderTop, setRenderTop) = remember { mutableStateOf<Int?>(null) }
+    val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
     // Measure the text and subscribe for layout changes whenever the text data changes.
     DisposableEffect(textMeasureData, style) {
         val parentLayoutId = parentLayout?.parentLayoutId ?: -1
-        val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
         val childIndex = parentLayout?.childIndex ?: -1
         Log.d(
             TAG,
@@ -298,7 +298,11 @@ internal fun DesignText(
     DisposableEffect(Unit) {
         onDispose {
             Log.d(TAG, "Unsubscribe TEXT $nodeName layoutId $layoutId")
-            LayoutManager.unsubscribe(layoutId)
+            LayoutManager.unsubscribe(
+                layoutId,
+                rootLayoutId,
+                parentLayout?.isWidgetAncestor == true
+            )
         }
     }
     LaunchedEffect(layoutState) {

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -232,40 +232,66 @@ internal fun DesignText(
             maxLines,
             style.min_width.pointsAsDp(density.density).value
         )
-    val useMeasure = isAutoHeightFillWidth(style)
 
     // Get the layout for this view that describes its size and position.
     val (layout, setLayout) = remember { mutableStateOf<Layout?>(null) }
     // Keep track of the layout state, which changes whenever this view's layout changes
     val (layoutState, setLayoutState) = remember { mutableStateOf(0) }
-    // Subscribe for layout changes whenever the text data changes.
+    // The height and top offset of the text might be slightly different than the height and top
+    // that is used in layout. This is because we want to honor the position from Figma used for
+    // layout, but when rendering we sometimes need to adjust the position because Compose text is
+    // slightly different than Figma text.
+    val (renderHeight, setRenderHeight) = remember { mutableStateOf<Int?>(null) }
+    val (renderTop, setRenderTop) = remember { mutableStateOf<Int?>(null) }
+    // Measure the text and subscribe for layout changes whenever the text data changes.
     DisposableEffect(textMeasureData, style) {
         val parentLayoutId = parentLayout?.parentLayoutId ?: -1
+        val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
         val childIndex = parentLayout?.childIndex ?: -1
         Log.d(
             TAG,
             "Subscribe TEXT $nodeName  layoutId $layoutId parent $parentLayoutId index $childIndex"
         )
-        if (useMeasure) {
+
+        // Only measure the text and subscribe with the resulting size if isAutoHeightFillWidth() is
+        // false, because otherwise the measureFunc is used
+        if (!isAutoHeightFillWidth(style)) {
+            val textBounds = measureTextBounds(style, textLayoutData, density)
+            Log.d(
+                TAG,
+                "Text measure $nodeName: textBounds ${textBounds.width} ${textBounds.layoutHeight} vertOffset ${textBounds.verticalOffset} renderHeight ${textBounds.renderHeight}"
+            )
+            setRenderHeight(textBounds.renderHeight)
+            setRenderTop(textBounds.verticalOffset)
+
+            LayoutManager.subscribeText(
+                layoutId,
+                setLayoutState,
+                parentLayoutId,
+                rootLayoutId,
+                childIndex,
+                style,
+                view.name,
+                textBounds.width,
+                textBounds.layoutHeight
+            )
+        } else {
+            // Use default layout for render height and 0 for top
+            setRenderHeight(null)
+            setRenderTop(0)
+
             LayoutManager.subscribeWithMeasure(
                 layoutId,
                 setLayoutState,
                 parentLayoutId,
-                parentLayout?.rootLayoutId ?: layoutId,
+                rootLayoutId,
                 childIndex,
                 style,
                 view.name,
                 textMeasureData
             )
-        } else
-            LayoutManager.subscribeText(
-                layoutId,
-                setLayoutState,
-                parentLayoutId,
-                childIndex,
-                style,
-                view.name
-            )
+        }
+
         onDispose {}
     }
     // Unsubscribe to layout changes when the composable is no longer in view.
@@ -278,36 +304,6 @@ internal fun DesignText(
     LaunchedEffect(layoutState) {
         val newLayout = LayoutManager.getLayout(layoutId)
         setLayout(newLayout)
-    }
-
-    // The height and top offset of the text might be slightly different than the height and top
-    // that is used in layout. This is because we want to honor the position from Figma used for
-    // layout, but when rendering we sometimes need to adjust the position because Compose text is
-    // slightly different than Figma text.
-    val (renderHeight, setRenderHeight) = remember { mutableStateOf<Int?>(null) }
-    val (renderTop, setRenderTop) = remember { mutableStateOf<Int?>(null) }
-    LaunchedEffect(style, textLayoutData, density, layout) {
-        // Only set the size if useMeasure is false, because otherwise the measureFunc is used
-        if (!useMeasure) {
-            val textBounds = measureTextBounds(style, textLayoutData, density)
-            Log.d(
-                TAG,
-                "Text measure $nodeName: textBounds ${textBounds.width} ${textBounds.layoutHeight} vertOffset ${textBounds.verticalOffset} renderHeight ${textBounds.renderHeight}"
-            )
-            setRenderHeight(textBounds.renderHeight)
-            setRenderTop(textBounds.verticalOffset)
-
-            LayoutManager.setNodeSize(
-                layoutId,
-                parentLayout?.rootLayoutId ?: layoutId,
-                textBounds.width,
-                textBounds.layoutHeight,
-            )
-        } else {
-            // Use default layout for render height and 0 for top
-            setRenderHeight(null)
-            setRenderTop(0)
-        }
     }
 
     val content =

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -698,10 +698,6 @@ internal fun DesignView(
                 parentSize = remember { mutableStateOf(Size(0F, 0F)) }
             }
 
-            // Set the base view in parentLayout if there is a variant replacement
-            val myParentLayout =
-                if (hasVariantReplacement) parentLayout?.withBaseView(v) else parentLayout
-
             return DesignFrame(
                 m,
                 view,
@@ -709,15 +705,17 @@ internal fun DesignView(
                 viewLayoutInfo,
                 document,
                 customizations,
-                myParentLayout,
+                parentLayout,
                 layoutId,
                 parentComponents,
                 MaskInfo(parentSize, maskViewType),
             ) {
                 val customContent = customizations.getContent(view.name)
                 if (customContent != null) {
+                    var rootLayoutId = parentLayout?.rootLayoutId ?: -1
+                    if (rootLayoutId == -1) rootLayoutId = layoutId
                     for (i in 0 until customContent.count) {
-                        customContent.content(i)(ContentReplacementContext(layoutId))
+                        customContent.content(i)(ContentReplacementContext(layoutId, rootLayoutId))
                     }
                 } else {
                     if ((view.data as ViewData.Container).children.isNotEmpty()) {

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -749,6 +749,9 @@ internal fun DesignView(
                             }
                         }
                         val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
+                        val isWidgetAncestor =
+                            parentLayout?.isWidgetChild == true ||
+                                parentLayout?.isWidgetAncestor == true
                         var childIndex = 0
                         viewList.forEach {
                             val childView = it.first
@@ -756,6 +759,13 @@ internal fun DesignView(
                             var maskViewType = MaskViewType.None
                             if (maskedChildren.isNotEmpty()) {
                                 maskedChildren.forEach { maskedChild ->
+                                    val parentLayoutInfo =
+                                        ParentLayoutInfo(
+                                            layoutId,
+                                            childIndex,
+                                            rootLayoutId,
+                                            isWidgetAncestor = isWidgetAncestor
+                                        )
                                     val show =
                                         DesignView(
                                             Modifier,
@@ -767,13 +777,20 @@ internal fun DesignView(
                                             interactionState,
                                             interactionScope,
                                             parentComps,
-                                            ParentLayoutInfo(layoutId, childIndex, rootLayoutId),
+                                            parentLayoutInfo,
                                             MaskInfo(parentSize, maskViewType),
                                         )
                                     if (show) ++childIndex
                                 }
                                 maskViewType = MaskViewType.MaskNode
                             }
+                            val parentLayoutInfo =
+                                ParentLayoutInfo(
+                                    layoutId,
+                                    childIndex,
+                                    rootLayoutId,
+                                    isWidgetAncestor = isWidgetAncestor
+                                )
                             val show =
                                 DesignView(
                                     Modifier,
@@ -785,7 +802,7 @@ internal fun DesignView(
                                     interactionState,
                                     interactionScope,
                                     parentComps,
-                                    ParentLayoutInfo(layoutId, childIndex, rootLayoutId),
+                                    parentLayoutInfo,
                                     MaskInfo(parentSize, maskViewType),
                                 )
                             if (show) ++childIndex

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -661,6 +661,7 @@ internal fun DesignView(
     // Use blue for DesignFrame nodes and green for DesignText nodes
     m = positionModifierFunc(Color(0f, 0f, 0.8f, 0.7f)).then(m)
 
+    val parentLayout = parentLayout?.withRootIdIfNone(layoutId)
     when (view.data) {
         is ViewData.Text ->
             return DesignText(
@@ -749,6 +750,7 @@ internal fun DesignView(
                                 }
                             }
                         }
+                        val rootLayoutId = parentLayout?.rootLayoutId ?: layoutId
                         var childIndex = 0
                         viewList.forEach {
                             val childView = it.first
@@ -767,7 +769,7 @@ internal fun DesignView(
                                             interactionState,
                                             interactionScope,
                                             parentComps,
-                                            ParentLayoutInfo(layoutId, childIndex),
+                                            ParentLayoutInfo(layoutId, childIndex, rootLayoutId),
                                             MaskInfo(parentSize, maskViewType),
                                         )
                                     if (show) ++childIndex
@@ -785,7 +787,7 @@ internal fun DesignView(
                                     interactionState,
                                     interactionScope,
                                     parentComps,
-                                    ParentLayoutInfo(layoutId, childIndex),
+                                    ParentLayoutInfo(layoutId, childIndex, rootLayoutId),
                                     MaskInfo(parentSize, maskViewType),
                                 )
                             if (show) ++childIndex

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -45,9 +45,6 @@ internal object Jni {
     ): ByteArray
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniGetLayout(layoutId: Int): ByteArray?
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     external fun jniSetNodeSize(
         layoutId: Int,
         rootLayoutId: Int,
@@ -63,9 +60,6 @@ internal object Jni {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     external fun jniRemoveNode(layoutId: Int, computeLayout: Boolean): ByteArray?
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniComputeLayout(layoutId: Int): ByteArray?
 
     init {
         System.loadLibrary("jni")

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -48,32 +48,24 @@ internal object Jni {
     external fun jniGetLayout(layoutId: Int): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniSetNodeSize(layoutId: Int, width: Int, height: Int): ByteArray?
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniAddNode(
+    external fun jniSetNodeSize(
         layoutId: Int,
-        parentLayoutId: Int,
-        childIndex: Int,
-        serializedView: ByteArray,
-        serializedBaseView: ByteArray,
-        computeLayout: Boolean
+        rootLayoutId: Int,
+        width: Int,
+        height: Int
     ): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniAddTextNode(
-        layoutId: Int,
-        parentLayoutId: Int,
-        childIndex: Int,
-        serializedView: ByteArray,
-        computeLayout: Boolean
+    external fun jniAddNodes(
+        rootLayoutId: Int,
+        serializedNodes: ByteArray,
     ): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     external fun jniRemoveNode(layoutId: Int, computeLayout: Boolean): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniComputeLayout(): ByteArray?
+    external fun jniComputeLayout(layoutId: Int): ByteArray?
 
     init {
         System.loadLibrary("jni")

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -59,7 +59,7 @@ internal object Jni {
     ): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    external fun jniRemoveNode(layoutId: Int, computeLayout: Boolean): ByteArray?
+    external fun jniRemoveNode(layoutId: Int, rootLayoutId: Int, computeLayout: Boolean): ByteArray?
 
     init {
         System.loadLibrary("jni")

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/LayoutTest.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/LayoutTest.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.unit.Density
@@ -228,10 +229,32 @@ fun MyFrame(
     val renderModifier = Modifier.myRender(name, color)
     val layoutModifier = Modifier.layoutStyle(name, layoutId)
 
-    Layout(modifier = modifier.then(renderModifier).then(layoutModifier), content = myContent) {
-        measurables,
-        constraints ->
-        println("$space Layout $name")
+    DesignFrameLayout(
+        modifier.then(renderModifier).then(layoutModifier),
+        name,
+        layoutId,
+        layoutState,
+        space,
+        myContent
+    )
+}
+
+@Composable
+internal inline fun DesignFrameLayout(
+    modifier: Modifier,
+    name: String,
+    layoutId: Int,
+    layoutState: Int,
+    space: String,
+    content: @Composable () -> Unit
+) {
+    val measurePolicy = remember(layoutState) { designMeasurePolicy(name, layoutId, space) }
+    Layout(content = content, measurePolicy = measurePolicy, modifier = modifier)
+}
+
+internal fun designMeasurePolicy(name: String, layoutId: Int, space: String) =
+    MeasurePolicy { measurables, constraints ->
+        println("$space START Layout $name")
 
         val placeables =
             measurables.mapIndexed { index, measurable ->
@@ -266,9 +289,9 @@ fun MyFrame(
                     }
                 }
             }
+        println("$space END Layout $name")
         result
     }
-}
 
 @Composable
 private fun Button(name: String, selected: Boolean, select: () -> Unit) {

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -1470,8 +1469,17 @@ fun ListWidgetTest() {
     fun itemComposable(items: ArrayList<Pair<GridItemType, String>>, index: Int) {
         when (items[index].first) {
             GridItemType.RowGrid ->
-                ListWidgetTestDoc.Item(type = ItemType.Grid, title = items[index].second)
-            else -> ListWidgetTestDoc.VItem(type = ItemType.Grid, title = items[index].second)
+                ListWidgetTestDoc.Item(
+                    type = ItemType.Grid,
+                    title = items[index].second,
+                    parentLayout = widgetParent
+                )
+            else ->
+                ListWidgetTestDoc.VItem(
+                    type = ItemType.Grid,
+                    title = items[index].second,
+                    parentLayout = widgetParent
+                )
         }
     }
 

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -308,15 +309,18 @@ fun OpenLinkTest() {
                         when (index) {
                             0 ->
                                 OpenLinkTestDoc.Red(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                                 )
                             1 ->
                                 OpenLinkTestDoc.Green(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                                 )
                             2 ->
                                 OpenLinkTestDoc.Blue(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                                 )
                             3 ->
                                 OpenLinkTestDoc.Square(
@@ -329,12 +333,17 @@ fun OpenLinkTest() {
                                                 { irc ->
                                                     OpenLinkTestDoc.PurpleCircle(
                                                         parentLayout =
-                                                            ParentLayoutInfo(irc.parentLayoutId, i)
+                                                            ParentLayoutInfo(
+                                                                irc.parentLayoutId,
+                                                                i,
+                                                                rc.rootLayoutId
+                                                            )
                                                     )
                                                 }
                                             }
                                         ),
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                                 )
                             else ->
                                 OpenLinkTestDoc.Square(
@@ -347,12 +356,17 @@ fun OpenLinkTest() {
                                                 { irc ->
                                                     OpenLinkTestDoc.PurpleCircle(
                                                         parentLayout =
-                                                            ParentLayoutInfo(irc.parentLayoutId, i)
+                                                            ParentLayoutInfo(
+                                                                irc.parentLayoutId,
+                                                                i,
+                                                                rc.rootLayoutId
+                                                            )
                                                     )
                                                 }
                                             }
                                         ),
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                                 )
                         }
                     }
@@ -604,7 +618,8 @@ fun ItemSpacingTest() {
                 content = { index ->
                     { rc ->
                         ItemSpacingTestDoc.Square(
-                            parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                            parentLayout =
+                                ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                         )
                     }
                 }
@@ -615,7 +630,8 @@ fun ItemSpacingTest() {
                 content = { index ->
                     { rc ->
                         ItemSpacingTestDoc.Square(
-                            parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                            parentLayout =
+                                ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                         )
                     }
                 }
@@ -649,9 +665,9 @@ fun RecursiveCustomizations() {
             ReplacementContent(
                 count = 1,
                 content = {
-                    { replacementContext ->
+                    { rc ->
                         RecursiveCustomizationsDoc.NameFrame(
-                            parentLayout = ParentLayoutInfo(replacementContext.parentLayoutId, 0)
+                            parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId)
                         )
                     }
                 }
@@ -660,24 +676,24 @@ fun RecursiveCustomizations() {
             ReplacementContent(
                 count = 3,
                 content = { index ->
-                    { replacementContext ->
+                    { rc ->
                         when (index) {
                             0 ->
                                 RecursiveCustomizationsDoc.TitleFrame(
                                     parentLayout =
-                                        ParentLayoutInfo(replacementContext.parentLayoutId, 0),
+                                        ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId),
                                     title = "First"
                                 )
                             1 ->
                                 RecursiveCustomizationsDoc.TitleFrame(
                                     parentLayout =
-                                        ParentLayoutInfo(replacementContext.parentLayoutId, 1),
+                                        ParentLayoutInfo(rc.parentLayoutId, 1, rc.rootLayoutId),
                                     title = "Second"
                                 )
                             else ->
                                 RecursiveCustomizationsDoc.TitleFrame(
                                     parentLayout =
-                                        ParentLayoutInfo(replacementContext.parentLayoutId, 2),
+                                        ParentLayoutInfo(rc.parentLayoutId, 2, rc.rootLayoutId),
                                     title = "Third"
                                 )
                         }
@@ -1576,7 +1592,8 @@ fun VariantInteractionsTest() {
                         when (index) {
                             0 ->
                                 VariantInteractionsTestDoc.ButtonVariant1(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.List,
                                     title = "One",
                                     onTap = { println("Tap One") },
@@ -1584,7 +1601,8 @@ fun VariantInteractionsTest() {
                                 )
                             1 ->
                                 VariantInteractionsTestDoc.ButtonVariant1(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.List,
                                     title = "Two",
                                     onTap = { println("Tap Two") },
@@ -1592,7 +1610,8 @@ fun VariantInteractionsTest() {
                                 )
                             2 ->
                                 VariantInteractionsTestDoc.ButtonVariant1(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.List,
                                     title = "Three",
                                     onTap = { println("Tap Three") },
@@ -1600,7 +1619,8 @@ fun VariantInteractionsTest() {
                                 )
                             3 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.Grid,
                                     playState = PlayState.Play,
                                     title = "Four",
@@ -1609,7 +1629,8 @@ fun VariantInteractionsTest() {
                                 )
                             4 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.Grid,
                                     playState = PlayState.Play,
                                     title = "Five",
@@ -1618,7 +1639,8 @@ fun VariantInteractionsTest() {
                                 )
                             5 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.Grid,
                                     playState = PlayState.Pause,
                                     title = "Six",
@@ -1627,7 +1649,8 @@ fun VariantInteractionsTest() {
                                 )
                             6 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.Grid,
                                     playState = PlayState.Pause,
                                     title = "Seven",
@@ -1636,7 +1659,8 @@ fun VariantInteractionsTest() {
                                 )
                             7 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.List,
                                     playState = PlayState.Pause,
                                     title = "Eight",
@@ -1645,7 +1669,8 @@ fun VariantInteractionsTest() {
                                 )
                             8 ->
                                 VariantInteractionsTestDoc.ButtonVariant2(
-                                    parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                    parentLayout =
+                                        ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                     type = ItemType.List,
                                     playState = PlayState.Pause,
                                     title = "Nine",
@@ -1688,13 +1713,21 @@ interface LayoutReplacementTest {
 @Composable
 fun LayoutReplacementTestCase(idx: Int, rc: ContentReplacementContext) {
     if (idx == 0) {
-        LayoutReplacementTestDoc.Fill(parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0))
+        LayoutReplacementTestDoc.Fill(
+            parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId)
+        )
     } else if (idx == 1) {
-        LayoutReplacementTestDoc.TopLeft(parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0))
+        LayoutReplacementTestDoc.TopLeft(
+            parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId)
+        )
     } else if (idx == 2) {
-        LayoutReplacementTestDoc.BottomRight(parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0))
+        LayoutReplacementTestDoc.BottomRight(
+            parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId)
+        )
     } else if (idx == 3) {
-        LayoutReplacementTestDoc.Center(parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0))
+        LayoutReplacementTestDoc.Center(
+            parentLayout = ParentLayoutInfo(rc.parentLayoutId, 0, rc.rootLayoutId)
+        )
     }
 }
 
@@ -1784,12 +1817,14 @@ fun CrossAxisFillTest() {
                     { rc ->
                         if (index == 0)
                             CrossAxisFillTestDoc.LargeFixedWidth(
-                                parentLayout = ParentLayoutInfo(rc.parentLayoutId, index),
+                                parentLayout =
+                                    ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId),
                                 modifier = Modifier.width(200.dp)
                             )
                         else
                             CrossAxisFillTestDoc.FillParentWidth(
-                                parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                                parentLayout =
+                                    ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                             )
                     }
                 }
@@ -2034,27 +2069,28 @@ fun LayoutTests() {
             ReplacementContent(
                 count = numChildren,
                 content = { index ->
-                    { replacementContext ->
+                    { rc ->
                         if (index % 2 == 0)
                             LayoutTestsDoc.BlueSquare(
                                 parentLayout =
-                                    ParentLayoutInfo(replacementContext.parentLayoutId, index)
+                                    ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                             )
                         else
                             LayoutTestsDoc.RedSquare(
                                 parentLayout =
-                                    ParentLayoutInfo(replacementContext.parentLayoutId, index)
+                                    ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                             )
                     }
                 }
             ),
         parent =
             ReplacementContent(
-                count = 1,
+                count = 3,
                 content = { index ->
                     { rc ->
-                        LayoutTestsDoc.Fill(
-                            parentLayout = ParentLayoutInfo(rc.parentLayoutId, index)
+                        LayoutTestsDoc.BlueSquare(
+                            parentLayout =
+                                ParentLayoutInfo(rc.parentLayoutId, index, rc.rootLayoutId)
                         )
                     }
                 }


### PR DESCRIPTION
When subscribing to layout, add the node to a list of layout nodes instead of adding them directly via a JNI call. When we detect we are done with layout and need to compute it, make one JNI call to add all the views and compute layout on the root node.

The function to compute layout now needs the layout id of the node to compute, instead of computing layout on all root level nodes. This helps performance by not computing layout on nodes that we know have not changed.

When computing layout in Rust, send back not only the layout IDs that changed, but all the layouts as well. The layout manager in Android now caches these layouts, so retrieving them no longer requires a JNI call.

Change layout subscriptions to add ViewStyle instead of View
Subscribing to layout with a View caused unnecessary serialization of data. In particular, serializing a View also serialized all of a View's children, meaning we were serializing O(n^2) data that wasn't even used. Since the Rust layout only uses the style within View, and the name for debugging purposes, it now takes those as parameters.

When subscribing to layout, use the ViewStyle created from merging with overrideStyle instead of the style that came with the View originally. This fixes the style used for variants and replacement nodes and means we no longer need the "baseView" mechanism of overriding styles.

Add another "rootLayoutId" parameter to ReplacementContext for ContentReplacement customizations. Replacement customizations should use this in the "parentLayout" parameter for the replacement content.

After computing layout for a specific layout_id, calculate layouts that changed for only the specified layout_id and its children instead of all root nodes.

Reduce layout computation when text nodes are measured. Simplify and improve text measurement and layout by measuring text before subscribing to layout, and then sending the text size when subscribing. This is an improvement in a few ways:
- Every text node visible no longer triggers a layout recomputation since they now subscribe in the same manner as frames where layout computation is done after all nodes have subscribed
- Text is laid out at the same time as frames, avoiding the problem of text flickering

Don't recompute layout when removing nodes that are ancestors of a list widget. Nodes are frequently removed from lazy grid views as they scroll and no layout needs to be recomputed since the lazy grid view handles layout itself.

Add another optimization when removing nodes by only computing layout for the root node of the node removed.