### PR TITLE
Closes #948: Remove support for interface inheritance

### DIFF
--- a/annotation/src/main/java/com/android/designcompose/annotation/Builder.kt
+++ b/annotation/src/main/java/com/android/designcompose/annotation/Builder.kt
@@ -30,7 +30,6 @@ annotation class DesignDoc(val id: String, val version: String = "0")
  * Generate a @Composable function that renders the given node
  *
  * @param node the name of the Figma node
- * @param override set to true if this function overrides a function. Defaulted to false
  * @param hideDesignSwitcher set to true if this is a root node and you do not want to show the
  *   design switcher. Defaulted to false
  * @param isRoot set to true if this is the root node. All customizations should be set in a root
@@ -40,7 +39,6 @@ annotation class DesignDoc(val id: String, val version: String = "0")
 @Target(AnnotationTarget.FUNCTION)
 annotation class DesignComponent(
     val node: String,
-    val override: Boolean = false,
     val hideDesignSwitcher: Boolean = false,
     val isRoot: Boolean = false
 )

--- a/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MediaAdapter.kt
+++ b/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MediaAdapter.kt
@@ -397,7 +397,7 @@ class MediaAdapter(
         currentMetadata: MediaItemMetadata?,
         onTap: TapCallback,
         key: String?,
-        media: CenterDisplayDoc,
+        media: CenterDisplayGen,
     ) {
         val (icon, setIcon) = remember { mutableStateOf<Bitmap?>(null) }
 
@@ -427,7 +427,7 @@ class MediaAdapter(
     private fun MediaNavButton(
         item: MediaItemMetadata,
         browseStack: MediaBrowseStack,
-        media: CenterDisplayDoc,
+        media: CenterDisplayGen,
     ) {
         val (icon, setIcon) = remember { mutableStateOf<Bitmap?>(null) }
         val navButtonType =
@@ -458,7 +458,7 @@ class MediaAdapter(
     }
 
     @Composable
-    fun getNowPlaying(media: CenterDisplayDoc): MediaNowPlaying {
+    fun getNowPlaying(media: CenterDisplayGen): MediaNowPlaying {
         val nowPlaying = MediaNowPlaying()
 
         // Observe now playing metadata
@@ -623,7 +623,7 @@ class MediaAdapter(
     private fun getSourceButtons(
         sources: MediaSourcesProvider,
         selectedPackageName: ComponentName?,
-        media: CenterDisplayDoc,
+        media: CenterDisplayGen,
     ): ListContent {
         val getSourceButtonType = { index: Int ->
             val source = sources.list[index]
@@ -661,7 +661,7 @@ class MediaAdapter(
         list: FutureData<List<MediaItemMetadata>>?,
         browseFunc: (MediaItemMetadata?) -> Unit,
         playFunc: (PlaybackViewModel.PlaybackController?, MediaItemMetadata) -> Unit,
-        media: CenterDisplayDoc,
+        media: CenterDisplayGen,
         showSectionTitles: Boolean = true,
     ): ListContent {
         if (list == null) return { ListContentData { _ -> } }
@@ -689,7 +689,7 @@ class MediaAdapter(
         list: List<MediaItemMetadata>?,
         browseFunc: (MediaItemMetadata?) -> Unit,
         playFunc: (PlaybackViewModel.PlaybackController?, MediaItemMetadata) -> Unit,
-        media: CenterDisplayDoc,
+        media: CenterDisplayGen,
         showSectionTitles: Boolean = true,
     ): ListContent {
         if (list == null) return { ListContentData { _ -> } }
@@ -830,7 +830,7 @@ class MediaAdapter(
     }
 
     @Composable
-    fun getBrowse(media: CenterDisplayDoc): MediaBrowse {
+    fun getBrowse(media: CenterDisplayGen): MediaBrowse {
         val browse = MediaBrowse()
 
         // Observer the currently browsing media source
@@ -937,7 +937,7 @@ class MediaAdapter(
     }
 
     @Composable
-    fun getSearch(media: CenterDisplayDoc): MediaSearch {
+    fun getSearch(media: CenterDisplayGen): MediaSearch {
         var search = MediaSearch()
 
         val (query, setQuery) = remember { mutableStateOf("") }


### PR DESCRIPTION
With design modules available, there should be no need for interface inheritance in @DesignDoc interfaces. Remove support for them and show an error if inheritance is attempted. In order to support upgrading the Compose compiler, which doesn't support default args in open functions, change the generated code to create a class instead of an interface.