### PR TITLE
Migrate the Layout Nodes structs to the Layout crate

### DIFF
--- a/crates/dc_jni/src/jni.rs
+++ b/crates/dc_jni/src/jni.rs
@@ -19,11 +19,11 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::error_map::map_err_to_exception;
 use android_logger::Config;
-use figma_import::layout::{LayoutNodeList, LayoutParentChildren};
 use figma_import::{fetch_doc, ConvertRequest, ProxyConfig};
 use jni::objects::{JByteArray, JClass, JObject, JString, JValue, JValueGen};
 use jni::sys::{jboolean, jint, JNI_VERSION_1_6};
 use jni::{JNIEnv, JavaVM};
+use layout::layout_node::{LayoutNodeList, LayoutParentChildren};
 use layout::{LayoutChangedResponse, LayoutManager};
 use lazy_static::lazy_static;
 use log::{error, info, LevelFilter};
@@ -217,7 +217,7 @@ fn jni_add_nodes<'local>(
                                 node.layout_id,
                                 node.parent_layout_id,
                                 node.child_index,
-                                node.style.layout_style,
+                                node.style,
                                 node.name,
                                 java_jni_measure_text,
                             );
@@ -226,7 +226,7 @@ fn jni_add_nodes<'local>(
                                 node.layout_id,
                                 node.parent_layout_id,
                                 node.child_index,
-                                node.style.layout_style,
+                                node.style,
                                 node.name,
                                 None,
                                 node.fixed_width,

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -26,7 +26,6 @@ mod extended_layout_schema;
 mod fetch;
 mod figma_schema;
 mod image_context;
-pub mod layout;
 pub mod reaction_schema;
 mod serialized_document;
 pub mod toolkit_font_style;

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -164,9 +164,11 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
     tracer
         .trace_type::<layout::layout_manager::LayoutChangedResponse>(&samples)
         .expect("couldn't trace LayoutChangedResponse");
-    tracer.trace_type::<crate::layout::LayoutNode>(&samples).expect("couldn't trace LayoutNode");
     tracer
-        .trace_type::<crate::layout::LayoutNodeList>(&samples)
+        .trace_type::<layout::layout_node::LayoutNode>(&samples)
+        .expect("couldn't trace LayoutNode");
+    tracer
+        .trace_type::<layout::layout_node::LayoutNodeList>(&samples)
         .expect("couldn't trace LayoutNodeList");
 
     tracer

--- a/crates/layout/src/layout_node.rs
+++ b/crates/layout/src/layout_node.rs
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `figma_import` fetches a document from Figma and converts nodes from the document
-//! to toolkit_schema Views, which can then be further customized (changing text or style)
-//! and presented in other components that implement logic.
-//!
-//! The goal of this crate is to perform the mapping from Figma to the toolkit; it does
-//! not provide any kind of UI logic mapping.
-
-use crate::toolkit_style::ViewStyle;
+use crate::layout_style::LayoutStyle;
 use serde::{Deserialize, Serialize};
 
 // A representation of a Figma node to register for layout.
@@ -28,7 +21,7 @@ pub struct LayoutNode {
     pub layout_id: i32,
     pub parent_layout_id: i32,
     pub child_index: i32,
-    pub style: ViewStyle,
+    pub style: LayoutStyle,
     pub name: String,
     pub use_measure_func: bool,
     pub fixed_width: Option<i32>,

--- a/crates/layout/src/lib.rs
+++ b/crates/layout/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate android_logger;
 extern crate log;
 pub mod layout_manager;
+pub mod layout_node;
 pub mod layout_style;
 pub mod styles;
 pub mod types;

--- a/designcompose/src/main/java/com/android/designcompose/Layout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Layout.kt
@@ -196,7 +196,7 @@ internal object LayoutManager {
                 layoutId,
                 parentLayoutId,
                 childIndex,
-                style,
+                style.layout_style,
                 name,
                 useMeasureFunc,
                 fixedWidth,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
@@ -141,7 +141,7 @@ internal fun updateLayoutTree(
                 layoutId,
                 parentLayoutId,
                 -1, // not childIdx!
-                resolvedNode.style,
+                resolvedNode.style.layout_style,
                 resolvedNode.view.name,
                 useMeasureFunc,
                 Optional.empty(),


### PR DESCRIPTION
While working on the Protobuf code I realized that we never finished changing the LayoutNode structs that are sent across the JNI to use LayoutStyle instead of the full ViewStyle. In order for me to finish the first set of Protobuf changes I'll need to get these moved to the proper crate.