### PR TITLE
Reduce the frequency of Dependabot version updates by only scheduling it to run on Fridays.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,10 @@ updates:
       github-workflow-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
       interval: weekly
-      day: wednesday
+      day: friday
 
   # A directory of "/" only actually includes .github/workflows.
   # A separate section is needed for our custom actions
@@ -49,10 +49,10 @@ updates:
       github-action-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
       interval: weekly
-      day: wednesday
+      day: friday
 
   - package-ecosystem: cargo
     directory: /
@@ -65,10 +65,10 @@ updates:
       rust-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
       interval: weekly
-      day: tuesday
+      day: friday
 
   - package-ecosystem: bundler
     directory: /docs
@@ -79,9 +79,10 @@ updates:
       jekyll-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
-      interval: monthly
+      interval: weekly
+      day: friday
 
   - package-ecosystem: npm
     directory: /support-figma/auto-content-preview-widget
@@ -92,9 +93,10 @@ updates:
       figma-widget-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
-      interval: monthly
+      interval: weekly
+      day: friday
 
   - package-ecosystem: npm
     directory: /support-figma/extended-layout-plugin
@@ -105,9 +107,10 @@ updates:
       figma-plugin-dependency-patches:
         update-types:
         - "patch"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     schedule:
-      interval: monthly
+      interval: weekly
+      day: friday
 
   - package-ecosystem: gradle
     directory: "/"
@@ -117,12 +120,11 @@ updates:
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
     target-branch: "main"
-    # Dependabot groups seem to be busted for Gradle. Uncommenting this will prevent
-    # PRs from being created for Gradle dependencies.
-    # groups:
-    #   gradle-dependencies-patches:
-    #     update-types:
-    #     - "patch"
-    open-pull-requests-limit: 3
+    groups:
+      gradle-dependencies-patches:
+        update-types:
+        - "patch"
+    open-pull-requests-limit: 5
     schedule:
-      interval: daily
+      interval: weekly
+      day: friday


### PR DESCRIPTION
This will make it easer to batch approve them and reduce the time spent on updates.