### PR TITLE
Disable the large fetch test.

### DIFF
--- a/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/JniFetchTests.kt
+++ b/designcompose/src/androidTest/kotlin/com/android/designcompose/figmaIntegrationTests/JniFetchTests.kt
@@ -86,11 +86,11 @@ class JniFetchTests {
         testFetch(largeDocID)
     }
 
-    @Test
-    fun veryLargeFetch() {
-        testFetch(veryLargeDocID)
-    }
-
+    //    @Test
+    //    fun veryLargeFetch() {
+    //        testFetch(veryLargeDocID)
+    //    }
+    //
     @Test
     fun invalidToken() {
         assertFailsWith(AccessDeniedException::class) {


### PR DESCRIPTION
It might just be too big. The test takes too long to complete, if it does complete.