### PR TITLE
Migrate FlexWrap to new proto message

### DIFF
--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use dc_bundle::definition::layout::FlexWrap;
 use serde_reflection::{Samples, Tracer, TracerConfig};
 
 pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
@@ -47,9 +48,7 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
     tracer
         .trace_type::<dc_bundle::legacy_definition::layout::positioning::FlexDirection>(&samples)
         .expect("couldn't trace FlexDirection");
-    tracer
-        .trace_type::<crate::toolkit_layout_style::FlexWrap>(&samples)
-        .expect("couldn't trace FlexWrap");
+    tracer.trace_type::<FlexWrap>(&samples).expect("couldn't trace FlexWrap");
     tracer
         .trace_type::<crate::toolkit_font_style::FontStyle>(&samples)
         .expect("couldn't trace FontStyle");

--- a/crates/figma_import/src/toolkit_layout_style.rs
+++ b/crates/figma_import/src/toolkit_layout_style.rs
@@ -73,19 +73,6 @@ impl Default for Overflow {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum FlexWrap {
-    NoWrap,
-    Wrap,
-    WrapReverse,
-}
-
-impl Default for FlexWrap {
-    fn default() -> Self {
-        Self::NoWrap
-    }
-}
-
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum LayoutSizing {

--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -15,6 +15,7 @@
 //! `toolkit_style` contains all of the style-related types that `toolkit_schema::View`
 //! uses.
 
+use dc_bundle::definition::layout::FlexWrap;
 use layout::layout_style::LayoutStyle;
 use layout::types::Size;
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,7 @@ use std::collections::HashMap;
 use crate::{
     color::Color,
     toolkit_font_style::{FontStretch, FontStyle, FontWeight},
-    toolkit_layout_style::{Display, FlexWrap, LayoutSizing, Number, Overflow},
+    toolkit_layout_style::{Display, LayoutSizing, Number, Overflow},
     toolkit_schema::{ColorOrVar, NumOrVar},
 };
 
@@ -556,7 +557,7 @@ impl Default for NodeStyle {
             backdrop_filter: Vec::new(),
             blend_mode: BlendMode::default(),
             display_type: Display::default(),
-            flex_wrap: FlexWrap::default(),
+            flex_wrap: FlexWrap::NoWrap,
             grid_layout: None,
             grid_columns_rows: 0,
             grid_adaptive_min_size: 1,

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::f32::consts::PI;
 
 use crate::toolkit_font_style::{FontStyle, FontWeight};
-use crate::toolkit_layout_style::{FlexWrap, Overflow};
+use crate::toolkit_layout_style::Overflow;
 
 use crate::toolkit_style::{
     Background, FilterOp, FontFeature, GridLayoutType, GridSpan, LayoutTransform, LineHeight,
@@ -41,6 +41,7 @@ use crate::{
     },
 };
 
+use dc_bundle::definition::layout::FlexWrap;
 use dc_bundle::legacy_definition::layout::grid::ItemSpacing;
 use dc_bundle::legacy_definition::layout::positioning::{
     AlignContent, AlignItems, AlignSelf, FlexDirection, JustifyContent, PositionType,

--- a/proto/definition/layout/grid.proto
+++ b/proto/definition/layout/grid.proto
@@ -56,7 +56,7 @@ enum OverflowDirection {
 // Defines how flex items wrap when they exceed the available space.
 enum FlexWrap {
   FLEX_WRAP_UNSPECIFIED = 0;
-  FLEX_WRAP_NOWRAP = 1;
+  FLEX_WRAP_NO_WRAP = 1;
   FLEX_WRAP_WRAP = 2;
   FLEX_WRAP_WRAP_REVERSE = 3;
 }


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1280

## Full chain of PRs as of 2024-06-21

* PR #1210: `wb/froeht/proto-impl-rust` ➔ `wb/froeht/fix-proto-package-names`
* PR #1280: `wb/froeht/fix-proto-package-names` ➔ `main`

<!-- end git-machete generated -->
Please read #1209 before reviewing.

This PR is a bit of a tester, replacing the native FlexWrap enum with the one generated by the protobuf compiler.

As you can see I had to make a small change to the proto file to get it to behave properly (in this case the enum was being generated with "FLEX_WRAP_NO_WRAP" being converted to "FlexWrap::Nowrap" instead of "FlexWrap::NoWrap").