### PR TITLE
Add serde serialization traits to all protobuf messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "prost-build",
+ "serde",
  "thiserror",
 ]
 

--- a/crates/dc_proto/Cargo.toml
+++ b/crates/dc_proto/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.68"
 [dependencies]
 prost.workspace = true
 thiserror.workspace = true
+serde.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/crates/dc_proto/build.rs
+++ b/crates/dc_proto/build.rs
@@ -23,6 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     prost_config.message_attribute("DimensionProto.Auto", "#[derive(Copy)]");
     prost_config.message_attribute("DimensionProto.Undefined", "#[derive(Copy)]");
     prost_config.enum_attribute("Dimension", "#[derive(Copy)]");
+    prost_config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
 
     let proto_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()


### PR DESCRIPTION
This is needed so that we can start replacing the existing structs with the proto-generated structs.

I am intenionally not adding them to reflection.rs right now. That's most easily done when doing the replacement. (See #1210 for an example).