### PR TITLE
Closes #601: Fix a crash when a rotation dial/gauge is set to "Scale"…

### DIFF
--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -527,7 +527,7 @@ pub struct ViewStyle {
     pub text_align_vertical: TextAlignVertical,
     pub text_overflow: TextOverflow,
     pub text_shadow: Option<TextShadow>,
-    pub text_size: Size<f32>,
+    pub node_size: Size<f32>,
     pub line_height: LineHeight,
     pub line_count: Option<usize>, // None means no limit on # lines.
     pub font_features: Vec<FontFeature>,
@@ -594,7 +594,7 @@ impl Default for ViewStyle {
             text_align_vertical: TextAlignVertical::Top,
             text_overflow: TextOverflow::Clip,
             text_shadow: None,
-            text_size: Size::default(),
+            node_size: Size::default(),
             line_height: LineHeight::Percent(1.0),
             line_count: None,
             font_features: Vec::new(),
@@ -753,8 +753,8 @@ impl ViewStyle {
         if self.text_shadow != other.text_shadow {
             delta.text_shadow = other.text_shadow;
         }
-        if self.text_size != other.text_size {
-            delta.text_size = other.text_size;
+        if self.node_size != other.node_size {
+            delta.node_size = other.node_size;
         }
         if self.line_height != other.line_height {
             delta.line_height = other.line_height;

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -286,6 +286,9 @@ fn compute_layout(node: &Node, parent: Option<&Node>) -> ViewStyle {
                 style.width = Dimension::Points(size.x());
                 style.height = Dimension::Points(size.y());
             }
+
+            style.node_size.width = size.x();
+            style.node_size.height = size.y();
         }
     }
 
@@ -301,11 +304,6 @@ fn compute_layout(node: &Node, parent: Option<&Node>) -> ViewStyle {
         }
         style.horizontal_sizing = vector.layout_sizing_horizontal.into();
         style.vertical_sizing = vector.layout_sizing_vertical.into();
-
-        if let Some(Vector { x: Some(x), y: Some(y) }) = &node.size {
-            style.text_size.width = *x;
-            style.text_size.height = *y;
-        }
 
         // The text style also contains some layout information. We previously exposed
         // auto-width text in our plugin.

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -253,7 +253,7 @@ internal fun DesignText(
             annotatedText,
             textStyle,
             LocalFontLoader.current,
-            style.text_size,
+            style.node_size,
             paragraph
         )
     val maxLines = if (style.line_count.isPresent) style.line_count.get().toInt() else Int.MAX_VALUE

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.IntSize
 import com.android.designcompose.serdegen.ArcMeterData
 import com.android.designcompose.serdegen.BoxShadow
+import com.android.designcompose.serdegen.Dimension
 import com.android.designcompose.serdegen.MeterData
 import com.android.designcompose.serdegen.Overflow
 import com.android.designcompose.serdegen.ProgressBarMeterData
@@ -106,8 +107,12 @@ private fun calculateRotationData(
         (rotationData.start + meterValue / 100f * (rotationData.end - rotationData.start))
             .coerceDiscrete(rotationData.discrete, rotationData.discreteValue)
 
-    val nodeWidth = style.width.pointsAsDp(density).value
-    val nodeHeight = style.height.pointsAsDp(density).value
+    val nodeWidth =
+        if (style.width is Dimension.Points) style.width.pointsAsDp(density).value
+        else style.node_size.width
+    val nodeHeight =
+        if (style.height is Dimension.Points) style.height.pointsAsDp(density).value
+        else style.node_size.height
 
     // Calculate offsets from parent when the rotation is 0
     val offsets =

--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -307,11 +307,11 @@ internal fun mergeStyles(base: ViewStyle, override: ViewStyle): ViewStyle {
         } else {
             base.text_shadow
         }
-    style.text_size =
-        if (override.text_size.width != 0.0f || override.text_size.height != 0.0f) {
-            override.text_size
+    style.node_size =
+        if (override.node_size.width != 0.0f || override.node_size.height != 0.0f) {
+            override.node_size
         } else {
-            base.text_size
+            base.node_size
         }
     style.line_height =
         if (!override.line_height.equals(LineHeight.Percent(1.0f))) {


### PR DESCRIPTION
… constraints.

When a node's constraints are set to "Scale", the ViewStyle's width and height fields are Auto, causing the rendering code to be unable to get the node's with and height. This causes the transform being used to be full of NaNs, and then ultimately causes a crash.

To fix this, save the original node's size into ViewStyle into the node_size field, renamed from text_style, and use it when the style's width/height are not known.

Note that this does not fix support constraints on nodes -- it just prevents a crash and allows the rotation to still function given that it stays the same size as in Figma.