### PR TITLE
Migrate the simple legacy element types to dc_bundle

### DIFF
--- a/crates/dc_bundle/src/legacy_definition/element.rs
+++ b/crates/dc_bundle/src/legacy_definition/element.rs
@@ -14,4 +14,7 @@
  * limitations under the License.
  */
 
+pub mod color;
+pub mod font;
 pub mod geometry;
+pub mod node;

--- a/crates/dc_bundle/src/legacy_definition/element/color.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/color.rs
@@ -1,19 +1,22 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
 
 use crate::utils::f32_eq;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Color {

--- a/crates/dc_bundle/src/legacy_definition/element/font.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/font.rs
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::utils::f32_eq;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+
+/// Allows italic or oblique faces to be selected.
+#[derive(Clone, Copy, PartialEq, Debug, Hash, Deserialize, Serialize, Default)]
+pub enum FontStyle {
+    /// A face that is neither italic not obliqued.
+    #[default]
+    Normal,
+    /// A form that is generally cursive in nature.
+    Italic,
+    /// A typically-sloped version of the regular face.
+    Oblique,
+}
+
+impl Display for FontStyle {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+/// The width of a font as an approximate fraction of the normal width.
+///
+/// Widths range from 0.5 to 2.0 inclusive, with 1.0 as the normal width.
+#[derive(Clone, Copy, Debug, PartialOrd, Deserialize, Serialize)]
+pub struct FontStretch(pub f32);
+
+impl PartialEq for FontStretch {
+    fn eq(&self, other: &Self) -> bool {
+        f32_eq(&self.0, &other.0)
+    }
+}
+
+impl Default for FontStretch {
+    #[inline]
+    fn default() -> FontStretch {
+        FontStretch::NORMAL
+    }
+}
+
+impl FontStretch {
+    /// Ultra-condensed width (50%), the narrowest possible.
+    pub const ULTRA_CONDENSED: FontStretch = FontStretch(0.5);
+    /// Extra-condensed width (62.5%).
+    pub const EXTRA_CONDENSED: FontStretch = FontStretch(0.625);
+    /// Condensed width (75%).
+    pub const CONDENSED: FontStretch = FontStretch(0.75);
+    /// Semi-condensed width (87.5%).
+    pub const SEMI_CONDENSED: FontStretch = FontStretch(0.875);
+    /// Normal width (100%).
+    pub const NORMAL: FontStretch = FontStretch(1.0);
+    /// Semi-expanded width (112.5%).
+    pub const SEMI_EXPANDED: FontStretch = FontStretch(1.125);
+    /// Expanded width (125%).
+    pub const EXPANDED: FontStretch = FontStretch(1.25);
+    /// Extra-expanded width (150%).
+    pub const EXTRA_EXPANDED: FontStretch = FontStretch(1.5);
+    /// Ultra-expanded width (200%), the widest possible.
+    pub const ULTRA_EXPANDED: FontStretch = FontStretch(2.0);
+}
+
+impl Hash for FontStretch {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let x = (self.0 * 100.0) as i32;
+        x.hash(state);
+    }
+}

--- a/crates/dc_bundle/src/legacy_definition/element/geometry.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/geometry.rs
@@ -146,3 +146,45 @@ impl From<proto::element::Size> for Size<f32> {
         Self { width: proto.width, height: proto.height }
     }
 }
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
+pub struct Rectangle {
+    pub x: Option<f32>,
+    pub y: Option<f32>,
+    pub width: Option<f32>,
+    pub height: Option<f32>,
+}
+
+impl Rectangle {
+    pub fn x(&self) -> f32 {
+        self.x.unwrap_or(0.0)
+    }
+    pub fn y(&self) -> f32 {
+        self.y.unwrap_or(0.0)
+    }
+    pub fn width(&self) -> f32 {
+        self.width.unwrap_or(0.0)
+    }
+    pub fn height(&self) -> f32 {
+        self.height.unwrap_or(0.0)
+    }
+}
+
+// XXX ColorStop, Transform
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
+pub struct Vector {
+    pub x: Option<f32>,
+    pub y: Option<f32>,
+}
+
+impl Vector {
+    pub fn is_valid(&self) -> bool {
+        self.x.is_some() && self.y.is_some()
+    }
+    pub fn x(&self) -> f32 {
+        self.x.unwrap_or(0.0)
+    }
+    pub fn y(&self) -> f32 {
+        self.y.unwrap_or(0.0)
+    }
+}

--- a/crates/dc_bundle/src/legacy_definition/element/node.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/node.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+/// We can fetch nodes either by ID or by their name.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
+pub enum NodeQuery {
+    /// Find the node by ID
+    NodeId(String),
+    /// Find the node by name
+    NodeName(String),
+    /// Node by name that is a variant, so the name may have multiple properties
+    /// The first string is the node name and the second is its parent's name
+    NodeVariant(String, String),
+    NodeComponentSet(String),
+}
+
+// Helper methods for NodeQuery construction.
+impl NodeQuery {
+    /// Construct a NodeQuery::NodeId from the given ID string.
+    pub fn id(id: impl ToString) -> NodeQuery {
+        NodeQuery::NodeId(id.to_string())
+    }
+
+    /// Construct a NodeQuery::NodeName from the given ID string.
+    pub fn name(name: impl ToString) -> NodeQuery {
+        NodeQuery::NodeName(name.to_string())
+    }
+
+    /// Construct a NodeQuery::NodeVariant from the given node name
+    pub fn variant(name: impl ToString, parent: impl ToString) -> NodeQuery {
+        NodeQuery::NodeVariant(name.to_string(), parent.to_string())
+    }
+
+    pub fn component_set(name: impl ToString) -> NodeQuery {
+        NodeQuery::NodeComponentSet(name.to_string())
+    }
+}

--- a/crates/dc_bundle/src/lib.rs
+++ b/crates/dc_bundle/src/lib.rs
@@ -20,6 +20,7 @@ include!(concat!(env!("OUT_DIR"), "/protos.rs"));
 // use dc_bundle::definition::element::Color;
 pub use designcompose::*;
 pub mod legacy_definition;
+mod utils;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/crates/dc_bundle/src/utils.rs
+++ b/crates/dc_bundle/src/utils.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Compare two finite f32 values
+/// This is not meant for situations dealing with NAN and INFINITY
+#[inline]
+pub(crate) fn f32_eq(a: &f32, b: &f32) -> bool {
+    assert!(a.is_finite());
+    assert!(b.is_finite());
+    (a - b).abs() < f32::EPSILON
+}

--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -16,9 +16,8 @@ use std::io::Write;
 
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
-use figma_import::{
-    DesignComposeDefinition, DesignComposeDefinitionHeader, Document, NodeQuery, ProxyConfig,
-};
+use dc_bundle::legacy_definition::element::node::NodeQuery;
+use figma_import::{DesignComposeDefinition, DesignComposeDefinitionHeader, Document, ProxyConfig};
 #[derive(Debug)]
 struct ConvertError(String);
 impl From<figma_import::Error> for ConvertError {

--- a/crates/figma_import/src/bin/fetch_layout.rs
+++ b/crates/figma_import/src/bin/fetch_layout.rs
@@ -15,9 +15,10 @@
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
 use dc_bundle::legacy_definition::element::geometry::Dimension;
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use figma_import::{
     toolkit_layout_style::LayoutSizing, toolkit_schema::View, DesignComposeDefinition, Document,
-    NodeQuery, ProxyConfig, ViewData,
+    ProxyConfig, ViewData,
 };
 use layout::LayoutManager;
 use std::collections::HashMap;

--- a/crates/figma_import/src/component_context.rs
+++ b/crates/figma_import/src/component_context.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    document::NodeQuery,
     figma_schema::Node,
     reaction_schema::{Action, Reaction},
 };

--- a/crates/figma_import/src/design_definition.rs
+++ b/crates/figma_import/src/design_definition.rs
@@ -19,9 +19,10 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use serde::{Deserialize, Serialize};
 
-use crate::{document::FigmaDocInfo, image_context::EncodedImageMap, toolkit_schema, NodeQuery};
+use crate::{document::FigmaDocInfo, image_context::EncodedImageMap, toolkit_schema};
 
 static CURRENT_VERSION: u32 = 20;
 

--- a/crates/figma_import/src/document.rs
+++ b/crates/figma_import/src/document.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -74,40 +75,6 @@ use crate::figma_v1_document_mocks::http_fetch;
 pub enum UpdateStatus {
     Updated,
     NotUpdated,
-}
-
-/// We can fetch nodes either by ID or by their name.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
-pub enum NodeQuery {
-    /// Find the node by ID
-    NodeId(String),
-    /// Find the node by name
-    NodeName(String),
-    /// Node by name that is a variant, so the name may have multiple properties
-    /// The first string is the node name and the second is its parent's name
-    NodeVariant(String, String),
-    NodeComponentSet(String),
-}
-// Helper methods for NodeQuery construction.
-impl NodeQuery {
-    /// Construct a NodeQuery::NodeId from the given ID string.
-    pub fn id(id: impl ToString) -> NodeQuery {
-        NodeQuery::NodeId(id.to_string())
-    }
-
-    /// Construct a NodeQuery::NodeName from the given ID string.
-    pub fn name(name: impl ToString) -> NodeQuery {
-        NodeQuery::NodeName(name.to_string())
-    }
-
-    /// Construct a NodeQuery::NodeVariant from the given node name
-    pub fn variant(name: impl ToString, parent: impl ToString) -> NodeQuery {
-        NodeQuery::NodeVariant(name.to_string(), parent.to_string())
-    }
-
-    pub fn component_set(name: impl ToString) -> NodeQuery {
-        NodeQuery::NodeComponentSet(name.to_string())
-    }
 }
 
 /// We can fetch figma documents in a project or from branches of another document.

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     DesignComposeDefinition, DesignComposeDefinitionHeader, Document, ImageContextSession,
-    NodeQuery, ServerFigmaDoc,
+    ServerFigmaDoc,
 };
 
 #[derive(Serialize, Deserialize)]

--- a/crates/figma_import/src/figma_schema.rs
+++ b/crates/figma_import/src/figma_schema.rs
@@ -14,9 +14,9 @@
 
 use std::collections::HashMap;
 
+use dc_bundle::legacy_definition::element::color::Color;
 use serde::{Deserialize, Serialize};
 
-use crate::color::Color;
 use crate::vector_schema::WindingRule;
 
 // We use serde to decode Figma's JSON documents into Rust structures.
@@ -89,6 +89,18 @@ impl Rectangle {
     }
     pub fn height(&self) -> f32 {
         self.height.unwrap_or(0.0)
+    }
+}
+
+// Generate an implementation of Into that converts this Rectangle to the one in dc_bundle
+impl Into<dc_bundle::legacy_definition::element::geometry::Rectangle> for &Rectangle {
+    fn into(self) -> dc_bundle::legacy_definition::element::geometry::Rectangle {
+        dc_bundle::legacy_definition::element::geometry::Rectangle {
+            x: Some(self.x()),
+            y: Some(self.y()),
+            width: Some(self.width()),
+            height: Some(self.height()),
+        }
     }
 }
 

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -18,7 +18,6 @@
 //!
 //! The goal of this crate is to perform the mapping from Figma to the toolkit; it does
 //! not provide any kind of UI logic mapping.
-mod color;
 mod component_context;
 mod design_definition;
 mod document;
@@ -36,19 +35,21 @@ mod transform_flexbox;
 mod utils;
 pub mod vector_schema;
 // Exports for library users
+pub use dc_bundle::legacy_definition::element::geometry::Rectangle;
 pub use design_definition::{load_design_def, save_design_def};
 pub use design_definition::{
     DesignComposeDefinition, DesignComposeDefinitionHeader, ServerFigmaDoc,
 };
-pub use document::{Document, NodeQuery};
+pub use document::Document;
 pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse, ProxyConfig};
 pub use figma_schema::Node;
-pub use figma_schema::Rectangle;
 pub use image_context::{ImageContextSession, ImageKey};
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience
-pub use color::Color;
+pub use dc_bundle::legacy_definition::element::color::Color;
+pub use dc_bundle::legacy_definition::element::node::NodeQuery;
+
 #[cfg(feature = "http_mock")]
 mod figma_v1_document_mocks;
 /// Functionality related to reflection for deserializing our bincode archives in other

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use dc_bundle::definition::layout::FlexWrap;
+use dc_bundle::legacy_definition::element::font::FontStyle;
 use dc_bundle::legacy_definition::element::geometry::Dimension;
 use serde_reflection::{Samples, Tracer, TracerConfig};
 
@@ -50,9 +51,7 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<dc_bundle::legacy_definition::layout::positioning::FlexDirection>(&samples)
         .expect("couldn't trace FlexDirection");
     tracer.trace_type::<FlexWrap>(&samples).expect("couldn't trace FlexWrap");
-    tracer
-        .trace_type::<crate::toolkit_font_style::FontStyle>(&samples)
-        .expect("couldn't trace FontStyle");
+    tracer.trace_type::<FontStyle>(&samples).expect("couldn't trace FontStyle");
     tracer
         .trace_type::<crate::toolkit_font_style::TextDecoration>(&samples)
         .expect("couldn't trace TextDecoration");

--- a/crates/figma_import/src/toolkit_font_style.rs
+++ b/crates/figma_import/src/toolkit_font_style.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This implementation is derived from font-kit 0.6.0, which is dual licensed under
-// MIT and Apache 2.0. We are using it under the Apache 2.0 terms.
 use crate::toolkit_schema::NumOrVar;
 use crate::utils::f32_eq;
 use serde::{Deserialize, Serialize};
@@ -21,68 +19,6 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
     hash::{Hash, Hasher},
 };
-
-#[derive(Debug, Copy, Clone)]
-pub struct FontMetrics {
-    pub units_per_em: u32,
-    pub ascent: f32,
-    pub descent: f32,
-    pub height: f32,
-    pub underline_position: f32,
-    pub underline_thickness: f32,
-}
-impl PartialEq for FontMetrics {
-    fn eq(&self, other: &Self) -> bool {
-        self.units_per_em == other.units_per_em
-            && f32_eq(&self.ascent, &other.ascent)
-            && f32_eq(&self.descent, &other.descent)
-            && f32_eq(&self.height, &other.height)
-            && f32_eq(&self.underline_position, &other.underline_position)
-            && f32_eq(&self.underline_thickness, &other.underline_thickness)
-    }
-}
-impl Hash for FontMetrics {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.units_per_em.hash(state);
-        ((self.ascent * 64.0) as i32).hash(state);
-        ((self.descent * 64.0) as i32).hash(state);
-        ((self.height * 64.0) as i32).hash(state);
-        ((self.underline_position * 64.0) as i32).hash(state);
-        ((self.underline_thickness * 64.0) as i32).hash(state);
-    }
-}
-/// Allows italic or oblique faces to be selected.
-#[derive(Clone, Copy, PartialEq, Debug, Hash, Deserialize, Serialize, Default)]
-pub enum FontStyle {
-    /// A face that is neither italic not obliqued.
-    #[default]
-    Normal,
-    /// A form that is generally cursive in nature.
-    Italic,
-    /// A typically-sloped version of the regular face.
-    Oblique,
-}
-
-impl Display for FontStyle {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Debug::fmt(self, f)
-    }
-}
-
-/// Allows strikethrough or underline text decoration to be selected.
-#[derive(Clone, Copy, PartialEq, Debug, Hash, Deserialize, Serialize, Default)]
-pub enum TextDecoration {
-    #[default]
-    None,
-    Strikethrough,
-    Underline,
-}
-
-impl Display for TextDecoration {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        Debug::fmt(self, f)
-    }
-}
 /// The degree of blackness or stroke thickness of a font. This value ranges from 100.0 to 900.0,
 /// with 400.0 as normal.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -128,42 +64,48 @@ impl FontWeight {
 /// The width of a font as an approximate fraction of the normal width.
 ///
 /// Widths range from 0.5 to 2.0 inclusive, with 1.0 as the normal width.
-#[derive(Clone, Copy, Debug, PartialOrd, Deserialize, Serialize)]
-pub struct FontStretch(pub f32);
-impl PartialEq for FontStretch {
+
+#[derive(Debug, Copy, Clone)]
+pub struct FontMetrics {
+    pub units_per_em: u32,
+    pub ascent: f32,
+    pub descent: f32,
+    pub height: f32,
+    pub underline_position: f32,
+    pub underline_thickness: f32,
+}
+impl PartialEq for FontMetrics {
     fn eq(&self, other: &Self) -> bool {
-        f32_eq(&self.0, &other.0)
+        self.units_per_em == other.units_per_em
+            && f32_eq(&self.ascent, &other.ascent)
+            && f32_eq(&self.descent, &other.descent)
+            && f32_eq(&self.height, &other.height)
+            && f32_eq(&self.underline_position, &other.underline_position)
+            && f32_eq(&self.underline_thickness, &other.underline_thickness)
     }
 }
-impl Default for FontStretch {
-    #[inline]
-    fn default() -> FontStretch {
-        FontStretch::NORMAL
-    }
-}
-impl FontStretch {
-    /// Ultra-condensed width (50%), the narrowest possible.
-    pub const ULTRA_CONDENSED: FontStretch = FontStretch(0.5);
-    /// Extra-condensed width (62.5%).
-    pub const EXTRA_CONDENSED: FontStretch = FontStretch(0.625);
-    /// Condensed width (75%).
-    pub const CONDENSED: FontStretch = FontStretch(0.75);
-    /// Semi-condensed width (87.5%).
-    pub const SEMI_CONDENSED: FontStretch = FontStretch(0.875);
-    /// Normal width (100%).
-    pub const NORMAL: FontStretch = FontStretch(1.0);
-    /// Semi-expanded width (112.5%).
-    pub const SEMI_EXPANDED: FontStretch = FontStretch(1.125);
-    /// Expanded width (125%).
-    pub const EXPANDED: FontStretch = FontStretch(1.25);
-    /// Extra-expanded width (150%).
-    pub const EXTRA_EXPANDED: FontStretch = FontStretch(1.5);
-    /// Ultra-expanded width (200%), the widest possible.
-    pub const ULTRA_EXPANDED: FontStretch = FontStretch(2.0);
-}
-impl Hash for FontStretch {
+impl Hash for FontMetrics {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let x = (self.0 * 100.0) as i32;
-        x.hash(state);
+        self.units_per_em.hash(state);
+        ((self.ascent * 64.0) as i32).hash(state);
+        ((self.descent * 64.0) as i32).hash(state);
+        ((self.height * 64.0) as i32).hash(state);
+        ((self.underline_position * 64.0) as i32).hash(state);
+        ((self.underline_thickness * 64.0) as i32).hash(state);
+    }
+}
+
+/// Allows strikethrough or underline text decoration to be selected.
+#[derive(Clone, Copy, PartialEq, Debug, Hash, Deserialize, Serialize, Default)]
+pub enum TextDecoration {
+    #[default]
+    None,
+    Strikethrough,
+    Underline,
+}
+
+impl Display for TextDecoration {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
     }
 }

--- a/crates/figma_import/src/toolkit_schema.rs
+++ b/crates/figma_import/src/toolkit_schema.rs
@@ -19,15 +19,16 @@ use std::sync::atomic::AtomicU16;
 // retain image references.
 use serde::{Deserialize, Serialize};
 
-use crate::color::Color;
 use crate::figma_schema;
 use crate::figma_schema::VariableCommon;
 use crate::reaction_schema::FrameExtras;
 use crate::reaction_schema::Reaction;
 use crate::toolkit_style::{StyledTextRun, ViewStyle};
+use dc_bundle::legacy_definition::element::color::Color;
+pub use dc_bundle::legacy_definition::element::geometry::Rectangle;
 use std::collections::HashMap;
 
-pub use crate::figma_schema::{FigmaColor, OverflowDirection, Rectangle, StrokeCap, VariableAlias};
+pub use crate::figma_schema::{FigmaColor, OverflowDirection, StrokeCap, VariableAlias};
 
 // Enum for fields that represent either a fixed number or a number variable
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -16,14 +16,15 @@
 //! uses.
 
 use dc_bundle::definition::layout::FlexWrap;
+use dc_bundle::legacy_definition::element::color::Color;
+use dc_bundle::legacy_definition::element::font::{FontStretch, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Size;
 use dc_bundle::legacy_definition::layout::layout_style::LayoutStyle;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::{
-    color::Color,
-    toolkit_font_style::{FontStretch, FontStyle, FontWeight, TextDecoration},
+    toolkit_font_style::{FontWeight, TextDecoration},
     toolkit_layout_style::{Display, LayoutSizing, Number, Overflow},
     toolkit_schema::{ColorOrVar, NumOrVar},
 };

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::f32::consts::PI;
 
-use crate::toolkit_font_style::{FontStyle, FontWeight};
+use crate::toolkit_font_style::FontWeight;
 use crate::toolkit_layout_style::Overflow;
 
 use crate::toolkit_style::{
@@ -42,6 +42,7 @@ use crate::{
 };
 
 use dc_bundle::definition::layout::FlexWrap;
+use dc_bundle::legacy_definition::element::font::FontStyle;
 use dc_bundle::legacy_definition::element::geometry::Dimension;
 use dc_bundle::legacy_definition::layout::grid::ItemSpacing;
 use dc_bundle::legacy_definition::layout::positioning::{
@@ -1196,7 +1197,7 @@ fn visit_node(
                 reactions,
                 characters,
                 check_text_node_string_res(node),
-                node.absolute_bounding_box,
+                node.absolute_bounding_box.map(|r| (&r).into()),
                 RenderMethod::None,
                 node.explicit_variable_modes.clone(),
             );
@@ -1245,7 +1246,7 @@ fn visit_node(
                     style.node_style.font_weight.clone()
                 };
                 let font_style = if let Some(true) = sub_style.italic {
-                    crate::toolkit_font_style::FontStyle::Italic
+                    FontStyle::Italic
                 } else {
                     style.node_style.font_style.clone()
                 };
@@ -1313,7 +1314,7 @@ fn visit_node(
                 reactions,
                 runs,
                 check_text_node_string_res(node),
-                node.absolute_bounding_box,
+                node.absolute_bounding_box.map(|r| (&r).into()),
                 RenderMethod::None,
             );
         }
@@ -1521,7 +1522,7 @@ fn visit_node(
         reactions,
         scroll_info,
         frame_extras,
-        node.absolute_bounding_box,
+        node.absolute_bounding_box.map(|r| (&r).into()),
         RenderMethod::None,
         node.explicit_variable_modes.clone(),
     );

--- a/crates/figma_import/tests/layout_tests.rs
+++ b/crates/figma_import/tests/layout_tests.rs
@@ -24,9 +24,10 @@
 //
 
 use dc_bundle::legacy_definition::element::geometry::Dimension;
+use dc_bundle::legacy_definition::element::node::NodeQuery;
 use figma_import::{
     toolkit_layout_style::LayoutSizing, toolkit_schema::View, DesignComposeDefinition,
-    DesignComposeDefinitionHeader, NodeQuery, ViewData,
+    DesignComposeDefinitionHeader, ViewData,
 };
 use layout::LayoutManager;
 use std::collections::HashMap;


### PR DESCRIPTION
In this PR I moved as many of the `element` types to `dc_bundle` as I could. Many of them were blocked by the difficulty in moving the `Variable` types (#1292) so this PR only gets some of them, but it's progress.

<!-- start git-machete generated -->

# Based on PR #1291

## Full chain of PRs as of 2024-06-24

* PR #1293: `wb/froeht/split-fi-ViewStyle` ➔ `wb/froeht/split-fi-migrate-layout`
* PR #1291: `wb/froeht/split-fi-migrate-layout` ➔ `main`

<!-- end git-machete generated -->
