### PR TITLE
Add recommended extensions and VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ node_modules
 # User settings dirs
 **/.idea/*
 !.idea/ktfmt.xml
-.vscode
+**/.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 local.properties
 
 #Other

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,19 @@
+{
+    "recommendations": [
+        "figma.figma-vscode-extension", // Figma!
+        "GitHub.vscode-pull-request-github", // Pull requests, comments, etc
+        "arahata.linter-actionlint", // Github Action linting
+        "xaver.clang-format", // Protobuf formatting
+        "vadimcn.vscode-lldb", // Needed for Rust debugging
+        "usernamehw.errorlens", // Not needed, very helpful
+        "tamasfe.even-better-toml", // TOML formatter
+        "fwcd.kotlin", // Basic Kotlin syntax
+        "bierner.markdown-preview-github-styles", // Get the Readme to render the way GitHub will render it
+        "davidanson.vscode-markdownlint", // Markdown linting and formatting
+        "plex.vscode-protolint", // Protobuf linting
+        "timonwong.shellcheck", // Shell script linting
+        "zxh404.vscode-proto3", // Needed for Protobuf linting
+        "redhat.vscode-yaml", // YAML formatting
+        "github.vscode-github-actions", // Github Action formatting and linting
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,43 @@
+{
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+        "editor.formatOnPaste": true,
+        "editor.formatOnSave": true
+    },
+    "[proto3]": {
+        "editor.defaultFormatter": "xaver.clang-format"
+    },
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "files.watcherExclude": {
+        "**/.gradle/**": true,
+        "**/build/**": true,
+        "**/build/.*/**": true,
+        "**/build/intermediates/**": true,
+        "**/build/kspCaches/**": true,
+        "**/target/**": true
+    },
+    "github.branchProtection": true,
+    "gitlens.advanced.messages": {
+        "suppressCreatePullRequestPrompt": true
+    },
+    "markdownlint.config": {
+        "MD037": false,
+        "MD052": false,
+        "line-length": {
+            "line_length": 100
+        },
+        "no-inline-html": false,
+        "single-h1": false
+    },
+    "protoc": {
+        "options": [
+            "--proto_path=${workspaceRoot}/proto/layout"
+        ]
+    },
+    "rust-analyzer.imports.merge.glob": false,
+    "rust-analyzer.testExplorer": true,
+    "search.exclude": {
+        "**/_site": true
+    }
+}


### PR DESCRIPTION
Open the root project in VSCode and it should recommend a set of extensions for you.

All settings in settings.json are "Workspace Settings". They'll be overwritten by your personal "User Settings".

Have I missed anything? I don't have anything for typescript, for example.