### PR TITLE
Change rendering tests to detect semantic on the root DesignDoc 

### DIFF
--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -91,7 +91,8 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         file += "import androidx.compose.runtime.Composable\n"
         file += "import androidx.compose.ui.text.TextStyle\n"
         file += "import androidx.compose.foundation.layout.Box\n"
-        file += "import androidx.compose.foundation.layout.size\n" +
+        file +=
+            "import androidx.compose.foundation.layout.size\n" +
                 "import androidx.compose.ui.unit.dp\n"
         file += "import android.graphics.Bitmap\n"
         file += "import androidx.compose.ui.Modifier\n"
@@ -824,9 +825,10 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             out.appendText("    ) {\n")
             // Embed the Doc's class to allow matching on in tests
             out.appendText("        val className = javaClass.name\n")
-//            out.appendText(
-//                "        Box(modifier = Modifier.size(0.dp).semantics { sDocClass = className})\n"
-//            )
+            //            out.appendText(
+            //                "        Box(modifier = Modifier.size(0.dp).semantics { sDocClass =
+            // className})\n"
+            //            )
             out.appendText("        val customizations = remember { CustomizationContext() }\n")
             out.appendText("        customizations.setKey(key)\n")
             out.appendText("        customizations.mergeFrom(LocalCustomizationContext.current)\n")
@@ -966,7 +968,9 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 out.appendText("                placeholder = $placeholderComposable,")
             }
             out.appendText("                customizations = customizations,\n")
-            out.appendText("                modifier = modifier.semantics { sDocClass = className},\n")
+            out.appendText(
+                "                modifier = modifier.semantics { sDocClass = className},\n"
+            )
             out.appendText(
                 "                serverParams = DocumentServerParams(queries, ignoredImages()),\n"
             )

--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -90,8 +90,11 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         file += "package $packageName\n\n"
         file += "import androidx.compose.runtime.Composable\n"
         file += "import androidx.compose.ui.text.TextStyle\n"
+        file += "import androidx.compose.foundation.layout.Box\n"
         file += "import android.graphics.Bitmap\n"
         file += "import androidx.compose.ui.Modifier\n"
+        file += "import androidx.compose.ui.semantics.semantics\n"
+        file += "import androidx.compose.ui.semantics.SemanticsPropertyReceiver\n"
         file += "import androidx.compose.runtime.mutableStateOf\n"
         file += "import androidx.compose.runtime.remember\n"
         file += "import androidx.compose.ui.platform.ComposeView\n"
@@ -135,6 +138,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         file += "import com.android.designcompose.setVisible\n"
         file += "import com.android.designcompose.TapCallback\n"
         file += "import com.android.designcompose.ParentComponentInfo\n"
+        file += "import com.android.designcompose.sDocClass\n"
         file += "import com.android.designcompose.LocalCustomizationContext\n\n"
 
         return file
@@ -816,6 +820,9 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             // Generate the function body by filling out customizations and then returning
             // the @Composable DesignDoc function
             out.appendText("    ) {\n")
+            // Embed the Doc's class to allow matching on in tests
+            out.appendText("        val className = javaClass.name\n")
+            out.appendText("        Box(modifier = Modifier.semantics { sDocClass = className})\n")
             out.appendText("        val customizations = remember { CustomizationContext() }\n")
             out.appendText("        customizations.setKey(key)\n")
             out.appendText("        customizations.mergeFrom(LocalCustomizationContext.current)\n")

--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -91,6 +91,8 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         file += "import androidx.compose.runtime.Composable\n"
         file += "import androidx.compose.ui.text.TextStyle\n"
         file += "import androidx.compose.foundation.layout.Box\n"
+        file += "import androidx.compose.foundation.layout.size\n" +
+                "import androidx.compose.ui.unit.dp\n"
         file += "import android.graphics.Bitmap\n"
         file += "import androidx.compose.ui.Modifier\n"
         file += "import androidx.compose.ui.semantics.semantics\n"
@@ -822,7 +824,9 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             out.appendText("    ) {\n")
             // Embed the Doc's class to allow matching on in tests
             out.appendText("        val className = javaClass.name\n")
-            out.appendText("        Box(modifier = Modifier.semantics { sDocClass = className})\n")
+//            out.appendText(
+//                "        Box(modifier = Modifier.size(0.dp).semantics { sDocClass = className})\n"
+//            )
             out.appendText("        val customizations = remember { CustomizationContext() }\n")
             out.appendText("        customizations.setKey(key)\n")
             out.appendText("        customizations.mergeFrom(LocalCustomizationContext.current)\n")
@@ -962,7 +966,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 out.appendText("                placeholder = $placeholderComposable,")
             }
             out.appendText("                customizations = customizations,\n")
-            out.appendText("                modifier = modifier,\n")
+            out.appendText("                modifier = modifier.semantics { sDocClass = className},\n")
             out.appendText(
                 "                serverParams = DocumentServerParams(queries, ignoredImages()),\n"
             )

--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -90,14 +90,9 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
         file += "package $packageName\n\n"
         file += "import androidx.compose.runtime.Composable\n"
         file += "import androidx.compose.ui.text.TextStyle\n"
-        file += "import androidx.compose.foundation.layout.Box\n"
-        file +=
-            "import androidx.compose.foundation.layout.size\n" +
-                "import androidx.compose.ui.unit.dp\n"
         file += "import android.graphics.Bitmap\n"
         file += "import androidx.compose.ui.Modifier\n"
         file += "import androidx.compose.ui.semantics.semantics\n"
-        file += "import androidx.compose.ui.semantics.SemanticsPropertyReceiver\n"
         file += "import androidx.compose.runtime.mutableStateOf\n"
         file += "import androidx.compose.runtime.remember\n"
         file += "import androidx.compose.ui.platform.ComposeView\n"
@@ -825,10 +820,6 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
             out.appendText("    ) {\n")
             // Embed the Doc's class to allow matching on in tests
             out.appendText("        val className = javaClass.name\n")
-            //            out.appendText(
-            //                "        Box(modifier = Modifier.size(0.dp).semantics { sDocClass =
-            // className})\n"
-            //            )
             out.appendText("        val customizations = remember { CustomizationContext() }\n")
             out.appendText("        customizations.setKey(key)\n")
             out.appendText("        customizations.mergeFrom(LocalCustomizationContext.current)\n")

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/HelloWorldInterface.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/HelloWorldInterface.kt
@@ -29,3 +29,8 @@ interface HelloWorld {
 }
 
 const val helloWorldFileName = "HelloWorldDoc_$helloWorldDocId.dcf"
+
+@DesignDoc(id = helloWorldDocId)
+interface HelloWorldWrongNode {
+    @DesignComponent(node = "#NonExistentNode", hideDesignSwitcher = true) fun nonExistentFrame()
+}

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/InstrumentedTestUtils.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/InstrumentedTestUtils.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.designcompose
+
+import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onSiblings
+
+fun SemanticsNodeInteraction.assertRenderStatus(status: DocRenderStatus) =
+    onSiblings().assertAny(expectValue(docRenderStatusSemanticsKey, status))
+
+fun ComposeContentTestRule.onDCDoc(genDoc: Any) =
+    onNode(expectValue(docClassSemanticsKey, genDoc.javaClass.name))

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/InstrumentedTestUtils.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/InstrumentedTestUtils.kt
@@ -16,14 +16,16 @@
 
 package com.android.designcompose
 
-import androidx.compose.ui.test.SemanticsMatcher.Companion.expectValue
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
-import androidx.compose.ui.test.onSiblings
-
-fun SemanticsNodeInteraction.assertRenderStatus(status: DocRenderStatus) =
-    onSiblings().assertAny(expectValue(docRenderStatusSemanticsKey, status))
 
 fun ComposeContentTestRule.onDCDoc(genDoc: Any) =
-    onNode(expectValue(docClassSemanticsKey, genDoc.javaClass.name))
+    onNode(SemanticsMatcher.expectValue(docClassSemanticsKey, genDoc.javaClass.name))
+
+fun SemanticsNodeInteraction.assertRenderStatus(status: DocRenderStatus) =
+    assert(SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, status))
+
+fun ComposeContentTestRule.assertDCRenderStatus(status: DocRenderStatus) =
+    onNode(SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, status)).assertExists()

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
@@ -19,8 +19,6 @@ package com.android.designcompose
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.test.assertNotNull

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
@@ -17,7 +17,6 @@
 package com.android.designcompose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.tooling.preview.Preview
@@ -58,9 +57,7 @@ class RenderTests {
 
         composeTestRule.waitForIdle()
 
-        composeTestRule
-            .onNode(SemanticsMatcher.expectValue(docIdSemanticsKey, designSwitcherDocId()))
-            .assertExists()
+        composeTestRule.onDCDoc(DesignSwitcherDoc).assertExists().assertExists()
         with(DesignSettings.testOnlyFigmaFetchStatus(designSwitcherDocId())) {
             assertNotNull(this)
             assertNotNull(lastLoadFromDisk)
@@ -76,10 +73,7 @@ class RenderTests {
         composeTestRule.waitForIdle()
 
         // Test that...
-        // No doc is rendered with this ID
-        composeTestRule
-            .onNode(SemanticsMatcher.keyIsDefined(docIdSemanticsKey))
-            .assertDoesNotExist()
+        composeTestRule.onDCDoc(HelloWorldDoc).assertRenderStatus(DocRenderStatus.NotAvailable)
 
         // The Node not found screen is shown
         composeTestRule

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
@@ -73,9 +73,7 @@ class RenderTests {
     fun missingSerializedFileDoesNotRender() {
         with(composeTestRule) {
             setContent { HelloWorldDoc.mainFrame(name = "No one") }
-            onRoot().printToLog("froeht")
 
-            // Test that...
             onDCDoc(HelloWorldDoc).assertDoesNotExist()
             assertDCRenderStatus(DocRenderStatus.NotAvailable)
 

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/RenderTests.kt
@@ -19,6 +19,8 @@ package com.android.designcompose
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToLog
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.test.assertNotNull
@@ -57,7 +59,7 @@ class RenderTests {
 
         composeTestRule.waitForIdle()
 
-        composeTestRule.onDCDoc(DesignSwitcherDoc).assertExists().assertExists()
+        composeTestRule.onDCDoc(DesignSwitcherDoc).assertExists()
         with(DesignSettings.testOnlyFigmaFetchStatus(designSwitcherDocId())) {
             assertNotNull(this)
             assertNotNull(lastLoadFromDisk)
@@ -69,17 +71,18 @@ class RenderTests {
     /** Test that a missing serialized file will cause the correct behavior */
     @Test
     fun missingSerializedFileDoesNotRender() {
-        composeTestRule.setContent { HelloWorldDoc.mainFrame(name = "No one") }
-        composeTestRule.waitForIdle()
+        with(composeTestRule) {
+            setContent { HelloWorldDoc.mainFrame(name = "No one") }
+            onRoot().printToLog("froeht")
 
-        // Test that...
-        composeTestRule.onDCDoc(HelloWorldDoc).assertRenderStatus(DocRenderStatus.NotAvailable)
+            // Test that...
+            onDCDoc(HelloWorldDoc).assertDoesNotExist()
+            assertDCRenderStatus(DocRenderStatus.NotAvailable)
 
-        // The Node not found screen is shown
-        composeTestRule
-            .onNodeWithText("Document $helloWorldDocId not available", substring = true)
-            .assertExists()
-
+            // The Node not found screen is shown
+            onNodeWithText("Document $helloWorldDocId not available", substring = true)
+                .assertExists()
+        }
         // It was not loaded from disk and did not render
         with(DesignSettings.testOnlyFigmaFetchStatus(helloWorldDocId)) {
             assertNotNull(this)

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/DocRenderSemanticBehavior.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/DocRenderSemanticBehavior.kt
@@ -22,6 +22,7 @@ import com.android.designcompose.DocRenderStatus
 import com.android.designcompose.HelloWorldDoc
 import com.android.designcompose.HelloWorldWrongNodeDoc
 import com.android.designcompose.TestUtils
+import com.android.designcompose.assertDCRenderStatus
 import com.android.designcompose.assertRenderStatus
 import com.android.designcompose.onDCDoc
 import org.junit.Before
@@ -51,7 +52,8 @@ class DocRenderSemanticBehavior {
         with(composeTestRule) {
             setContent { HelloWorldWrongNodeDoc.nonExistentFrame() }
             TestUtils.triggerLiveUpdate()
-            onDCDoc(HelloWorldWrongNodeDoc).assertRenderStatus(DocRenderStatus.NodeNotFound)
+            onDCDoc(HelloWorldWrongNodeDoc).assertDoesNotExist()
+            assertDCRenderStatus(DocRenderStatus.NodeNotFound)
         }
     }
 }

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/DocRenderSemanticBehavior.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/DocRenderSemanticBehavior.kt
@@ -14,38 +14,44 @@
  * limitations under the License.
  */
 
-package com.android.designcompose.testapp.helloworld
+package com.android.designcompose.figmaIntegrationTests
 
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
-import com.android.designcompose.DesignSettings
+import com.android.designcompose.DocRenderStatus
+import com.android.designcompose.HelloWorldDoc
+import com.android.designcompose.HelloWorldWrongNodeDoc
 import com.android.designcompose.TestUtils
-import kotlin.test.assertNotNull
+import com.android.designcompose.assertRenderStatus
+import com.android.designcompose.onDCDoc
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class TestFetchAndRender {
+class DocRenderSemanticBehavior {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Before
     fun setup() {
+        // Clear any previously cached files
         InstrumentationRegistry.getInstrumentation().context.filesDir.deleteRecursively()
     }
 
     @Test
-    fun testHello() {
-        composeTestRule.setContent { HelloWorldDoc.mainFrame(name = "Testers!") }
-        TestUtils.triggerLiveUpdate()
-
-        with(DesignSettings.testOnlyFigmaFetchStatus(helloWorldDocId)) {
-            assertNotNull(this)
-            assertNotNull(lastLoadFromDisk)
-            assertNotNull(lastFetch)
-            assertNotNull(lastUpdateFromFetch)
+    fun docIsRenderedAfterLoad() {
+        with(composeTestRule) {
+            setContent { HelloWorldDoc.mainFrame(name = "Testers!") }
+            TestUtils.triggerLiveUpdate()
+            onDCDoc(HelloWorldDoc).assertRenderStatus(DocRenderStatus.Rendered)
         }
+    }
 
-        composeTestRule.onNodeWithText("Testers!", substring = true).assertExists()
+    @Test
+    fun docWithBadNodeSaysNodeNotFound() {
+        with(composeTestRule) {
+            setContent { HelloWorldWrongNodeDoc.nonExistentFrame() }
+            TestUtils.triggerLiveUpdate()
+            onDCDoc(HelloWorldWrongNodeDoc).assertRenderStatus(DocRenderStatus.NodeNotFound)
+        }
     }
 }

--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/LiveUpdateBehaviorTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/LiveUpdateBehaviorTests.kt
@@ -16,7 +16,6 @@
 
 package com.android.designcompose.figmaIntegrationTests
 
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -25,7 +24,6 @@ import com.android.designcompose.HelloWorldDoc
 import com.android.designcompose.TestUtils
 import com.android.designcompose.annotation.DesignComponent
 import com.android.designcompose.annotation.DesignDoc
-import com.android.designcompose.docIdSemanticsKey
 import com.android.designcompose.helloWorldDocId
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -64,10 +62,6 @@ class LiveUpdateBehaviorTests {
     fun fetchHelloWorld() {
         composeTestRule.setContent { HelloWorldDoc.mainFrame(name = "Testers!") }
         TestUtils.triggerLiveUpdate()
-        composeTestRule.waitForIdle()
-        composeTestRule
-            .onNode(SemanticsMatcher.expectValue(docIdSemanticsKey, helloWorldDocId))
-            .assertExists()
 
         with(DesignSettings.testOnlyFigmaFetchStatus(helloWorldDocId)) {
             assertNotNull(this)
@@ -82,14 +76,8 @@ class LiveUpdateBehaviorTests {
     fun wrongNodeCausesRenderFailure() {
         composeTestRule.setContent { HelloWorldWrongNodeDoc.nonExistentFrame() }
         TestUtils.triggerLiveUpdate()
-        composeTestRule.waitForIdle()
 
         // Check that...
-        // No doc is rendered with this ID
-        composeTestRule
-            .onNode(SemanticsMatcher.keyIsDefined(docIdSemanticsKey))
-            .assertDoesNotExist()
-
         // The Node not found screen is shown
         composeTestRule
             .onNodeWithText("Node \"#NonExistentNode\" not found", substring = true)

--- a/designcompose/src/main/java/com/android/designcompose/CustomSemantics.kt
+++ b/designcompose/src/main/java/com/android/designcompose/CustomSemantics.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.designcompose
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+
+// Custom Compose Semantic that identifies a DesignCompose Composable
+// The semantic will be set to the generated doc's `javaClass.name`.
+// For example, to match the generated doc a DesignDoc named "HelloWorld", match on
+// `HelloWorldDoc.javaClass.name`
+val docClassSemanticsKey = SemanticsPropertyKey<String>("DocClass")
+var SemanticsPropertyReceiver.sDocClass by docClassSemanticsKey
+
+enum class DocRenderStatus {
+    Rendered,
+    Fetching,
+    NodeNotFound,
+    NotAvailable
+}
+
+val docRenderStatusSemanticsKey = SemanticsPropertyKey<DocRenderStatus>("DocRenderStatus")
+var SemanticsPropertyReceiver.sDocRenderStatus by docRenderStatusSemanticsKey

--- a/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import com.android.designcompose.common.DocumentServerParams
 import com.android.designcompose.common.FeedbackLevel
@@ -200,7 +201,7 @@ private interface DesignSwitcher {
                 designSwitcherDocId(),
                 NodeQuery.NodeName("#SettingsView"),
                 customizations = customizations,
-                modifier = modifier,
+                modifier = modifier.semantics { sDocClass = DesignSwitcherDoc.javaClass.name },
                 serverParams = DocumentServerParams(queries(), ignoredImages()),
                 designSwitcherPolicy = DesignSwitcherPolicy.IS_DESIGN_SWITCHER,
                 liveUpdateMode = getLiveMode(),

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -941,7 +941,6 @@ internal fun DesignDocInternal(
         }
     }
 
-    Box(modifier = Modifier.semantics { sDocRenderStatus = docRenderStatus })
 
     var noFrameErrorMessage = ""
     var noFrameBgColor = Color(0x00000000)
@@ -950,10 +949,12 @@ internal fun DesignDocInternal(
     if (doc != null) {
         val startFrame = interactionState.rootNode(rootNodeQuery, doc, isRoot)
         if (startFrame != null) {
+
+    Box(modifier = Modifier.size(0.dp).semantics { sDocRenderStatus = docRenderStatus })
             LaunchedEffect(docId) { designComposeCallbacks?.docReadyCallback?.invoke(docId) }
             CompositionLocalProvider(LocalDesignIsRootContext provides DesignIsRoot(false)) {
                 DesignView(
-                    modifier,
+                    modifier.semantics { sDocRenderStatus = docRenderStatus },
                     startFrame,
                     variantParentName,
                     docId,

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -941,7 +941,6 @@ internal fun DesignDocInternal(
         }
     }
 
-
     var noFrameErrorMessage = ""
     var noFrameBgColor = Color(0x00000000)
 
@@ -949,8 +948,6 @@ internal fun DesignDocInternal(
     if (doc != null) {
         val startFrame = interactionState.rootNode(rootNodeQuery, doc, isRoot)
         if (startFrame != null) {
-
-    Box(modifier = Modifier.size(0.dp).semantics { sDocRenderStatus = docRenderStatus })
             LaunchedEffect(docId) { designComposeCallbacks?.docReadyCallback?.invoke(docId) }
             CompositionLocalProvider(LocalDesignIsRootContext provides DesignIsRoot(false)) {
                 DesignView(
@@ -1021,7 +1018,11 @@ internal fun DesignDocInternal(
         designSwitcher()
     } else {
         CompositionLocalProvider(LocalDesignIsRootContext provides DesignIsRoot(false)) {
-            Box(Modifier.fillMaxSize().background(noFrameBgColor).padding(20.dp)) {
+            Box(
+                Modifier.fillMaxSize().background(noFrameBgColor).padding(20.dp).semantics {
+                    sDocRenderStatus = docRenderStatus
+                }
+            ) {
                 BasicText(text = noFrameErrorMessage, style = TextStyle(fontSize = 24.sp))
             }
             designSwitcher()

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -16,6 +16,7 @@
 
 package com.android.designcompose
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -43,6 +44,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,8 +62,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.semantics.SemanticsPropertyKey
-import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.IntSize
@@ -331,10 +331,6 @@ internal data class MaskInfo(
     // The type of node with respect to masking
     val type: MaskViewType?,
 )
-
-// Custom Compose Semantic that identifies a DesignCompose Composable
-val docIdSemanticsKey = SemanticsPropertyKey<String>("DocId")
-var SemanticsPropertyReceiver.sDocId by docIdSemanticsKey
 
 @Composable
 internal fun DesignView(
@@ -886,6 +882,7 @@ internal fun DesignDocInternal(
     designComposeCallbacks: DesignComposeCallbacks? = null,
     parentComponents: List<ParentComponentInfo> = listOf(),
 ) {
+    var docRenderStatus by remember { mutableStateOf(DocRenderStatus.NotAvailable) }
     val docId = DocumentSwitcher.getSwitchedDocId(incomingDocId)
     val doc =
         DocServer.doc(
@@ -944,6 +941,8 @@ internal fun DesignDocInternal(
         }
     }
 
+    Box(modifier = Modifier.semantics { sDocRenderStatus = docRenderStatus })
+
     var noFrameErrorMessage = ""
     var noFrameBgColor = Color(0x00000000)
 
@@ -954,7 +953,7 @@ internal fun DesignDocInternal(
             LaunchedEffect(docId) { designComposeCallbacks?.docReadyCallback?.invoke(docId) }
             CompositionLocalProvider(LocalDesignIsRootContext provides DesignIsRoot(false)) {
                 DesignView(
-                    modifier.semantics { sDocId = docId },
+                    modifier,
                     startFrame,
                     variantParentName,
                     docId,
@@ -969,6 +968,7 @@ internal fun DesignDocInternal(
                         absoluteParentLayoutInfo
                     }
                 )
+                docRenderStatus = DocRenderStatus.Rendered
                 // If we're the root, then also paint overlays
                 if (isRoot || designSwitcherPolicy == DesignSwitcherPolicy.IS_DESIGN_SWITCHER) {
                     for (overlay in interactionState.rootOverlays(doc)) {
@@ -999,16 +999,19 @@ internal fun DesignDocInternal(
         if (rootFrameName.isNotEmpty()) {
             noFrameErrorMessage = "Node \"$rootFrameName\" not found in $docId"
             noFrameBgColor = Color(0xFFFFFFFF)
-            println("Node not found: rootNodeQuery $rootNodeQuery rootFrameName $rootFrameName")
+            Log.e(TAG, "Node not found: rootNodeQuery $rootNodeQuery rootFrameName $rootFrameName")
+            docRenderStatus = DocRenderStatus.NodeNotFound
         }
     } else {
         // The doc is null, so either we're fetching it, or it's missing.
-        noFrameErrorMessage =
-            if (!DesignSettings.liveUpdatesEnabled) {
-                "Document $docId not available"
-            } else {
-                "Fetching $docId..."
-            }
+
+        if (!DesignSettings.liveUpdatesEnabled) {
+            noFrameErrorMessage = "Document $docId not available"
+            docRenderStatus = DocRenderStatus.NotAvailable
+        } else {
+            noFrameErrorMessage = "Fetching $docId..."
+            docRenderStatus = DocRenderStatus.Fetching
+        }
     }
 
     // If we have a placeholder then present it.

--- a/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/figmaIntegrationTests/FetchAndRenderExamples.kt
+++ b/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/figmaIntegrationTests/FetchAndRenderExamples.kt
@@ -18,15 +18,18 @@ package com.android.designcompose.testapp.validation.figmaIntegrationTests
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onSiblings
 import androidx.test.platform.app.InstrumentationRegistry
 import com.android.designcompose.DesignSettings
+import com.android.designcompose.DocRenderStatus
 import com.android.designcompose.TestUtils
-import com.android.designcompose.docIdSemanticsKey
+import com.android.designcompose.docClassSemanticsKey
+import com.android.designcompose.docRenderStatusSemanticsKey
 import com.android.designcompose.testapp.validation.EXAMPLES
 import com.android.designcompose.testapp.validation.interFont
-import kotlin.test.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,14 +46,13 @@ import org.junit.runners.Parameterized
  * @constructor Create empty Fetch and render examples
  * @property testName Human readable name for a the test
  * @property testComposable The composable to run
- * @property fileId The Figma file ID of the test (currently each test should only use one Figma
- *   file)
+ * @property fileClass The classname of the DesignCompose DesignDoc that is being tested file)
  */
 @RunWith(Parameterized::class)
 class FetchAndRenderExamples(
     private val testName: String,
     private val testComposable: @Composable () -> Unit,
-    private val fileId: String
+    private val fileClass: String
 ) {
     @get:Rule val composeTestRule = createComposeRule()
 
@@ -81,18 +83,14 @@ class FetchAndRenderExamples(
         composeTestRule.setContent(testComposable)
         TestUtils.triggerLiveUpdate()
 
-        composeTestRule.waitForIdle()
-        // Check that at least one node has the doc ID set correctly (some tests use display
+        // Check that at least one node has the doc's class set correctly (some tests use display
         // multiple instances)
         composeTestRule
-            .onAllNodes(SemanticsMatcher.expectValue(docIdSemanticsKey, fileId))
+            .onAllNodes(SemanticsMatcher.expectValue(docClassSemanticsKey, fileClass))
             .onFirst()
-            .assertExists()
-
-        with(DesignSettings.testOnlyFigmaFetchStatus(fileId)) {
-            assertNotNull(this)
-            assertNotNull(lastUpdateFromFetch)
-            assertNotNull(lastFetch)
-        }
+            .onSiblings()
+            .assertAny(
+                SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, DocRenderStatus.Rendered)
+            )
     }
 }

--- a/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/figmaIntegrationTests/FetchAndRenderExamples.kt
+++ b/integration-tests/validation/src/androidTest/java/com/android/designcompose/testapp/validation/figmaIntegrationTests/FetchAndRenderExamples.kt
@@ -18,10 +18,9 @@ package com.android.designcompose.testapp.validation.figmaIntegrationTests
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onSiblings
 import androidx.test.platform.app.InstrumentationRegistry
 import com.android.designcompose.DesignSettings
 import com.android.designcompose.DocRenderStatus
@@ -88,8 +87,7 @@ class FetchAndRenderExamples(
         composeTestRule
             .onAllNodes(SemanticsMatcher.expectValue(docClassSemanticsKey, fileClass))
             .onFirst()
-            .onSiblings()
-            .assertAny(
+            .assert(
                 SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, DocRenderStatus.Rendered)
             )
     }

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/MainActivity.kt
@@ -116,43 +116,63 @@ const val TAG = "DesignCompose"
 
 val EXAMPLES: ArrayList<Triple<String, @Composable () -> Unit, String?>> =
     arrayListOf(
-        Triple("Hello", { HelloWorld() }, "pxVlixodJqZL95zo2RzTHl"),
-        Triple("Image Update", { ImageUpdateTest() }, "oQw7kiy94fvdVouCYBC9T0"),
-        Triple("Telltales", { TelltaleTest() }, "TZgHrKWx8wvQM7UPTyEpmz"),
-        Triple("OpenLink", { OpenLinkTest() }, "r7m4tqyKv6y9DWcg7QBEDf"),
-        Triple("Variant *", { VariantAsteriskTest() }, "gQeYHGCSaBE4zYSFpBrhre"),
-        Triple("Alignment", { AlignmentTest() }, "JIjE9oKQbq8ipi66ab5UaK"),
-        Triple("Battleship", { BattleshipTest() }, "RfGl9SWnBEvdg8T1Ex6ZAR"),
-        Triple("H Constraints", { HConstraintsTest() }, "KuHLbsKA23DjZPhhgHqt71"),
-        Triple("V Constraints", { VConstraintsTest() }, "KuHLbsKA23DjZPhhgHqt71"),
-        Triple("Interaction", { InteractionTest() }, "8Zg9viyjYTnyN29pbkR1CE"),
-        Triple("Shadows", { ShadowsTest() }, "OqK58Y46IqP4wIgKCWys48"),
-        Triple("Item Spacing", { ItemSpacingTest() }, "YXrHBp6C6OaW5ShcCYeGJc"),
-        Triple("Recurse Customization", { RecursiveCustomizations() }, "o0GWzcqdOWEgzj4kIeIlAu"),
-        Triple("Color Tint", { ColorTintTest() }, "MCtUD3yjONxK6rQm65yqM5"),
-        Triple("Variant Properties", { VariantPropertiesTest() }, "4P7zDdrQxj7FZsKJoIQcx1"),
+        Triple("Hello", { HelloWorld() }, HelloWorldDoc.javaClass.name),
+        Triple("Image Update", { ImageUpdateTest() }, ImageUpdateTestDoc.javaClass.name),
+        Triple("Telltales", { TelltaleTest() }, TelltaleTestDoc.javaClass.name),
+        Triple("OpenLink", { OpenLinkTest() }, OpenLinkTestDoc.javaClass.name),
+        Triple("Variant *", { VariantAsteriskTest() }, VariantAsteriskTestDoc.javaClass.name),
+        Triple("Alignment", { AlignmentTest() }, AlignmentTestDoc.javaClass.name),
+        Triple("Battleship", { BattleshipTest() }, BattleshipDoc.javaClass.name),
+        Triple("H Constraints", { HConstraintsTest() }, ConstraintsDoc.javaClass.name),
+        Triple("V Constraints", { VConstraintsTest() }, ConstraintsDoc.javaClass.name),
+        Triple("Interaction", { InteractionTest() }, InteractionTestDoc.javaClass.name),
+        Triple("Shadows", { ShadowsTest() }, ShadowsTestDoc.javaClass.name),
+        Triple("Item Spacing", { ItemSpacingTest() }, ItemSpacingTestDoc.javaClass.name),
+        Triple(
+            "Recurse Customization",
+            { RecursiveCustomizations() },
+            RecursiveCustomizationsDoc.javaClass.name
+        ),
+        Triple("Color Tint", { ColorTintTest() }, ColorTintTestDoc.javaClass.name),
+        Triple(
+            "Variant Properties",
+            { VariantPropertiesTest() },
+            VariantPropertiesTestDoc.javaClass.name
+        ),
         // Lazy Grid doesn't actually use a doc
         Triple("Lazy Grid", { LazyGridItemSpans() }, null),
-        Triple("Grid Layout", { GridLayoutTest() }, "JOSOEvsrjvMqanyQa5OpNR"),
-        Triple("Grid Widget", { GridWidgetTest() }, "OBhNItd9i9J2LwVYuLxEIx"),
-        Triple("List Widget", { ListWidgetTest() }, "9ev0MBNHFrgTqJOrAGcEpV"),
-        Triple("1px Separator", { OnePxSeparatorTest() }, "EXjTHxfMNBtXDrz8hr6MFB"),
-        Triple("Variant Interactions", { VariantInteractionsTest() }, "WcsgoLR4aDRSkZHY29Qdhq"),
-        Triple("Layout Replacement", { LayoutReplacementTest() }, "dwk2GF7RiNvlbbAKPjqldx"),
-        Triple("Text Elide", { TextElideTest() }, "oQ7nK49Ya5PJ3GpjI5iy8d"),
-        Triple("Fancy Fills", { FancyFillTest() }, "xQ9cunHt8VUm6xqJJ2Pjb2"),
-        Triple("Fill Container", { FillTest() }, "dB3q96FkxkTO4czn5NqnxV"),
-        Triple("CrossAxis Fill", { CrossAxisFillTest() }, "GPr1cx4n3zBPwLhqlSL1ba"),
+        Triple("Grid Layout", { GridLayoutTest() }, GridLayoutTestDoc.javaClass.name),
+        Triple("Grid Widget", { GridWidgetTest() }, GridWidgetTestDoc.javaClass.name),
+        Triple("List Widget", { ListWidgetTest() }, ListWidgetTestDoc.javaClass.name),
+        Triple("1px Separator", { OnePxSeparatorTest() }, OnePxSeparatorDoc.javaClass.name),
+        Triple(
+            "Variant Interactions",
+            { VariantInteractionsTest() },
+            VariantInteractionsTestDoc.javaClass.name
+        ),
+        Triple(
+            "Layout Replacement",
+            { LayoutReplacementTest() },
+            LayoutReplacementTestDoc.javaClass.name
+        ),
+        Triple("Text Elide", { TextElideTest() }, TextElideTestDoc.javaClass.name),
+        Triple("Fancy Fills", { FancyFillTest() }, FancyFillTestDoc.javaClass.name),
+        Triple("Fill Container", { FillTest() }, FillTestDoc.javaClass.name),
+        Triple("CrossAxis Fill", { CrossAxisFillTest() }, CrossAxisFillTestDoc.javaClass.name),
         Triple(
             "Grid Layout Documentation",
             { GridLayoutDocumentation() },
-            "MBNjjSbzzKeN7nBjVoewsl"
+            GridLayoutDoc.javaClass.name
         ),
-        Triple("Blend Modes", { BlendModeTest() }, "ZqX5i5g6inv9tANIwMMXUV"),
-        Triple("Vector Rendering", { VectorRenderingTest() }, "Z3ucY0wMAbIwZIa6mLEWIK"),
-        Triple("Dials Gauges", { DialsGaugesTest() }, "lZj6E9GtIQQE4HNLpzgETw"),
-        Triple("Masks", { MaskTest() }, "mEmdUVEIjvBBbV0kELPy37"),
-        Triple("Variable Borders", { VariableBorderTest() }, "MWnVAfW3FupV4VMLNR1m67")
+        Triple("Blend Modes", { BlendModeTest() }, BlendModeTestDoc.javaClass.name),
+        Triple(
+            "Vector Rendering",
+            { VectorRenderingTest() },
+            VectorRenderingTestDoc.javaClass.name
+        ),
+        Triple("Dials Gauges", { DialsGaugesTest() }, DialsGaugesTestDoc.javaClass.name),
+        Triple("Masks", { MaskTest() }, MaskTestDoc.javaClass.name),
+        Triple("Variable Borders", { VariableBorderTest() }, VariableBorderTestDoc.javaClass.name),
     )
 
 // TEST Basic Hello World example

--- a/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
+++ b/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
@@ -19,11 +19,15 @@ package com.android.designcompose.testapp.validation
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.onSiblings
 import com.android.designcompose.DesignSettings
-import com.android.designcompose.docIdSemanticsKey
+import com.android.designcompose.DocRenderStatus
+import com.android.designcompose.docClassSemanticsKey
+import com.android.designcompose.docRenderStatusSemanticsKey
 import com.github.takahirom.roborazzi.RoborazziRule
 import java.io.File
 import org.junit.BeforeClass
@@ -42,7 +46,7 @@ class RenderAllExamples(private val config: TestConfig) {
     data class TestConfig(
         internal val fileName: String,
         internal val fileComposable: @Composable () -> Unit,
-        internal val fileId: String
+        internal val fileClass: String
     )
 
     @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
@@ -51,9 +55,12 @@ class RenderAllExamples(private val config: TestConfig) {
     fun testRender() {
         composeTestRule.setContent(config.fileComposable)
         composeTestRule
-            .onAllNodes(SemanticsMatcher.expectValue(docIdSemanticsKey, config.fileId))
+            .onAllNodes(SemanticsMatcher.expectValue(docClassSemanticsKey, config.fileClass))
             .onFirst()
-            .assertExists()
+            .onSiblings()
+            .assertAny(
+                SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, DocRenderStatus.Rendered)
+            )
     }
 
     @get:Rule

--- a/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
+++ b/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
@@ -20,11 +20,9 @@ import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.onSiblings
 import com.android.designcompose.DesignSettings
 import com.android.designcompose.DocRenderStatus
 import com.android.designcompose.docClassSemanticsKey

--- a/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
+++ b/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/RenderAllExamples.kt
@@ -19,6 +19,7 @@ package com.android.designcompose.testapp.validation
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
@@ -54,11 +55,11 @@ class RenderAllExamples(private val config: TestConfig) {
     @Test
     fun testRender() {
         composeTestRule.setContent(config.fileComposable)
+        composeTestRule.waitForIdle()
         composeTestRule
             .onAllNodes(SemanticsMatcher.expectValue(docClassSemanticsKey, config.fileClass))
             .onFirst()
-            .onSiblings()
-            .assertAny(
+            .assert(
                 SemanticsMatcher.expectValue(docRenderStatusSemanticsKey, DocRenderStatus.Rendered)
             )
     }

--- a/reference-apps/helloworld/src/testDebug/kotlin/RenderHelloWorld.kt
+++ b/reference-apps/helloworld/src/testDebug/kotlin/RenderHelloWorld.kt
@@ -18,11 +18,15 @@ package com.android.designcompose.testapp.helloworld
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.onSiblings
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.designcompose.docIdSemanticsKey
+import com.android.designcompose.DocRenderStatus
+import com.android.designcompose.docClassSemanticsKey
+import com.android.designcompose.docRenderStatusSemanticsKey
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziRule
 import org.junit.Rule
@@ -34,7 +38,7 @@ import org.robolectric.annotation.GraphicsMode
 /**
  * Render hello world
  *
- * Basic test that uses Robolectrict's native graphics to test that HelloWorld renders.
+ * Basic test that uses Robolectric's native graphics to test that HelloWorld renders.
  *
  * Includes Roborazzi for Screenshot tests,
  */
@@ -62,7 +66,14 @@ class RenderHelloWorld {
     fun testHello() {
         with(composeTestRule) {
             setContent { HelloWorldDoc.mainFrame(name = "Testers!") }
-            onNode(SemanticsMatcher.expectValue(docIdSemanticsKey, helloWorldDocId)).assertExists()
+            onNode(SemanticsMatcher.expectValue(docClassSemanticsKey, HelloWorldDoc.javaClass.name))
+                .onSiblings()
+                .assertAny(
+                    SemanticsMatcher.expectValue(
+                        docRenderStatusSemanticsKey,
+                        DocRenderStatus.Rendered
+                    )
+                )
             onNodeWithText("Testers!", substring = true).assertExists()
         }
     }

--- a/reference-apps/helloworld/src/testDebug/kotlin/RenderHelloWorld.kt
+++ b/reference-apps/helloworld/src/testDebug/kotlin/RenderHelloWorld.kt
@@ -18,11 +18,10 @@ package com.android.designcompose.testapp.helloworld
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.onSiblings
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.designcompose.DocRenderStatus
 import com.android.designcompose.docClassSemanticsKey
@@ -67,8 +66,7 @@ class RenderHelloWorld {
         with(composeTestRule) {
             setContent { HelloWorldDoc.mainFrame(name = "Testers!") }
             onNode(SemanticsMatcher.expectValue(docClassSemanticsKey, HelloWorldDoc.javaClass.name))
-                .onSiblings()
-                .assertAny(
+                .assert(
                     SemanticsMatcher.expectValue(
                         docRenderStatusSemanticsKey,
                         DocRenderStatus.Rendered


### PR DESCRIPTION
Targeting main with this PR instead of #459 which targeted the feature branch.

This provides a more consistent method of detecting and testing DesignCompose docs and whether they rendered.