### PR TITLE
Enable printing of Rust backtraces in Robolectric tests, failFast to …

### DIFF
--- a/build-logic/src/main/kotlin/designcompose/conventions/roborazzi.gradle.kts
+++ b/build-logic/src/main/kotlin/designcompose/conventions/roborazzi.gradle.kts
@@ -33,6 +33,9 @@ project.pluginManager.withPlugin("com.android.base") {
                     maxParallelForks =
                         (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 
+                    environment("RUST_BACKTRACE", "1")
+                    failFast = true
+
                     testLogging {
                         events("passed", "failed")
                         showExceptions = true


### PR DESCRIPTION
…end execution early and make it easier to parse the output

Fixes #1102