### PR TITLE
Update GitHub pages deploy action to 4.0.5.

### DIFF
--- a/.github/workflows/giithub-pages.yml
+++ b/.github/workflows/giithub-pages.yml
@@ -95,4 +95,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
This should fix our docs upload problem.