### PR TITLE
Fix #1093: Improve `dcf_info` tool to optionally dump file contents.

### DIFF
--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -19,7 +19,7 @@
 // Example:
 // `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf`
 // or
-// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill``
+// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill`
 
 use clap::Parser;
 use figma_import::load_design_doc;

--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -14,7 +14,12 @@
 
 // Utility program to parse a .dcf file and print its contents.
 // By default prints the header and file info.
-// Provide the optional `--dump` switch to dump the entire file contents.
+// Provide the optional `--node` or `-n` switch to dump figma document using
+// that node as root.
+// Example:
+// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf`
+// or
+// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill``
 
 use clap::Parser;
 use figma_import::load_design_doc;

--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -78,7 +78,7 @@ fn dcf_info(args: Args) -> Result<(), ParseError> {
 fn main() {
     let args = Args::parse();
     if let Err(e) = dcf_info(args) {
-        eprintln!("dcf_info failed: {:#?}", e);
+        eprintln!("dcf_info failed: {:?}", e);
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
See associated Issue for description.

Tim told me he's also working in this area, so I can close this as unnecessary if an improved workflow is incoming.