### PR TITLE
Cherrypick: Check size of stops of gradient background (#1036)

### DIFF
--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -43,6 +43,7 @@ use layout::styles::{
     AlignContent, AlignItems, AlignSelf, FlexDirection, ItemSpacing, JustifyContent, PositionType,
 };
 use layout::types::Dimension;
+use log::error;
 use unicode_segmentation::UnicodeSegmentation;
 //::{Taffy, Dimension, JustifyContent, Size, AvailableSpace, FlexDirection};
 
@@ -591,20 +592,25 @@ fn compute_background(
 
         let stops = &gradient.gradient_stops;
 
-        for s in stops {
-            let c = crate::Color::from_f32s(
-                s.color.r,
-                s.color.g,
-                s.color.b,
-                s.color.a * last_paint.opacity,
-            );
+        if stops.is_empty() {
+            error!("No stops found for linear gradient {:?}", gradient);
+            Background::None
+        } else {
+            for s in stops {
+                let c = crate::Color::from_f32s(
+                    s.color.r,
+                    s.color.g,
+                    s.color.b,
+                    s.color.a * last_paint.opacity,
+                );
 
-            let g = (s.position, c);
+                let g = (s.position, c);
 
-            g_stops.push(g);
+                g_stops.push(g);
+            }
+
+            Background::LinearGradient { start_x, start_y, end_x, end_y, color_stops: g_stops }
         }
-
-        Background::LinearGradient { start_x, start_y, end_x, end_y, color_stops: g_stops }
     } else if let PaintData::GradientAngular { gradient } = &last_paint.data {
         let center_x = gradient.gradient_handle_positions[0].x();
         let center_y = gradient.gradient_handle_positions[0].y();
@@ -621,20 +627,25 @@ fn compute_background(
 
         let stops = &gradient.gradient_stops;
 
-        for s in stops {
-            let c = crate::Color::from_f32s(
-                s.color.r,
-                s.color.g,
-                s.color.b,
-                s.color.a * last_paint.opacity,
-            );
+        if stops.is_empty() {
+            error!("No stops found for angular gradient {:?}", gradient);
+            Background::None
+        } else {
+            for s in stops {
+                let c = crate::Color::from_f32s(
+                    s.color.r,
+                    s.color.g,
+                    s.color.b,
+                    s.color.a * last_paint.opacity,
+                );
 
-            let g = (s.position, c);
+                let g = (s.position, c);
 
-            g_stops.push(g);
+                g_stops.push(g);
+            }
+
+            Background::AngularGradient { center_x, center_y, angle, scale, color_stops: g_stops }
         }
-
-        Background::AngularGradient { center_x, center_y, angle, scale, color_stops: g_stops }
     } else if let PaintData::GradientRadial { gradient } = &last_paint.data {
         let center_x = gradient.gradient_handle_positions[0].x();
         let center_y = gradient.gradient_handle_positions[0].y();
@@ -653,20 +664,25 @@ fn compute_background(
 
         let stops = &gradient.gradient_stops;
 
-        for s in stops {
-            let c = crate::Color::from_f32s(
-                s.color.r,
-                s.color.g,
-                s.color.b,
-                s.color.a * last_paint.opacity,
-            );
+        if stops.is_empty() {
+            error!("No stops found for radial gradient {:?}", gradient);
+            Background::None
+        } else {
+            for s in stops {
+                let c = crate::Color::from_f32s(
+                    s.color.r,
+                    s.color.g,
+                    s.color.b,
+                    s.color.a * last_paint.opacity,
+                );
 
-            let g = (s.position, c);
+                let g = (s.position, c);
 
-            g_stops.push(g);
+                g_stops.push(g);
+            }
+
+            Background::RadialGradient { center_x, center_y, radius, angle, color_stops: g_stops }
         }
-
-        Background::RadialGradient { center_x, center_y, radius, angle, color_stops: g_stops }
     } else if let PaintData::GradientDiamond { gradient } = &last_paint.data {
         let center_x = gradient.gradient_handle_positions[0].x();
         let center_y = gradient.gradient_handle_positions[0].y();
@@ -685,20 +701,25 @@ fn compute_background(
 
         let stops = &gradient.gradient_stops;
 
-        for s in stops {
-            let c = crate::Color::from_f32s(
-                s.color.r,
-                s.color.g,
-                s.color.b,
-                s.color.a * last_paint.opacity,
-            );
+        if stops.is_empty() {
+            error!("No stops found for diamond gradient {:?}", gradient);
+            Background::None
+        } else {
+            for s in stops {
+                let c = crate::Color::from_f32s(
+                    s.color.r,
+                    s.color.g,
+                    s.color.b,
+                    s.color.a * last_paint.opacity,
+                );
 
-            let g = (s.position, c);
+                let g = (s.position, c);
 
-            g_stops.push(g);
+                g_stops.push(g);
+            }
+
+            Background::RadialGradient { center_x, center_y, radius, angle, color_stops: g_stops }
         }
-
-        Background::RadialGradient { center_x, center_y, radius, angle, color_stops: g_stops }
     } else {
         Background::None
     }

--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -1230,42 +1230,84 @@ internal fun Background.asBrush(document: DocContent, density: Float): Pair<Brus
         }
         is Background.LinearGradient -> {
             val linearGradient = this
-            return Pair(
-                RelativeLinearGradient(
-                    linearGradient.color_stops.map { convertColor(it.field1) }.toList(),
-                    linearGradient.color_stops.map { it.field0 }.toList(),
-                    start = Offset(linearGradient.start_x, linearGradient.start_y),
-                    end = Offset(linearGradient.end_x, linearGradient.end_y)
-                ),
-                1.0f
-            )
+            when (linearGradient.color_stops.size) {
+                0 -> {
+                    Log.e(TAG, "No stops found for the linear gradient")
+                    return null
+                }
+                1 -> {
+                    Log.w(TAG, "Single stop found for the linear gradient and do it as a fill")
+                    return Pair(
+                        SolidColor(convertColor(linearGradient.color_stops[0].field1)),
+                        1.0f
+                    )
+                }
+                else ->
+                    return Pair(
+                        RelativeLinearGradient(
+                            linearGradient.color_stops.map { convertColor(it.field1) }.toList(),
+                            linearGradient.color_stops.map { it.field0 }.toList(),
+                            start = Offset(linearGradient.start_x, linearGradient.start_y),
+                            end = Offset(linearGradient.end_x, linearGradient.end_y)
+                        ),
+                        1.0f
+                    )
+            }
         }
         is Background.RadialGradient -> {
             val radialGradient = this
-            return Pair(
-                RelativeRadialGradient(
-                    colors = radialGradient.color_stops.map { convertColor(it.field1) },
-                    stops = radialGradient.color_stops.map { it.field0 },
-                    center = Offset(radialGradient.center_x, radialGradient.center_y),
-                    radiusX = radialGradient.radius[0],
-                    radiusY = radialGradient.radius[1],
-                    angle = radialGradient.angle
-                ),
-                1.0f
-            )
+            return when (radialGradient.color_stops.size) {
+                0 -> {
+                    Log.e(TAG, "No stops found for the radial gradient")
+                    return null
+                }
+                1 -> {
+                    Log.w(TAG, "Single stop found for the radial gradient and do it as a fill")
+                    return Pair(
+                        SolidColor(convertColor(radialGradient.color_stops[0].field1)),
+                        1.0f
+                    )
+                }
+                else ->
+                    return Pair(
+                        RelativeRadialGradient(
+                            colors = radialGradient.color_stops.map { convertColor(it.field1) },
+                            stops = radialGradient.color_stops.map { it.field0 },
+                            center = Offset(radialGradient.center_x, radialGradient.center_y),
+                            radiusX = radialGradient.radius[0],
+                            radiusY = radialGradient.radius[1],
+                            angle = radialGradient.angle
+                        ),
+                        1.0f
+                    )
+            }
         }
         is Background.AngularGradient -> {
             val angularGradient = this
-            return Pair(
-                RelativeSweepGradient(
-                    center = Offset(angularGradient.center_x, angularGradient.center_y),
-                    angle = angularGradient.angle,
-                    scale = angularGradient.scale,
-                    colors = angularGradient.color_stops.map { convertColor(it.field1) },
-                    stops = angularGradient.color_stops.map { it.field0 }
-                ),
-                1.0f
-            )
+            return when (angularGradient.color_stops.size) {
+                0 -> {
+                    Log.e(TAG, "No stops found for the angular gradient")
+                    return null
+                }
+                1 -> {
+                    Log.w(TAG, "Single stop found for the angular gradient and do it as a fill")
+                    return Pair(
+                        SolidColor(convertColor(angularGradient.color_stops[0].field1)),
+                        1.0f
+                    )
+                }
+                else ->
+                    return Pair(
+                        RelativeSweepGradient(
+                            center = Offset(angularGradient.center_x, angularGradient.center_y),
+                            angle = angularGradient.angle,
+                            scale = angularGradient.scale,
+                            colors = angularGradient.color_stops.map { convertColor(it.field1) },
+                            stops = angularGradient.color_stops.map { it.field0 }
+                        ),
+                        1.0f
+                    )
+            }
         }
     }
     return null


### PR DESCRIPTION
Figma is returning empty stops for gradients. Gradients can also have a
single stop set.
Also add logging when size is smaller than 2.