### PR TITLE
Add missing description to the Build Figma Resource action

### DIFF
--- a/.github/actions/build-figma-resource/action.yml
+++ b/.github/actions/build-figma-resource/action.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 name: Build Figma resource
+description: "Reusable action for building Figma resources"
 
 inputs:
   resource:
@@ -23,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-    - name: Build 
+    - name: Build
       working-directory: support-figma/${{ inputs.resource }}
       run: npm ci; npm run build
       shell: bash


### PR DESCRIPTION
Looks like a new version of ActionLint was just released that started checking for descriptions. It's annoying that it updated on it's own but I don't see a way to both pin the version that's used and have it be updated by dependabot.