### PR TITLE
Add BSD-3 Clause license to cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -125,6 +125,7 @@ allow = [
     "OpenSSL", # Notice
     # "Apache-2.0 WITH LLVM-exception",
     "Zlib", # Notice
+    "BSD-3-Clause", # Notice
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
An update that went in with dependabot added a dependency that uses it.