### PR TITLE
Fix test-all's ktfmt check

### DIFF
--- a/dev-scripts/test-all.sh
+++ b/dev-scripts/test-all.sh
@@ -124,7 +124,8 @@ else
   echo "actionlint not installed, skipping."
 fi
 
-run_cmd "KTFmt Check" . ./gradlew ktfmtCheck ktfmtCheckBuildScripts --no-configuration-cache
+run_cmd "KTFmt Check Build Scripts" . ./gradlew ktfmtCheckBuildScripts --no-configuration-cache
+run_cmd "KTFmt Check" . ./gradlew ktfmtCheck
 run_cmd "Cargo Fmt" . cargo-fmt --all --check
 
 run_cmd "Cargo Test" . cargo test --all-targets --all-features


### PR DESCRIPTION
Updates to the ktfmt plugin caused an internal dependency issue that needed to be fixed in #784. A similar fix is needed here.