### PR TITLE
Fix DesignCompose Integration tests

### DIFF
--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -119,7 +119,6 @@ dependencies {
 
     debugImplementation(libs.androidx.compose.ui.tooling)
 
-    androidTestImplementation(project(":test:internal"))
     androidTestImplementation(project(":test"))
     androidTestImplementation(kotlin("test"))
     androidTestImplementation(libs.google.truth)

--- a/integration-tests/validation/build.gradle.kts
+++ b/integration-tests/validation/build.gradle.kts
@@ -129,7 +129,6 @@ dependencies {
 
     androidTestImplementation(testFixtures(project(":designcompose")))
     androidTestImplementation(project(":test"))
-    androidTestImplementation(project(":test:internal"))
     androidTestImplementation(kotlin("test"))
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.junit)


### PR DESCRIPTION
The internal-test dependency wasn't supposed to be added to Android Integration tests. It contains Robolectric dependencies which don't work in an Android environment.

To test: Run ./gradlew designcompose:connectedAndroidTest validation-app:connectedAndroidTest