### PR TITLE
support-figma: add allowlisted domains for Figma plugins

### DIFF
--- a/support-figma/auto-content-preview-widget/README.md
+++ b/support-figma/auto-content-preview-widget/README.md
@@ -41,10 +41,25 @@ We recommend writing TypeScript code using Visual Studio code:
 That's it! Visual Studio Code will regenerate the JavaScript file every time you save.
 
 ## Adding the widget to Figma
+
 To add the development version of the widget, you need to be running the Figma desktop application on a Windows or MacOS machine.
 
-* In a doc, right-click and open the widget menu.
-* Select "Development"
-* Select "Import widget from manifest"
-* Navigate to your `manifest.json` and press OK.
-* Once you've done this once, the widget will be available directly in the "Development" menu option.
+- In a doc, right-click and open the widget menu.
+- Select "Development"
+- Select "Import widget from manifest"
+- Navigate to your `manifest.json` and press OK.
+- Once you've done this once, the widget will be available directly in the "Development" menu option.
+
+## Network access restrictions
+
+> [!TIP]
+> You can use the `devAllowedDomains` field to define domains that you need
+> access to for development purposes.
+
+The [manifest.json](manifest.json) file defines an allowlist of domains that the
+widget is permitted to load [cross-origin resources] from. Any changes that
+introduce dependencies on origins not covered by the existing allowlist will
+need to update the [networkAccess] field in the widget's manifest file.
+
+[cross-origin resources]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[networkAccess]: https://www.figma.com/widget-docs/widget-manifest/#networkaccess

--- a/support-figma/auto-content-preview-widget/manifest.json
+++ b/support-figma/auto-content-preview-widget/manifest.json
@@ -4,9 +4,13 @@
   "api": "1.0.0",
   "main": "dist/code.js",
   "ui": "dist/ui.html",
-  "editorType": [
-    "figma"
-  ],
+  "editorType": ["figma"],
   "containsWidget": true,
-  "widgetApi": "1.0.0"
+  "widgetApi": "1.0.0",
+  "networkAccess": {
+    "allowedDomains": [
+      "https://cdn.jsdelivr.net/gh/thomas-lowry/figma-plugin-ds/dist/figma-plugin-ds.css"
+    ],
+    "reasoning": "The widget uses the stylesheet from https://github.com/thomas-lowry/figma-plugin-ds to make the UI consistent with the rest of the Figma UI (https://www.figma.com/plugin-docs/figma-components/)."
+  }
 }

--- a/support-figma/extended-layout-plugin/README.md
+++ b/support-figma/extended-layout-plugin/README.md
@@ -2,13 +2,13 @@
 
 This plugin adds some additional capabilities to Figma specifically for Automotive Design for Compose. It writes additional data into Figma nodes using Figma's JS API that can be read from Figma's REST API. It uses a Figma UI2 stylesheet from <https://github.com/thomas-lowry/figma-plugin-ds> to look more like Figma. There are five plugin menu options, detailed below.
 
-* Live text format: Additional controls to set:
-    * The maximum line count (or zero for unlimited lines).
-    * Whether the text should be ellipsized.
-* Dials and Gauges: Configure nodes to act as a type of dial or gauge
-* Check document for errors: Using a JSON file created from the application's DesignCompose annotations, check for possible errors in the document such as missing or incorrectly named nodes
-* Check/update keywords: Upload a new JSON file created from the application's DesignCompose annotations
-* Sync Prototype changes: Copies the interactive fields from the JS API to a data area that the REST API can fetch (since our webservice can't talk to the JS API). This needs to be run anytime an interaction changes.
+- Live text format: Additional controls to set:
+  - The maximum line count (or zero for unlimited lines).
+  - Whether the text should be ellipsized.
+- Dials and Gauges: Configure nodes to act as a type of dial or gauge
+- Check document for errors: Using a JSON file created from the application's DesignCompose annotations, check for possible errors in the document such as missing or incorrectly named nodes
+- Check/update keywords: Upload a new JSON file created from the application's DesignCompose annotations
+- Sync Prototype changes: Copies the interactive fields from the JS API to a data area that the REST API can fetch (since our webservice can't talk to the JS API). This needs to be run anytime an interaction changes.
 
 ## Building the plugin
 
@@ -55,10 +55,25 @@ That's it! Visual Studio Code will regenerate the JavaScript file every time you
 Add the plugin to your local Figma:
 
 ## Running the plugin in Figma
+
 To run the development version of the plugin, you need to be running the Figma desktop application on a Windows or MacOS machine.
 
-* In a doc, right-click and open the plugins menu.
-* Select "Development"
-* Select "Import plugin from manifest"
-* Navigate to your `manifest.json` and press OK.
-* Once you've done this once, the plugin will be available directly in the "Development" menu option.
+- In a doc, right-click and open the plugins menu.
+- Select "Development"
+- Select "Import plugin from manifest"
+- Navigate to your `manifest.json` and press OK.
+- Once you've done this once, the plugin will be available directly in the "Development" menu option.
+
+## Network access restrictions
+
+> [!TIP]
+> You can use the `devAllowedDomains` field to define domains that you need
+> access to for development purposes.
+
+The [manifest.json](manifest.json) file defines an allowlist of domains that the
+plugin is permitted to load [cross-origin resources] from. Any changes that
+introduce dependencies on origins not covered by the existing allowlist will
+need to update the [networkAccess] field in the plugins's manifest file.
+
+[cross-origin resources]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[networkAccess]: https://www.figma.com/plugin-docs/manifest/#networkaccess

--- a/support-figma/extended-layout-plugin/manifest.json
+++ b/support-figma/extended-layout-plugin/manifest.json
@@ -12,5 +12,11 @@
     { "name": "Check document for errors", "command": "clippy" },
     { "name": "Check/update keywords", "command": "check-keywords" },
     { "name": "Sync Prototype changes", "command": "sync" }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://cdn.jsdelivr.net/gh/thomas-lowry/figma-plugin-ds/dist/figma-plugin-ds.css"
+    ],
+    "reasoning": "The plugin uses the stylesheet from https://github.com/thomas-lowry/figma-plugin-ds to make the UI consistent with the rest of the Figma UI (https://www.figma.com/plugin-docs/figma-components/)."
+  }
 }


### PR DESCRIPTION
This change defines the `networkAccess` field in the Figma plugin and widget's `manifest.json` files. This will prevent cross-origin requests to domains not matched by any item in the `allowedDomains` field and will update their Community pages to reflect that network access restrictions are in place (as opposed to "Unknown network access").

There are currently only two cross-origin requests being made. The first fetches the [figma-plugin-ds](https://github.com/thomas-lowry/figma-plugin-ds) stylesheet and the other(s) are made by the stylesheet in an attempt to load some Inter fonts from rsms.me using `@font-face`.

Figma pre-loads Inter for plugins to use making it unnecessary to fetch them again so I've intentionally excluded those domains from the allow-list. There are a few errors that show up in the dev console due to the CSP blocking the requests to fetch the fonts, but those can be safely ignored[^1].

I also added a section in the README's that calls out the network access restrictions.  The other changes were all formatting fixes applied by Prettier.

Fixes google/automotive-design-compose#65

[^1]: Technically only the Regular and Bold styles are being pre-loaded, but Figma appends `https://static.figma.com/webfont/` to the `font-src` directive in the CSP and the rest of the font family can be fetched from there if need be. This isn't officially documented anywhere as far as I can tell so it's probably better to just expand the allowlist if other fonts are needed.