### PR TITLE
Fixes #1250: Move design/element/text to the modifier package.

### DIFF
--- a/proto/definition/modifier/text.proto
+++ b/proto/definition/modifier/text.proto
@@ -14,16 +14,11 @@
 
 syntax = "proto3";
 
-package com.android.designcompose.proto.definition.element;
+package com.android.designcompose.proto.definition.modifier;
 
 import "definition/element/color.proto";
 
 option java_multiple_files = true;
-
-// Text
-message Text {
-  string content = 1;
-}
 
 // Horizontal text alignment. This value aligns the text within its bounds.
 enum TextAlign {
@@ -51,7 +46,7 @@ enum TextOverflow {
 // A text shadow.
 message TextShadow {
   float blur_radius = 1;
-  Color color = 2;
+  element.Color color = 2;
   float offset_x = 3;
   float offset_y = 4;
 }

--- a/proto/definition/view/node_style.proto
+++ b/proto/definition/view/node_style.proto
@@ -19,7 +19,6 @@ package com.android.designcompose.proto.definition.view;
 import "definition/element/font.proto";
 import "definition/element/geometry.proto";
 import "definition/element/path.proto";
-import "definition/element/text.proto";
 import "definition/interaction/pointer.proto";
 import "definition/layout/display.proto";
 import "definition/layout/grid.proto";
@@ -28,6 +27,7 @@ import "definition/modifier/blend.proto";
 import "definition/modifier/filter.proto";
 import "definition/modifier/matrix_transform.proto";
 import "definition/modifier/shadow.proto";
+import "definition/modifier/text.proto";
 import "definition/plugin/meter_data.proto";
 
 option java_multiple_files = true;
@@ -52,10 +52,11 @@ message NodeStyle {
   definition.modifier.LayoutTransform relative_transform = 12;
 
   // Text layout
-  definition.element.TextAlign text_align = 13;
-  definition.element.TextAlignVertical text_align_vertical = 14;
-  definition.element.TextOverflow text_overflow = 15;
-  definition.element.TextShadow text_shadow = 16;
+  definition.modifier.TextAlign text_align = 13;
+  definition.modifier.TextAlignVertical text_align_vertical = 14;
+  definition.modifier.TextOverflow text_overflow = 15;
+  definition.modifier.TextShadow text_shadow = 16;
+
 
   // Size and layout
   definition.element.Size node_size = 17;

--- a/proto/definition/view/view.proto
+++ b/proto/definition/view/view.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package com.android.designcompose.proto.definition.view;
 
 import "definition/element/geometry.proto";
-import "definition/element/text.proto";
 import "definition/element/view_shape.proto";
 import "definition/interaction/reaction.proto";
 import "definition/layout/grid.proto";
@@ -83,7 +82,7 @@ message ViewData {
 
   oneof view_data {
     Container container = 1;
-    definition.element.Text text = 2;
+    string text = 2;
     StyledText styled_text = 3;
   }
 }


### PR DESCRIPTION
Fixes #1250: Move design/element/text to the modifier package.

<!-- start git-machete generated -->

# Based on PR #1262

## Full chain of PRs as of 2024-06-20

* PR #1258: `wb/froeht/move-text-modifier` ➔ `wb/froeht/clean-up-SDD-naming`
* PR #1262: `wb/froeht/clean-up-SDD-naming` ➔ `main`

<!-- end git-machete generated -->