### PR TITLE
WIP: squoosh down DesignCompose kotlin renderer a bit.

### DIFF
--- a/crates/figma_import/src/toolkit_schema.rs
+++ b/crates/figma_import/src/toolkit_schema.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU16;
+
 // We use serde to serialize and deserialize our "toolkit style" views. Because we need
 // serialization, we use our own replacement for ViewStyle which can be serialized and
 // retain image references.
@@ -124,6 +126,9 @@ pub enum RenderMethod {
 /// Represents a toolkit View (like a Composable).
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct View {
+    // unique numeric id (not replicated within one DesignCompose file), which is used by the
+    // renderer when building a layout tree, or when mapping from an integer to a View.
+    pub unique_id: u16,
     // id doesn't exist in vsw toolkit, but is useful for tracing from Figma node to output
     pub id: String,
     // name doesn't exist in vsw toolkit, but is also useful for tracing.
@@ -143,6 +148,10 @@ pub struct View {
     pub render_method: RenderMethod,
 }
 impl View {
+    fn next_unique_id() -> u16 {
+        static COUNTER: AtomicU16 = AtomicU16::new(0);
+        COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
     pub(crate) fn new_rect(
         id: &String,
         name: &String,
@@ -156,6 +165,7 @@ impl View {
         render_method: RenderMethod,
     ) -> View {
         View {
+            unique_id: View::next_unique_id(),
             id: id.clone(),
             name: name.clone(),
             component_info,
@@ -179,6 +189,7 @@ impl View {
         render_method: RenderMethod,
     ) -> View {
         View {
+            unique_id: View::next_unique_id(),
             id: id.clone(),
             name: name.clone(),
             component_info,
@@ -202,6 +213,7 @@ impl View {
         render_method: RenderMethod,
     ) -> View {
         View {
+            unique_id: View::next_unique_id(),
             id: id.clone(),
             name: name.clone(),
             style,

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -18,5 +18,5 @@ mod layout;
 
 pub use layout::{
     add_view, add_view_measure, clear_views, compute_layout, get_node_layout, print_layout,
-    remove_view, set_node_size, unchanged_response,
+    remove_view, set_node_size, unchanged_response, add_style
 };

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -275,6 +275,7 @@ internal fun DesignText(
     // slightly different than Figma text.
     val (renderHeight, setRenderHeight) = remember { mutableStateOf<Int?>(null) }
     val (renderTop, setRenderTop) = remember { mutableStateOf<Int?>(null) }
+    Log.d(TAG, "Pre-launched effect $nodeName")
     LaunchedEffect(style, textLayoutData, density, layout) {
         // Only set the size if autoWidthHeight is false, because otherwise the measureFunc is used
         if (!isAutoHeightFillWidth(style)) {
@@ -297,6 +298,7 @@ internal fun DesignText(
             setRenderTop(0)
         }
     }
+    Log.d(TAG, "Post-launched effect $nodeName render height $renderHeight renderTop $renderTop")
 
     val content =
         @Composable {

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -82,6 +83,7 @@ import com.android.designcompose.serdegen.Trigger
 import com.android.designcompose.serdegen.View
 import com.android.designcompose.serdegen.ViewData
 import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.squoosh.SquooshRoot
 import kotlin.math.min
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -227,8 +229,9 @@ internal object DebugNodeManager {
         nodes.values.forEach {
             Box(
                 modifier =
-                    Modifier.absoluteOffset(it.position.x.dp, it.position.y.dp)
-                        .size(it.size.width.dp, it.size.height.dp)
+                Modifier
+                    .absoluteOffset(it.position.x.dp, it.position.y.dp)
+                    .size(it.size.width.dp, it.size.height.dp)
             ) {
                 BasicText(
                     it.nodeName,
@@ -604,14 +607,19 @@ internal fun DesignView(
     if (viewLayoutInfo !is LayoutInfoGrid) {
         when (view.scroll_info.overflow) {
             is OverflowDirection.VERTICAL_SCROLLING -> {
-                m = Modifier.verticalScroll(rememberScrollState()).then(m)
+                m = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .then(m)
             }
             is OverflowDirection.HORIZONTAL_SCROLLING -> {
-                m = Modifier.horizontalScroll(rememberScrollState()).then(m)
+                m = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .then(m)
             }
             is OverflowDirection.HORIZONTAL_AND_VERTICAL_SCROLLING -> {
                 m =
-                    Modifier.horizontalScroll(rememberScrollState())
+                    Modifier
+                        .horizontalScroll(rememberScrollState())
                         .verticalScroll(rememberScrollState())
                         .then(m)
             }
@@ -971,6 +979,13 @@ internal fun DesignDocInternal(
     var noFrameErrorMessage = ""
     var noFrameBgColor = Color(0x00000000)
 
+    // TESTING
+    SquooshRoot(docName = docName, incomingDocId = incomingDocId, rootNodeQuery = rootNodeQuery, customizationContext = customizations)
+
+    return
+    val (renderCount, setRenderCount) = remember { mutableStateOf(0) }
+    if (renderCount > 0) return
+    setRenderCount(1)
     // Reset the isRendered flag, only set it back to true if the DesignView properly displays
     if (doc != null) {
         val startFrame = interactionState.rootNode(rootNodeQuery, doc, isRoot)
@@ -1057,7 +1072,11 @@ internal fun DesignDocInternal(
         designSwitcher()
     } else {
         CompositionLocalProvider(LocalDesignIsRootContext provides DesignIsRoot(false)) {
-            Box(Modifier.fillMaxSize().background(noFrameBgColor).padding(20.dp)) {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(noFrameBgColor)
+                    .padding(20.dp)) {
                 BasicText(text = noFrameErrorMessage, style = TextStyle(fontSize = 24.sp))
             }
             designSwitcher()

--- a/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
+++ b/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
@@ -553,6 +553,37 @@ internal fun InteractionState.nodeVariant(
     )
 }
 
+internal fun InteractionState.squooshNodeVariant(
+    instanceId: String,
+    key: String?,
+    doc: DocContent
+): View?
+{
+    val varKey = getInstanceIdWithKey(instanceId, key)
+    val variant = variantMemory[varKey] ?: return null
+    return searchNodes(
+        NodeQuery.NodeId(variant),
+        doc.c.document.views,
+        doc.c.variantViewMap,
+        doc.c.variantPropertyMap
+    )
+}
+internal fun InteractionState.squooshRootNode(
+    initialNode: NodeQuery,
+    doc: DocContent,
+    isRoot: Boolean
+): View? {
+    val findRootNode = {
+        if (isRoot) {
+            navigationHistory.lastOrNull() ?: initialNode
+        } else {
+            initialNode
+        }
+    }
+    val query = findRootNode()
+    return searchNodes(query, doc.c.document.views, doc.c.variantViewMap, doc.c.variantPropertyMap)
+}
+
 /// InteractionState is managed in a global, per document. We don't pass it down via a
 /// LocalComposition, because we want to support usage models where there are multiple
 /// roots (e.g.: many ComposeViews are used to mix design elements in with existing

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -61,6 +61,14 @@ internal object Jni {
     ): ByteArray?
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    external fun jniAddStyle(
+        layoutId: Int,
+        parentLayoutId: Int,
+        childIndex: Int,
+        serializedStyle: ByteArray,
+    )
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     external fun jniAddTextNode(
         layoutId: Int,
         parentLayoutId: Int,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -1,0 +1,418 @@
+package com.android.designcompose.squoosh
+
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.android.designcompose.CustomizationContext
+import com.android.designcompose.DocContent
+import com.android.designcompose.DocServer
+import com.android.designcompose.DocumentSwitcher
+import com.android.designcompose.InteractionState
+import com.android.designcompose.InteractionStateManager
+import com.android.designcompose.Jni
+import com.android.designcompose.LayoutManager
+import com.android.designcompose.ParentComponentInfo
+import com.android.designcompose.common.DocumentServerParams
+import com.android.designcompose.doc
+import com.android.designcompose.getKey
+import com.android.designcompose.getMatchingVariant
+import com.android.designcompose.mergeStyles
+import com.android.designcompose.nodeVariant
+import com.android.designcompose.render
+import com.android.designcompose.rootNode
+import com.android.designcompose.serdegen.Layout
+import com.android.designcompose.serdegen.LayoutChangedResponse
+import com.android.designcompose.serdegen.NodeQuery
+import com.android.designcompose.serdegen.View
+import com.android.designcompose.serdegen.ViewData
+import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.squooshNodeVariant
+import com.android.designcompose.squooshRootNode
+import com.android.designcompose.squooshShapeRender
+import com.android.designcompose.stateForDoc
+import com.android.designcompose.width
+import com.novi.bincode.BincodeDeserializer
+import com.novi.bincode.BincodeSerializer
+import kotlin.system.measureTimeMillis
+
+const val TAG: String = "DC_SQUOOSH"
+
+// Notes on Layout impl:
+//  - add some unique id to View, to make it easier to build a layout tree. [DONE]
+//  - make a taffy instance creatable, rather than global; don't need to run layout on everything.
+//  - make taffy take the style, instead of the View (or in addition to?)
+
+internal object SquooshLayout {
+    private var nextLayoutId: Int = 0
+    var density: Float = 1f
+
+    internal fun getNextLayoutId(): Int {
+        return ++nextLayoutId
+    }
+
+    internal fun addOrUpdateNode(
+        layoutId: Int,
+        parentLayoutId: Int,
+        childIndex: Int,
+        view: View,
+        baseView: View?)
+    {
+        Jni.jniAddNode(
+            layoutId,
+            parentLayoutId,
+            childIndex,
+            serialize(view),
+            serialize(baseView),
+            false)
+    }
+
+    internal fun removeNode(layoutId: Int) {
+        Jni.jniRemoveNode(layoutId, false)
+    }
+
+    internal fun keepJniBits() {
+        Jni.jniSetNodeSize(0, 0, 0)
+        Jni.jniAddTextNode(0, 0, 0, emptyByteArray, false)
+        Jni.jniRemoveNode(0, false)
+    }
+
+    internal fun doLayout(): List<Int> {
+        val response = Jni.jniComputeLayout() ?: return emptyList()
+        val layoutChangedResponse: LayoutChangedResponse = LayoutChangedResponse.deserialize(BincodeDeserializer(response))
+        return layoutChangedResponse.changed_layout_ids
+    }
+    internal fun getComputedLayout(layoutId: Int): Layout? {
+        val layoutBytes = Jni.jniGetLayout(layoutId) ?: return null
+        val deserializer = BincodeDeserializer(layoutBytes)
+        return Layout.deserialize(deserializer)
+    }
+
+    private val emptyByteArray = ByteArray(0)
+    private fun serialize(v: View?): ByteArray {
+        if (v == null) {
+            return emptyByteArray
+        }
+        val serializer = BincodeSerializer()
+        v.serialize(serializer)
+        return serializer._bytes
+    }
+}
+
+internal class SquooshResolvedNode(
+    val view: View,
+    val style: ViewStyle,
+    var firstChild: SquooshResolvedNode? = null,
+    var nextSibling: SquooshResolvedNode? = null,
+    var computedLayout: Layout? = null
+)
+
+/// Iterate over a given view tree recursively, applying customizations that will select
+/// variants or affect layout. The output of this function is a `SquooshResolvedNode` which
+/// has links to siblings and children (but no layout value).
+///
+/// Subsequent passes of this generated tree can set up a native layout tree, and then populate
+/// the computed layout values, and finally render the view tree.
+internal fun resolveVariantsRecursively(
+    v: View,
+    document: DocContent,
+    customizations: CustomizationContext,
+    interactionState: InteractionState,
+    parentComponents: List<ParentComponentInfo>,
+    variantParentName: String = ""): SquooshResolvedNode
+{
+    // XXX: This seems to do a lot of extra allocations. We'll realloc this list all the way
+    //      down, when I think we could simply push and pop. It would be nice if there was a
+    //      way to avoid even that, since the list is a static property of the View and not
+    //      a dynamic thing at all.
+    val parentComps =
+        if (v.component_info.isPresent) {
+            val pc = parentComponents.toMutableList()
+            pc.add(ParentComponentInfo(v.id, v.component_info.get()))
+            pc
+        } else {
+            parentComponents
+        }
+
+    // Do we have an override style? This is style data which we should apply to the final style
+    // even if we're swapping out our view definition for a variant.
+    var overrideStyle: ViewStyle? = null
+    if (v.component_info.isPresent) {
+        val componentInfo = v.component_info.get()
+        if (componentInfo.overrides.isPresent) {
+            val overrides = componentInfo.overrides.get()
+            if (overrides.style.isPresent) {
+                overrideStyle = overrides.style.get()
+            }
+        }
+    }
+
+    // See if we've got a replacement node from an interaction
+    var view = interactionState.squooshNodeVariant(v.id, customizations.getKey(), document) ?: v
+    var hasVariantReplacement = view.name != v.name
+    var variantParentName = variantParentName
+    if (!hasVariantReplacement) {
+        // If an interaction has not changed the current variant, then check to see if this node
+        // is part of a component set with variants and if any @DesignVariant annotations
+        // set variant properties that match. If so, variantNodeName will be set to the
+        // name of the node with all the variants set to the @DesignVariant parameters
+        val variantNodeName = customizations.getMatchingVariant(view.component_info)
+        if (variantNodeName != null) {
+            // Find the view associated with the variant name
+            val variantNodeQuery =
+                NodeQuery.NodeVariant(variantNodeName, variantParentName.ifEmpty { view.name })
+            val isRoot = true // XXX XXX RALPH
+            val variantView = interactionState.squooshRootNode(variantNodeQuery, document, isRoot)
+            if (variantView != null) {
+                view = variantView
+                hasVariantReplacement = true
+                variantView.component_info.ifPresent { variantParentName = it.component_set_name }
+            }
+        }
+    }
+
+    // Calculate the style we're going to use. If we have an override style then we have to apply
+    // that on top of the view (or variant) style.
+    val style =
+        if (overrideStyle == null) {
+            view.style
+        } else {
+            mergeStyles(view.style, overrideStyle)
+        }
+    // XXX: Skip figuring out grid info, scrolling, interactions.
+
+    // Now we know the view we want to render, the style we want to use, etc. We can create
+    // a record of it. After this, another pass can be done to build a layout tree. Finally,
+    // layout can be performed and rendering done.
+    val resolvedView = SquooshResolvedNode(view, style)
+
+    if (view.data is ViewData.Container) {
+        val viewData = view.data as ViewData.Container
+        var previousChild: SquooshResolvedNode? = null
+        for (child in viewData.children) {
+            val childResolvedNode = resolveVariantsRecursively(child, document, customizations, interactionState, parentComps)
+            if (resolvedView.firstChild == null)
+                resolvedView.firstChild = childResolvedNode
+            if (previousChild != null)
+                previousChild.nextSibling = childResolvedNode
+            previousChild = childResolvedNode
+        }
+    }
+
+    return resolvedView
+}
+
+/// Takes a `SquooshResolvedNode` and recursively builds or updates a native layout tree via
+/// the `SquooshLayout` wrapper of `JniLayout`.
+internal fun updateLayoutTree(
+    rootLayoutId: Int,
+    resolvedNode: SquooshResolvedNode,
+    layoutCache: HashMap<Int, Int>,
+    parentLayoutId: Int = 0,
+    childIndex: Int = 0,
+) {
+    // Make a unique layout id for this node by taking the root's unique id and adding the
+    // file specific unique id (which is a u16).
+    val layoutId = rootLayoutId + resolvedNode.view.unique_id
+
+    // Compute a cache key for the layout; we use this to determine if we need to update the
+    // node with a new layout value or not.
+    val layoutCacheKey = resolvedNode.style.hashCode()
+    val needsLayoutUpdate = layoutCache[layoutId] != layoutCacheKey
+
+    if (needsLayoutUpdate) {
+        SquooshLayout.addOrUpdateNode(
+            layoutId = layoutId,
+            parentLayoutId = parentLayoutId,
+            childIndex = childIndex,
+            view = resolvedNode.view,
+            baseView = null // XXX: Really just need to pass the merged style in...
+        )
+        layoutCache[layoutId] = layoutCacheKey
+    }
+    // XXX: We might want separate (cheaper) calls to assert the tree structure.
+    // XXX XXX: This code doesn't ever update the tree structure.
+
+    var childIdx = 0
+    var child = resolvedNode.firstChild
+    while (child != null) {
+        updateLayoutTree(rootLayoutId, child, layoutCache, layoutId, childIdx)
+        childIdx++
+        child = child.nextSibling
+    }
+}
+
+/// Iterate over a `SquooshComputedNode` tree and populate the computed layout values
+/// so that the nodes can be used for presentation or interaction (hit testing).
+internal fun populateComputedLayout(
+    rootLayoutId: Int,
+    resolvedNode: SquooshResolvedNode,
+    layoutValueCache: HashMap<Int, Layout>
+)
+{
+    val layoutId = rootLayoutId + resolvedNode.view.unique_id
+    val layoutValue = layoutValueCache[layoutId]
+    if (layoutValue == null) {
+        val updatedLayoutValue = SquooshLayout.getComputedLayout(layoutId)
+        if (updatedLayoutValue == null) {
+            Log.d(TAG, "Unable to fetch computed layout for ${resolvedNode.view.name} and its children")
+            return
+        }
+        layoutValueCache[layoutId] = updatedLayoutValue
+        resolvedNode.computedLayout = updatedLayoutValue
+    } else {
+        resolvedNode.computedLayout = layoutValue
+    }
+    var child = resolvedNode.firstChild
+    while (child != null) {
+        populateComputedLayout(rootLayoutId, child, layoutValueCache)
+        child = child.nextSibling
+    }
+}
+// Experiment -- minimal DesignCompose root node; no switcher, no interactions, etc.
+@Composable
+fun SquooshRoot(
+    docName: String,
+    incomingDocId: String,
+    rootNodeQuery: NodeQuery,
+    customizationContext: CustomizationContext = CustomizationContext()
+) {
+    val docId = DocumentSwitcher.getSwitchedDocId(incomingDocId)
+    val doc = DocServer.doc(docName, docId, DocumentServerParams(), null, false)
+
+    if (doc == null) {
+        Log.d(TAG, "No doc! $docName / $incomingDocId")
+        return
+    }
+
+    val interactionState = InteractionStateManager.stateForDoc(docId)
+    val startFrame = interactionState.rootNode(initialNode = rootNodeQuery, doc = doc, isRoot = true)
+
+    if (startFrame == null) {
+        Log.d(TAG, "No start frame $docName / $incomingDocId")
+        SquooshLayout.keepJniBits() // XXX: Must call this from somewhere otherwise it gets stripped and the jni lib won't link.
+        return
+    }
+
+    val density = LocalDensity.current.density
+    LaunchedEffect(density) { LayoutManager.setDensity(density) }
+
+    val variantParentName = when (rootNodeQuery) {
+        is NodeQuery.NodeVariant -> rootNodeQuery.field1
+        else -> ""
+    }
+
+    val rootLayoutId = remember { LayoutManager.getNextLayoutId() * 1000000 }
+    val layoutCache = remember { HashMap<Int, Int>() }
+    val layoutValueCache = remember { HashMap<Int, Layout>() }
+
+    // Ok, now we have done the dull stuff, we need to build a tree applying
+    // the correct variants etc and then build/update the tree. How do we know
+    // what's different from last time? Does the Rust side track
+
+    // I want to only call the addOrUpdateNode function when the view has actually
+    // changed. That means I need to know if I'm visiting the same view as before.
+    // I can assign layout ids sequentially.
+
+    var root: SquooshResolvedNode? = null
+    val resolveVariantsTime = measureTimeMillis {
+        root = resolveVariantsRecursively(
+            startFrame,
+            doc,
+            customizationContext,
+            interactionState,
+            emptyList(),
+            variantParentName
+        )
+    }
+    val buildLayoutTreeTime = measureTimeMillis {
+        updateLayoutTree(rootLayoutId, root!!, layoutCache)
+    }
+    val performLayoutTime = measureTimeMillis {
+        val invalidatedLayoutIds = SquooshLayout.doLayout()
+        for (invalidatedLayoutId in invalidatedLayoutIds) {
+            layoutValueCache.remove(invalidatedLayoutId)
+        }
+        Log.d(TAG, "$docName layout invalidated ${invalidatedLayoutIds.size} nodes")
+    }
+    val populateLayoutTime = measureTimeMillis {
+        populateComputedLayout(rootLayoutId, root!!, layoutValueCache)
+    }
+
+    Log.d(TAG, "$docName resolveVariants: $resolveVariantsTime ms, buildLayout: $buildLayoutTreeTime ms, eval. layout $performLayoutTime ms, populate layout values: $populateLayoutTime ms")
+
+    // Now our tree of resolved nodes is ready to use!
+
+    if (root != null && root!!.computedLayout != null) {
+        Log.d(TAG, "$docName root size: ${root!!.computedLayout!!.width}x${root!!.computedLayout!!.height}")
+    }
+    // Ok, good enough, we can make a composable that will:
+    //  1. occupy the space of the root,
+    //  2. place any child composables
+    //  3. draw the content
+
+    // We will also need a sort of "draw/interact" child that accepts derivative
+    // layout
+
+    Box(
+        Modifier.size(
+            width = root!!.computedLayout!!.width.dp,
+            height = root!!.computedLayout!!.height.dp
+        ).squooshRender(root!!, doc, customizationContext)
+    )
+}
+
+internal fun Modifier.squooshRender(
+    node: SquooshResolvedNode,
+    document: DocContent,
+    customizations: CustomizationContext
+): Modifier =
+    this.then(
+        Modifier.drawWithContent {
+            // no masking yet :(
+            var frameRenderCount = 0
+            val renderTime = measureTimeMillis {
+                fun renderNode(node: SquooshResolvedNode) {
+                    val computedLayout = node.computedLayout ?: return
+                    val shape = when (node.view.data) {
+                        is ViewData.Container -> (node.view.data as ViewData.Container).shape
+                        else -> return
+                    }
+                    squooshShapeRender(
+                        drawContext,
+                        density,
+                        Size(computedLayout.width * density, computedLayout.height * density),
+                        node.style,
+                        shape,
+                        null, // customImageWithContext
+                        document,
+                        node.view.name,
+                        customizations
+                    ) {
+                        var child = node.firstChild
+                        while (child != null) {
+                            val childLayout = child.computedLayout
+                            if (childLayout != null) {
+                                translate(childLayout.left * density, childLayout.top * density) {
+                                    renderNode(child!!)
+                                }
+                            }
+                            child = child.nextSibling
+                        }
+                    }
+                    frameRenderCount++
+                }
+                renderNode(node)
+            }
+            Log.d(TAG, "render $frameRenderCount frames only recursively $renderTime ms")
+        }
+    )
+

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -63,16 +63,13 @@ internal object SquooshLayout {
         layoutId: Int,
         parentLayoutId: Int,
         childIndex: Int,
-        view: View,
-        baseView: View?)
+        style: ViewStyle)
     {
-        Jni.jniAddNode(
+        Jni.jniAddStyle(
             layoutId,
             parentLayoutId,
             childIndex,
-            serialize(view),
-            serialize(baseView),
-            false)
+            serialize(style))
     }
 
     internal fun removeNode(layoutId: Int) {
@@ -82,6 +79,13 @@ internal object SquooshLayout {
     internal fun keepJniBits() {
         Jni.jniSetNodeSize(0, 0, 0)
         Jni.jniAddTextNode(0, 0, 0, emptyByteArray, false)
+        Jni.jniAddNode(
+            0,
+            0,
+            0,
+            emptyByteArray,
+            emptyByteArray,
+            false)
         Jni.jniRemoveNode(0, false)
     }
 
@@ -97,7 +101,7 @@ internal object SquooshLayout {
     }
 
     private val emptyByteArray = ByteArray(0)
-    private fun serialize(v: View?): ByteArray {
+    private fun serialize(v: ViewStyle?): ByteArray {
         if (v == null) {
             return emptyByteArray
         }
@@ -233,8 +237,7 @@ internal fun updateLayoutTree(
             layoutId = layoutId,
             parentLayoutId = parentLayoutId,
             childIndex = childIndex,
-            view = resolvedNode.view,
-            baseView = null // XXX: Really just need to pass the merged style in...
+            style = resolvedNode.style
         )
         layoutCache[layoutId] = layoutCacheKey
     }

--- a/integration-tests/validation/build.gradle.kts
+++ b/integration-tests/validation/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation(libs.androidx.compose.material)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.material)
+    implementation("androidx.compose.runtime:runtime-tracing:1.0.0-alpha03")
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)


### PR DESCRIPTION
I made this super stripped down version of the DesignCompose renderer to make profiling easier. It doesn't support text or interactions (text will be needed for profiling soon...). I'm not sure if it makes sense as a direction to take the library in, or if it will only be useful for profiling the new layout work.