### PR TITLE
Closes #813: Create a tool that outputs the version info of a .dcf file

### DIFF
--- a/crates/figma_import/Cargo.toml
+++ b/crates/figma_import/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 reflection = ["serde-reflection", "serde-generate", "clap"]
 http_mock = ["phf"]
 fetch = ["clap"]
+dcf_info = ["clap"]
 
 [dependencies]
 "ureq" = "2"
@@ -53,3 +54,8 @@ required-features = ["reflection"]
 name = "fetch"
 path = "src/bin/fetch.rs"
 required-features = ["fetch"]
+
+[[bin]]
+name = "dcf_info"
+path = "src/bin/dcf_info.rs"
+required-features = ["dcf_info"]

--- a/crates/figma_import/README.md
+++ b/crates/figma_import/README.md
@@ -34,3 +34,7 @@ Currently `figma_import` uses the Rust `bincode` serialization format to encode 
 ### Application binaries
 
 * `reflection` generates Java code to deserialize the `bincode` encoded `toolkit_schema` and `serialized_document` types.
+* `dcf_info` deserializes a serialized DesignCompose file (.dcf) and prints out some basic data about the file.
+  * Usage: `cargo run --bin dcf_info --features=dcf_info <path>`
+* `fetch` queries Figma for a file with specified nodes, then processes and serializes the response, and saves it into a .dcf file.
+  * Usage: `cargo run --bin fetch --features=fetch -- --doc-id=<figma doc ID> --api-key=<figma API key>--output=<output file> --nodes=<nodes to retrieve>`

--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Utility program to parse a .dcf file and print out the header and version info for the file.
+
+use bincode::Options;
+use clap::Parser;
+use figma_import::{SerializedDesignDoc, SerializedDesignDocHeader};
+
+#[derive(Debug)]
+struct ParseError(String);
+impl From<bincode::Error> for ParseError {
+    fn from(e: bincode::Error) -> Self {
+        eprintln!("Error during deserialization: {:?}", e);
+        ParseError(format!("Error during deserialization: {:?}", e))
+    }
+}
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        eprintln!("Error opening file: {:?}", e);
+        ParseError(format!("Error opening file: {:?}", e))
+    }
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    // Path to the .dcf file to deserialize
+    dcf_file: std::path::PathBuf,
+}
+
+fn dcf_info(args: Args) -> Result<(), ParseError> {
+    let file_contents = std::fs::read(args.dcf_file)?;
+    let bytes = file_contents.as_slice();
+
+    // Deserialize the header
+    let header: SerializedDesignDocHeader = bincode::deserialize(bytes)?;
+    let header_size = bincode::serialized_size(&header)? as usize;
+
+    println!("Deserialized header");
+    println!("  DC Version: {}", header.version);
+
+    let current_version = SerializedDesignDocHeader::current().version;
+    if header.version != current_version {
+        println!(
+            "Header version {} does not match current version {}, aborting",
+            header.version, current_version
+        );
+        return Err(ParseError("Version mismatch".to_string()));
+    }
+
+    // Deserialize the document
+    let doc: SerializedDesignDoc = bincode::Options::deserialize(
+        bincode::Options::with_limit(
+            bincode::config::DefaultOptions::new().with_fixint_encoding().allow_trailing_bytes(),
+            100 * 1024 * 1024, // Max 100MB
+        ),
+        &bytes[header_size..],
+    )?;
+
+    println!("Deserialized file");
+    println!("  Doc ID: {}", doc.id);
+    println!("  Figma Version: {}", doc.version);
+    println!("  Name: {}", doc.name);
+    println!("  Last Modified: {}", doc.last_modified);
+    Ok(())
+}
+
+fn main() {
+    let args = Args::parse();
+    if let Err(e) = dcf_info(args) {
+        eprintln!("dcf_info failed: {:?}", e);
+        std::process::exit(1);
+    }
+}

--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -85,6 +85,11 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
         version: doc.get_version(),
         id: doc.get_document_id(),
     };
+    println!("Fetched document");
+    println!("  Doc ID: {}", doc.get_document_id());
+    println!("  Version: {}", doc.get_version());
+    println!("  Name: {}", doc.get_name());
+    println!("  Last Modified: {}", doc.last_modified().clone());
     // We don't bother with serialization headers or image sessions with
     // this tool.
     let output = std::fs::File::create(args.output)?;


### PR DESCRIPTION
Output the file name, ID, version, and timestamp. Also do this in the fetch tool.