### PR TITLE
Restore UntrackedTask annotations on Cargo tasks

### DIFF
--- a/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/InteractionTriggers.kt
+++ b/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/InteractionTriggers.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.android.designcompose.testapp.validation
 
 import androidx.activity.ComponentActivity

--- a/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildAndroidTask.kt
+++ b/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildAndroidTask.kt
@@ -16,7 +16,6 @@
 
 package com.android.designcompose.cargoplugin
 
-import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -28,8 +27,10 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
 /**
  * Cargo build task
@@ -43,6 +44,11 @@ import org.gradle.process.ExecOperations
  * @property androidAbi The ABI to build
  * @property compileApi The API version to build
  */
+@UntrackedTask(
+    because =
+        "Cargo has it's own up-to-date checks. Trying to reproduce them so that we don't need " +
+            "to run Cargo is infeasible, and any errors will cause out-of-date code to be included"
+)
 abstract class CargoBuildAndroidTask @Inject constructor(private val executor: ExecOperations) :
     CargoBuildTask() {
 

--- a/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildAndroidTask.kt
+++ b/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildAndroidTask.kt
@@ -16,6 +16,7 @@
 
 package com.android.designcompose.cargoplugin
 
+import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -30,7 +31,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.process.ExecOperations
-import javax.inject.Inject
 
 /**
  * Cargo build task

--- a/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
+++ b/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
@@ -22,9 +22,15 @@ import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.process.ExecOperations
 
+@UntrackedTask(
+    because =
+    "Cargo has it's own up-to-date checks. Trying to reproduce them so that we don't need " +
+            "to run Cargo is infeasible, and any errors will cause out-of-date code to be included"
+)
 abstract class CargoBuildHostTask @Inject constructor(private val executor: ExecOperations) :
     CargoBuildTask() {
 

--- a/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
+++ b/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
@@ -28,7 +28,7 @@ import org.gradle.process.ExecOperations
 
 @UntrackedTask(
     because =
-    "Cargo has it's own up-to-date checks. Trying to reproduce them so that we don't need " +
+        "Cargo has it's own up-to-date checks. Trying to reproduce them so that we don't need " +
             "to run Cargo is infeasible, and any errors will cause out-of-date code to be included"
 )
 abstract class CargoBuildHostTask @Inject constructor(private val executor: ExecOperations) :


### PR DESCRIPTION
Gradle tries to optimize build times by detecting when tasks do not need to be re-run. This works well for many tasks, but gets tricker for more complex ones, such running `Cargo build`. While you can add configuration to inform Gradle of task inputs and outputs, so that it can decide whether a task is up to date or not, this is very difficult to do for a Cargo build, as there isn't a known mechanism for detecting all of the inputs that Cargo would use to decide what to rebuild.  Also, Cargo already has it's own up-to-date checks and they generally complete within a few milliseconds.

The `@UntrackedTask` annotation informs Gradle to not try to track whether the task is up-to-date and can be skipped, and instead tells it to always run the task. The annotation had been applied to the original CargoBuildTask, but that task was refactored into the `CargoBuildHostTask` and `CargoBuildAndroidTask`. Apparently the annotation doesn't apply to descendants of the base class. Applying the annotation to the new tasks fixes the below issue.

Fixes #697