### PR TITLE
Remove unnecessary proguard rules

### DIFF
--- a/designcompose/consumer-proguard-rules.pro
+++ b/designcompose/consumer-proguard-rules.pro
@@ -1,6 +1,1 @@
-# Must keep all generated messages
--shrinkunusedprotofields
-
-# I can't find the exact reason why, but ignoring this warning seems to be a standard thing to do.
-# Including in the grpc examples
--dontwarn javax.naming.**
+# Not currently requiring any rules

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 designcompose = "0.24.0-SNAPSHOT"
 
 #Android Gradle Plugin
-agp = "8.1.2"
+agp = "8.3.0-alpha13"
 # The minimum supported AGP version for DesignCompose Apps
 agp-minSupported = "7.3.1"
 


### PR DESCRIPTION
These have been causing build warnings and haven't done anything ever since we removed the grpc code.