### PR TITLE
Closes #855: Add support to parse baseline alignment, diamond stroke cap

### DIFF
--- a/crates/figma_import/src/figma_schema.rs
+++ b/crates/figma_import/src/figma_schema.rs
@@ -605,6 +605,7 @@ pub enum LayoutAlignItems {
     Center,
     Max,
     SpaceBetween,
+    Baseline, // Not supported
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
@@ -769,6 +770,7 @@ pub enum StrokeCap {
     LineArrow,
     TriangleArrow,
     CircleFilled,
+    DiamondFilled, // Not supported
 }
 
 fn default_stroke_cap() -> StrokeCap {

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -143,12 +143,14 @@ fn compute_layout(node: &Node, parent: Option<&Node>) -> ViewStyle {
             LayoutAlignItems::Max => AlignItems::FlexEnd,
             LayoutAlignItems::Min => AlignItems::FlexStart,
             LayoutAlignItems::SpaceBetween => AlignItems::FlexStart, // XXX
+            LayoutAlignItems::Baseline => AlignItems::FlexStart, // Not supported, default to FlexStart
         };
         style.justify_content = match frame.primary_axis_align_items {
             LayoutAlignItems::Center => JustifyContent::Center,
             LayoutAlignItems::Max => JustifyContent::FlexEnd,
             LayoutAlignItems::Min => JustifyContent::FlexStart,
             LayoutAlignItems::SpaceBetween => JustifyContent::SpaceBetween,
+            LayoutAlignItems::Baseline => JustifyContent::FlexStart, // Not supported, default to FlexStart
         };
         // The toolkit picks "Stretch" as a sensible default, but we don't
         // want that for Figma elements.


### PR DESCRIPTION
This avoid serialization errors.