### PR TITLE
Fix build for MacOS

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -26,6 +26,7 @@ spotless {
     }
     kotlinGradle { ktfmt(libs.versions.ktfmt.get()).kotlinlangStyle() }
 }
+kotlin { jvmToolchain(libs.versions.jvmToolchain.get().toInt())}
 
 dependencies {
     implementation(libs.android.gradlePlugin)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -24,3 +24,8 @@ dependencyResolutionManagement {
     }
     versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 }
+plugins {
+    // Downloads the required Java Toolchain, if needed.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+

--- a/designcompose/src/main/java/com/android/designcompose/Jni.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Jni.kt
@@ -102,8 +102,12 @@ internal object Jni {
 
             // Find the JNI library and set up an input stream
             val jniStream =
-                javaClass.classLoader?.getResourceAsStream("libdc_jni.so")
-                    ?: throw FileNotFoundException("JNI missing")
+                with(javaClass.classLoader!!) {
+                    getResourceAsStream("libdc_jni.so")
+                        ?: getResourceAsStream("libdc_jni.dylib")
+                        ?: getResourceAsStream("libdc_jni.dll")
+                        ?: throw FileNotFoundException("JNI missing")
+                }
 
             // Copy the library out of the jar file into the filesystem so we can load it.
             val tempFile = File.createTempFile("libdc_jni", ".so")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 # DesignCompose
 designcompose = "0.27.0-SNAPSHOT"
 
+jvmToolchain = "17"
+
 #Android Gradle Plugin
 agp = "8.3.2"
 # The minimum supported AGP version for DesignCompose Apps

--- a/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
+++ b/plugins/cargo-plugin/src/main/kotlin/com/android/designcompose/cargoplugin/CargoBuildHostTask.kt
@@ -42,7 +42,9 @@ abstract class CargoBuildHostTask @Inject constructor(private val executor: Exec
 
         fs.copy {
             it.from(cargoTargetDir.get().dir(buildType.get().toString()))
-            it.include("*.so")
+            it.include("*.so") // Linux
+            it.include("*.dylib") // Mac
+            it.include("*.dll") // Windows
             it.into(outLibDir)
         }
     }


### PR DESCRIPTION
Handle the different dynamic library suffixes for Mac (and Windows too, why not)

Finally (?) add proper handling for missing Java runtime versions (when your install Java is at least high enough to initially run Gradle)