### PR TITLE
Add a benchmark variant of DesignCompose

### DIFF
--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -45,6 +45,13 @@ android {
         }
     }
 
+    buildTypes {
+        create("benchmark") {
+            initWith(buildTypes.getByName("release"))
+            matchingFallbacks.add("release")
+        }
+    }
+
     buildFeatures { compose = true }
 
     composeOptions {

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -35,6 +35,7 @@ internal class TextSize(
     var height: Float = 0F,
 )
 
+@Keep
 internal object Jni {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,7 @@ android.useAndroidX=true
 # Jetifier isn't needed any more! Disabling to speed up our builds.
 android.enableJetifier=false
 kotlin.code.style=official
+
+# Allow two r8 minify tasks to run in parallel. Each task takes 20-50 seconds so this helps speed things up.
+# Uses more of the heap, but 4GB of heap still seems sufficient.
+android.r8.maxWorkers=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 designcompose = "0.24.0-SNAPSHOT"
 
 #Android Gradle Plugin
-agp = "8.1.2"
+agp = "8.3.0-alpha13"
 # The minimum supported AGP version for DesignCompose Apps
 agp-minSupported = "7.3.1"
 


### PR DESCRIPTION
Includes modifications to the CargoPlugin to allow the abiFilter to be applied to the benchmark variant.