### PR TITLE
Configure the dependency review action to re-run when new deps are added

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -40,3 +40,8 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
+        with:
+          # This will cause the dependency graph workflow to re-run if new dependencies are uploaded
+          # by a job that finishes after this one. Specifically needed for the Gradle dependency snapshot upload
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 1200


### PR DESCRIPTION
Following the recommendation here: https://github.com/gradle/gradle-build-action#integrating-dependency-review-action-for-pull-request-workflows