### PR TITLE
Rename Serialized Design Doc to DesignCompose Definition

### DIFF
--- a/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
+++ b/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
@@ -16,10 +16,10 @@
 
 package com.android.designcompose.common
 
+import com.android.designcompose.serdegen.DesignComposeDefinition
+import com.android.designcompose.serdegen.DesignComposeDefinitionHeader
 import com.android.designcompose.serdegen.FigmaDocInfo
 import com.android.designcompose.serdegen.NodeQuery
-import com.android.designcompose.serdegen.SerializedDesignDoc
-import com.android.designcompose.serdegen.SerializedDesignDocHeader
 import com.android.designcompose.serdegen.ServerFigmaDoc
 import com.android.designcompose.serdegen.View
 import com.novi.bincode.BincodeDeserializer
@@ -31,8 +31,8 @@ import java.io.InputStream
 
 class GenericDocContent(
     var docId: DesignDocId,
-    private val header: SerializedDesignDocHeader,
-    val document: SerializedDesignDoc,
+    private val header: DesignComposeDefinitionHeader,
+    val document: DesignComposeDefinition,
     val variantViewMap: HashMap<String, HashMap<String, View>>,
     val variantPropertyMap: VariantPropertyMap,
     private val imageSessionData: ByteArray,
@@ -109,8 +109,8 @@ fun decodeDiskBaseDoc(
 
     val header = decodeHeader(deserializer, docId, feedback) ?: return null
 
-    // Disk loads are in the format of SerializedDesignDoc
-    val content = SerializedDesignDoc.deserialize(deserializer)
+    // Disk loads are in the format of DesignComposeDefinition
+    val content = DesignComposeDefinition.deserialize(deserializer)
     val imageSessionData = decodeImageSession(docBytes, deserializer)
     val variantMap = createVariantViewMap(content.views)
     val variantPropertyMap = createVariantPropertyMap(content.views)
@@ -207,9 +207,9 @@ private fun decodeHeader(
     deserializer: BincodeDeserializer,
     docId: DesignDocId,
     feedback: FeedbackImpl
-): SerializedDesignDocHeader? {
+): DesignComposeDefinitionHeader? {
     // Now attempt to deserialize the doc)
-    val header = SerializedDesignDocHeader.deserialize(deserializer)
+    val header = DesignComposeDefinitionHeader.deserialize(deserializer)
     if (header.version != FSAAS_DOC_VERSION) {
         feedback.documentDecodeVersionMismatch(FSAAS_DOC_VERSION, header.version, docId)
         return null

--- a/crates/dc_bundle/build.rs
+++ b/crates/dc_bundle/build.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     prost_config.compile_protos(
         &[
             proto_path.join("android_interface/jni_layout.proto"),
-            proto_path.join("toolkit/serialized_design_doc.proto"),
+            proto_path.join("definition/design_compose_definition.proto"),
         ],
         &[&proto_path],
     )?;

--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -22,7 +22,7 @@
 // `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill`
 
 use clap::Parser;
-use figma_import::load_design_doc;
+use figma_import::load_design_def;
 
 #[derive(Debug)]
 struct ParseError(String);
@@ -57,7 +57,7 @@ fn dcf_info(args: Args) -> Result<(), ParseError> {
     let file_path = &args.dcf_file;
     let node = args.node;
 
-    let (header, doc) = load_design_doc(file_path)?;
+    let (header, doc) = load_design_def(file_path)?;
 
     println!("Deserialized file");
     println!("  Header Version: {}", header.version);

--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -17,7 +17,7 @@ use std::io::Write;
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
 use figma_import::{
-    Document, NodeQuery, ProxyConfig, SerializedDesignDoc, SerializedDesignDocHeader,
+    DesignComposeDefinition, DesignComposeDefinitionHeader, Document, NodeQuery, ProxyConfig,
 };
 #[derive(Debug)]
 struct ConvertError(String);
@@ -92,7 +92,7 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
     let variable_map = doc.build_variable_map();
 
     // Build the serializable doc structure
-    let serializable_doc = SerializedDesignDoc {
+    let serializable_doc = DesignComposeDefinition {
         views,
         component_sets: doc.component_sets().clone(),
         images: doc.encoded_image_map(),
@@ -103,14 +103,14 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
         variable_map: variable_map,
     };
     println!("Fetched document");
-    println!("  DC Version: {}", SerializedDesignDocHeader::current().version);
+    println!("  DC Version: {}", DesignComposeDefinitionHeader::current().version);
     println!("  Doc ID: {}", doc.get_document_id());
     println!("  Version: {}", doc.get_version());
     println!("  Name: {}", doc.get_name());
     println!("  Last Modified: {}", doc.last_modified().clone());
     // We don't bother with serialization of image sessions with this tool.
     let mut output = std::fs::File::create(args.output)?;
-    let header = bincode::serialize(&SerializedDesignDocHeader::current())?;
+    let header = bincode::serialize(&DesignComposeDefinitionHeader::current())?;
     let doc = bincode::serialize(&serializable_doc)?;
     output.write_all(header.as_slice())?;
     output.write_all(doc.as_slice())?;

--- a/crates/figma_import/src/bin/fetch_layout.rs
+++ b/crates/figma_import/src/bin/fetch_layout.rs
@@ -15,8 +15,8 @@
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
 use figma_import::{
-    toolkit_layout_style::LayoutSizing, toolkit_schema::View, Document, NodeQuery, ProxyConfig,
-    SerializedDesignDoc, ViewData,
+    toolkit_layout_style::LayoutSizing, toolkit_schema::View, DesignComposeDefinition, Document,
+    NodeQuery, ProxyConfig, ViewData,
 };
 use layout::types::Dimension;
 use layout::LayoutManager;
@@ -257,7 +257,7 @@ fn fetch_impl(args: Args) -> Result<(), ConvertError> {
     let variable_map = doc.build_variable_map();
 
     // Build the serializable doc structure
-    let serializable_doc = SerializedDesignDoc {
+    let serializable_doc = DesignComposeDefinition {
         views,
         component_sets: doc.component_sets().clone(),
         images: doc.encoded_image_map(),

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -15,8 +15,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Document, ImageContextSession, NodeQuery, SerializedDesignDoc, SerializedDesignDocHeader,
-    ServerFigmaDoc,
+    DesignComposeDefinition, DesignComposeDefinitionHeader, Document, ImageContextSession,
+    NodeQuery, ServerFigmaDoc,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -101,7 +101,7 @@ pub fn fetch_doc(
 
         let variable_map = doc.build_variable_map();
 
-        let figma_doc = SerializedDesignDoc {
+        let figma_doc = DesignComposeDefinition {
             views,
             component_sets: doc.component_sets().clone(),
             images: doc.encoded_image_map(),
@@ -111,7 +111,7 @@ pub fn fetch_doc(
             id: doc.get_document_id(),
             variable_map: variable_map,
         };
-        let mut response = bincode::serialize(&SerializedDesignDocHeader::current())?;
+        let mut response = bincode::serialize(&DesignComposeDefinitionHeader::current())?;
         response.append(&mut bincode::serialize(&ServerFigmaDoc {
             figma_doc,
             errors: error_list,

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -20,6 +20,7 @@
 //! not provide any kind of UI logic mapping.
 mod color;
 mod component_context;
+mod design_definition;
 mod document;
 mod error;
 mod extended_layout_schema;
@@ -27,7 +28,6 @@ mod fetch;
 mod figma_schema;
 mod image_context;
 pub mod reaction_schema;
-mod serialized_document;
 pub mod toolkit_font_style;
 pub mod toolkit_layout_style;
 pub mod toolkit_schema;
@@ -36,14 +36,16 @@ mod transform_flexbox;
 mod utils;
 pub mod vector_schema;
 // Exports for library users
+pub use design_definition::{load_design_def, save_design_def};
+pub use design_definition::{
+    DesignComposeDefinition, DesignComposeDefinitionHeader, ServerFigmaDoc,
+};
 pub use document::{Document, NodeQuery};
 pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse, ProxyConfig};
 pub use figma_schema::Node;
 pub use figma_schema::Rectangle;
 pub use image_context::{ImageContextSession, ImageKey};
-pub use serialized_document::{load_design_doc, save_design_doc};
-pub use serialized_document::{SerializedDesignDoc, SerializedDesignDocHeader, ServerFigmaDoc};
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience
 pub use color::Color;

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -204,10 +204,10 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .expect("couldn't trace EncodedImageMap");
     tracer.trace_type::<crate::NodeQuery>(&samples).expect("couldn't trace NodeQuery");
     tracer
-        .trace_type::<crate::SerializedDesignDocHeader>(&samples)
+        .trace_type::<crate::DesignComposeDefinitionHeader>(&samples)
         .expect("couldn't trace SerializedDesignDocHeader");
     tracer
-        .trace_type::<crate::SerializedDesignDoc>(&samples)
+        .trace_type::<crate::DesignComposeDefinition>(&samples)
         .expect("couldn't trace SerializedDesignDoc");
     tracer.trace_type::<crate::ServerFigmaDoc>(&samples).expect("couldn't trace ServerFigmaDoc");
     tracer.trace_type::<crate::ConvertResponse>(&samples).expect("couldn't trace ConvertResponse");

--- a/crates/figma_import/tests/layout_tests.rs
+++ b/crates/figma_import/tests/layout_tests.rs
@@ -24,8 +24,8 @@
 //
 
 use figma_import::{
-    toolkit_layout_style::LayoutSizing, toolkit_schema::View, NodeQuery, SerializedDesignDoc,
-    SerializedDesignDocHeader, ViewData,
+    toolkit_layout_style::LayoutSizing, toolkit_schema::View, DesignComposeDefinition,
+    DesignComposeDefinitionHeader, NodeQuery, ViewData,
 };
 use layout::types::Dimension;
 use layout::LayoutManager;
@@ -128,21 +128,21 @@ fn add_view_to_layout(
     }
 }
 
-fn load_doc() -> std::io::Result<SerializedDesignDoc> {
+fn load_doc() -> std::io::Result<DesignComposeDefinition> {
     let mut file = File::open("tests/layout-unit-tests.dcf")?;
     let mut buf: Vec<u8> = vec![];
     let bytes_read = file.read_to_end(&mut buf)?;
     let bytes = buf.as_slice();
     println!("Read {} bytes", bytes_read);
 
-    let header: SerializedDesignDocHeader = bincode::deserialize(bytes).unwrap();
+    let header: DesignComposeDefinitionHeader = bincode::deserialize(bytes).unwrap();
     let header_size = bincode::serialized_size(&header).unwrap() as usize;
 
-    let figma_doc: SerializedDesignDoc = bincode::deserialize(&bytes[header_size..]).unwrap();
+    let figma_doc: DesignComposeDefinition = bincode::deserialize(&bytes[header_size..]).unwrap();
     Ok(figma_doc)
 }
 
-fn load_view(node_name: &str, doc: &SerializedDesignDoc) -> LayoutManager {
+fn load_view(node_name: &str, doc: &DesignComposeDefinition) -> LayoutManager {
     let view_result = doc.views.get(&NodeQuery::NodeName(node_name.into()));
     assert!(view_result.is_some());
     let view = view_result.unwrap();

--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -509,7 +509,7 @@ internal fun DocServer.doc(
         return preloadedDoc
     }
 
-    // Use the LocalContext to locate this doc in the precompiled serializedDesignDocuments
+    // Use the LocalContext to locate this doc in the precompiled DesignComposeDefinitionuments
     val assetManager = context.assets
     try {
         val assetDoc = assetManager.open("figma/$id.dcf")

--- a/proto/README.md
+++ b/proto/README.md
@@ -11,5 +11,4 @@ The messages in this directory are organized according to the following principl
 ## plugin - Capabilities added by the DesignCompose plugin
 ## view - Collected styles and settings that are applied to nodes in the design definition
 # android_interface - Types specifically used for the interface from the rust library to the android library
-# toolkit - Types specific for the toolkit
 ```

--- a/proto/definition/design_compose_definition.proto
+++ b/proto/definition/design_compose_definition.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package com.android.designcompose.proto.toolkit;
+package com.android.designcompose.proto.design;
 
 import "definition/element/variable.proto";
 import "definition/view/view.proto";
@@ -24,7 +24,7 @@ option java_multiple_files = true;
 // A serialized Figma design document, containing views, images, component sets,
 // version, ID, and variable map. It's used for storing and loading Figma
 // designs in a DesignCompose project.
-message SerializedDesignDoc {
+message DesignComposeDefinition {
   string last_modified = 1;
   map<string, definition.view.View> views = 2;
   EncodedImageMap images = 3;
@@ -34,40 +34,7 @@ message SerializedDesignDoc {
   string id = 7;
   definition.element.VariableMap variable_map = 8;
 }
-/// We can fetch figma documents in a project or from branches of another
-/// document. We store each as a name and ID
-message FigmaDocInfo {
-  string name = 1;
-  string id = 2;
-  string version_id = 3;
-}
-// This is the struct we send over to the client. It contains the serialized
-// document along with some extra data: document branches, project files, and
-// errors
-message ServerFigmaDoc {
-  SerializedDesignDoc figma_doc = 1;
-  repeated FigmaDocInfo branches = 2;
-  repeated FigmaDocInfo project_files = 3;
-  repeated string errors = 4;
-}
 
-// A message used to identify a specific Figma node within a design document. It
-// supports different ways to specify the node, including by its ID, name,
-// variant (name and parent), or component set.
-message NodeQuery {
-  // A Node that is a variant, so the name may have multiple properties
-  // The first string is the node name and the second is its parent's name
-  message NodeVariant {
-    string name = 1;
-    string parent = 2;
-  }
-  oneof NodeQuery {
-    string node_id = 1;
-    string node_name = 2;
-    NodeVariant node_variant = 3;
-    string node_component_set = 4;
-  }
-}
 
 // EncodedImageMap contains a mapping from ImageKey to network bytes. It can
 // create an ImageMap and is intended to be used when we want to use


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1262

## Full chain of PRs as of 2024-06-20

* PR #1260: `wb/froeht/rename-SDD-to-Definition` ➔ `wb/froeht/clean-up-SDD-naming`
* PR #1262: `wb/froeht/clean-up-SDD-naming` ➔ `main`

<!-- end git-machete generated -->

Towards #1252