### PR TITLE
Update dependabot.yml to target main again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
     directory: /
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     groups:
       github-workflow-dependency-patches:
         update-types:
@@ -44,7 +44,7 @@ updates:
     directory: "/.github/actions/build-figma-resource"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     groups:
       github-action-dependency-patches:
         update-types:
@@ -58,7 +58,7 @@ updates:
     directory: /
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     allow:
       - dependency-type: "all"
     groups:
@@ -74,7 +74,7 @@ updates:
     directory: /docs
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     groups:
       jekyll-dependency-patches:
         update-types:
@@ -87,7 +87,7 @@ updates:
     directory: /support-figma/auto-content-preview-widget
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     groups:
       figma-widget-dependency-patches:
         update-types:
@@ -100,7 +100,7 @@ updates:
     directory: /support-figma/extended-layout-plugin
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     groups:
       figma-plugin-dependency-patches:
         update-types:
@@ -116,7 +116,7 @@ updates:
     - gradle-plugin-portal
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "feature/rustlayout"
+    target-branch: "main"
     # Dependabot groups seem to be busted for Gradle. Uncommenting this will prevent
     # PRs from being created for Gradle dependencies.
     # groups:


### PR DESCRIPTION
I thought I'd fixed this in the rustlayout merge, but perhaps I lost a commit.