### PR TITLE
Fix #1213: support for list-based content replacement in squoosh

### DIFF
--- a/crates/dc_jni/src/jni.rs
+++ b/crates/dc_jni/src/jni.rs
@@ -14,7 +14,7 @@
 
 use std::ffi::c_void;
 
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use crate::error::{throw_basic_exception, Error};
 use crate::error_map::map_err_to_exception;
@@ -31,10 +31,13 @@ use lazy_static::lazy_static;
 use log::{error, LevelFilter};
 
 lazy_static! {
-    static ref JAVA_VM: Mutex<Option<JavaVM>> = Mutex::new(None);
+    static ref JAVA_VM: Mutex<Option<Arc<JavaVM>>> = Mutex::new(None);
 }
-pub fn javavm() -> MutexGuard<'static, Option<JavaVM>> {
-    JAVA_VM.lock().unwrap()
+pub fn javavm() -> Option<Arc<JavaVM>> {
+    JAVA_VM.lock().unwrap().clone()
+}
+fn set_javavm(vm: JavaVM) {
+    *JAVA_VM.lock().unwrap() = Some(Arc::new(vm))
 }
 
 fn get_string(env: &mut JNIEnv, obj: &JObject) -> Option<String> {
@@ -183,10 +186,7 @@ pub extern "system" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
     }
 
     // Save the Java VM so we can call back into Android
-    {
-        let mut javavm = javavm();
-        *javavm = Some(vm);
-    }
+    set_javavm(vm);
 
     JNI_VERSION_1_6
 }

--- a/crates/dc_jni/src/layout_manager.rs
+++ b/crates/dc_jni/src/layout_manager.rs
@@ -105,6 +105,8 @@ pub(crate) fn jni_add_nodes<'local>(
     root_layout_id: jint,
     serialized_views: JByteArray,
 ) -> JByteArray<'local> {
+    info!("jni_add_nodes manager_id: {}", manager_id);
+
     let manager_ref = match manager(manager_id) {
         Some(it) => it,
         None => {
@@ -141,6 +143,7 @@ pub(crate) fn jni_add_nodes<'local>(
             layout_response_to_bytearray(env, layout_response)
         }
         Err(e) => {
+            info!("jni_add_nodes: failed with error {:?}", e);
             throw_basic_exception(&mut env, &e);
             JObject::null().into()
         }
@@ -216,8 +219,7 @@ pub(crate) fn java_jni_measure_text(
     available_width: f32,
     available_height: f32,
 ) -> (f32, f32) {
-    let vm = javavm();
-    if let Some(vm) = vm.as_ref() {
+    if let Some(vm) = javavm() {
         let mut env: JNIEnv<'_> = vm.get_env().expect("Cannot get reference to the JNIEnv");
         let class_result = env.find_class("com/android/designcompose/DesignTextMeasure");
         match class_result {
@@ -256,7 +258,7 @@ pub(crate) fn java_jni_measure_text(
             }
         }
     } else {
-        error!("Java JNI failed to get JavaVM: {:?}", vm);
+        error!("Java JNI failed to get JavaVM");
     }
     (0.0, 0.0)
 }

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -398,6 +398,13 @@ fun measureTextBoundsFunc(
     // Look up the measure data -- this map is created/updated when building the layout tree.
     val textMeasureData = LayoutManager.getTextMeasureData(layoutId)
     if (textMeasureData == null) {
+        // Maybe there's a custom measure function. We could do something with id namespaces to
+        // avoid a double-hashmap lookup if this shows up on a profiler.
+        val customMeasureFunc = LayoutManager.getCustomMeasure(layoutId)
+        if (customMeasureFunc != null) {
+            val size = customMeasureFunc(width, height, availableWidth, availableHeight)
+            if (size != null) return Pair(size.width, size.height)
+        }
         Log.d(TAG, "measureTextBoundsFunc() error: no textMeasureData for layoutId $layoutId")
         return Pair(0F, 0F)
     }

--- a/designcompose/src/main/java/com/android/designcompose/LayoutManager.kt
+++ b/designcompose/src/main/java/com/android/designcompose/LayoutManager.kt
@@ -17,6 +17,7 @@
 package com.android.designcompose
 
 import android.util.Log
+import android.util.SizeF
 import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
 import androidx.tracing.trace
 import com.android.designcompose.android_interface.LayoutChangedResponse
@@ -36,6 +37,7 @@ internal object LayoutManager {
     private val subscribers: HashMap<Int, (Int) -> Unit> = HashMap()
     private val layoutsInProgress: HashSet<Int> = HashSet()
     private var textMeasures: HashMap<Int, TextMeasureData> = HashMap()
+    private var customMeasure: HashMap<Int, ((Float, Float, Float, Float) -> SizeF?)> = HashMap()
     private var modifiedSizes: HashSet<Int> = HashSet()
     private var nextLayoutId: Int = 0
     private var performLayoutComputation: Boolean = false
@@ -130,6 +132,20 @@ internal object LayoutManager {
     internal fun squooshClearTextMeasureData(layoutId: Int) {
         textMeasures.remove(layoutId)
     }
+
+    internal fun squooshSetCustomMeasure(
+        layoutId: Int,
+        m: ((Float, Float, Float, Float) -> SizeF?)
+    ) {
+        customMeasure[layoutId] = m
+    }
+
+    internal fun squooshClearCustomMeasure(layoutId: Int) {
+        customMeasure.remove(layoutId)
+    }
+
+    internal fun getCustomMeasure(layoutId: Int): ((Float, Float, Float, Float) -> SizeF?)? =
+        customMeasure[layoutId]
 
     private fun subscribe(
         layoutId: Int,

--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -58,7 +58,9 @@ import com.android.designcompose.serdegen.Display
 import com.android.designcompose.serdegen.Easing
 import com.android.designcompose.serdegen.FlexDirection
 import com.android.designcompose.serdegen.FlexWrap
+import com.android.designcompose.serdegen.FontStretch
 import com.android.designcompose.serdegen.FontStyle
+import com.android.designcompose.serdegen.FontWeight
 import com.android.designcompose.serdegen.ItemSpacing
 import com.android.designcompose.serdegen.JustifyContent
 import com.android.designcompose.serdegen.Layout
@@ -71,6 +73,8 @@ import com.android.designcompose.serdegen.Overflow
 import com.android.designcompose.serdegen.PointerEvents
 import com.android.designcompose.serdegen.PositionType
 import com.android.designcompose.serdegen.ScaleMode
+import com.android.designcompose.serdegen.Stroke
+import com.android.designcompose.serdegen.StrokeAlign
 import com.android.designcompose.serdegen.StrokeWeight
 import com.android.designcompose.serdegen.StyledTextRun
 import com.android.designcompose.serdegen.TextAlign
@@ -82,6 +86,7 @@ import com.android.designcompose.serdegen.ViewData
 import com.android.designcompose.serdegen.ViewShape
 import com.android.designcompose.serdegen.ViewStyle
 import com.android.designcompose.serdegen.WindingRule
+import java.util.Optional
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
@@ -648,6 +653,42 @@ internal fun LayoutStyle.asBuilder(): LayoutStyle.Builder {
     return builder
 }
 
+private fun zeroRect(): com.android.designcompose.serdegen.Rect =
+    com.android.designcompose.serdegen.Rect(
+        Dimension.Percent(0f),
+        Dimension.Percent(0f),
+        Dimension.Percent(0f),
+        Dimension.Percent(0f)
+    )
+
+internal fun defaultLayoutStyle(): LayoutStyle.Builder {
+    val builder = LayoutStyle.Builder()
+    builder.position_type = PositionType.Relative()
+    builder.flex_direction = FlexDirection.Row()
+    builder.align_items = AlignItems.FlexStart()
+    builder.align_self = AlignSelf.Auto()
+    builder.align_content = AlignContent.FlexStart()
+    builder.justify_content = JustifyContent.FlexStart()
+    builder.top = Dimension.Undefined()
+    builder.left = Dimension.Undefined()
+    builder.bottom = Dimension.Undefined()
+    builder.right = Dimension.Undefined()
+    builder.margin = zeroRect()
+    builder.padding = zeroRect()
+    builder.item_spacing = ItemSpacing.Auto(0, 0)
+    builder.flex_grow = 1.0f
+    builder.flex_shrink = 0.0f
+    builder.flex_basis = Dimension.Undefined()
+    builder.bounding_box = com.android.designcompose.serdegen.Size(0f, 0f)
+    builder.width = Dimension.Undefined()
+    builder.height = Dimension.Undefined()
+    builder.min_width = Dimension.Undefined()
+    builder.min_height = Dimension.Undefined()
+    builder.max_width = Dimension.Undefined()
+    builder.max_height = Dimension.Undefined()
+    return builder
+}
+
 internal fun NodeStyle.asBuilder(): NodeStyle.Builder {
     val builder = NodeStyle.Builder()
     builder.text_color = text_color
@@ -689,6 +730,50 @@ internal fun NodeStyle.asBuilder(): NodeStyle.Builder {
     builder.aspect_ratio = aspect_ratio
     builder.pointer_events = pointer_events
     builder.meter_data = meter_data
+    return builder
+}
+
+internal fun defaultNodeStyle(): NodeStyle.Builder {
+    val builder = NodeStyle.Builder()
+    builder.text_color = Background.None()
+    builder.font_size = NumOrVar.Num(0f)
+    builder.font_family = Optional.empty()
+    builder.font_weight = FontWeight(NumOrVar.Num(0f))
+    builder.font_style = FontStyle.Normal()
+    builder.font_stretch = FontStretch(0f)
+    builder.background = emptyList()
+    builder.box_shadow = emptyList()
+    builder.stroke = Stroke(StrokeAlign.Center(), StrokeWeight.Uniform(0f), emptyList())
+    builder.opacity = Optional.empty()
+    builder.transform = Optional.empty()
+    builder.relative_transform = Optional.empty()
+    builder.text_align = TextAlign.Left()
+    builder.text_align_vertical = TextAlignVertical.Top()
+    builder.text_overflow = TextOverflow.Clip()
+    builder.text_shadow = Optional.empty()
+    builder.node_size = com.android.designcompose.serdegen.Size(0f, 0f)
+    builder.line_height = LineHeight.Percent(1.0f)
+    builder.line_count = Optional.empty()
+    builder.font_features = emptyList()
+    builder.filter = emptyList()
+    builder.backdrop_filter = emptyList()
+    builder.blend_mode = BlendMode.PassThrough()
+    builder.display_type = Display.flex()
+    builder.flex_wrap = FlexWrap.NoWrap()
+    builder.grid_layout = Optional.empty()
+    builder.grid_columns_rows = 0
+    builder.grid_adaptive_min_size = 0
+    builder.grid_span_content = emptyList()
+    builder.overflow = Overflow.Visible()
+    builder.max_children = Optional.empty()
+    builder.overflow_node_id = Optional.empty()
+    builder.overflow_node_name = Optional.empty()
+    builder.cross_axis_item_spacing = 0f
+    builder.horizontal_sizing = LayoutSizing.HUG()
+    builder.vertical_sizing = LayoutSizing.HUG()
+    builder.aspect_ratio = com.android.designcompose.serdegen.Number.Undefined()
+    builder.pointer_events = PointerEvents.Auto()
+    builder.meter_data = Optional.empty()
     return builder
 }
 // XXX: Horrible code to deal with our terrible generated types. Maybe if style moves to proto then

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
@@ -139,6 +139,14 @@ private fun updateLayoutTree(
             LayoutManager.squooshSetTextMeasureData(layoutId, resolvedNode.textInfo)
         }
 
+        // We need to measure some children during the Compose layout phase, because they're
+        // actual Composables and not part of the DesignCompose layout tree. For those, we
+        // use the measure func mechanism, and ask the child Composable for its intrinsic
+        // size.
+        if (resolvedNode.needsChildLayout) {
+            useMeasureFunc = true
+        }
+
         layoutNodes.add(
             LayoutNode(
                 layoutId,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
@@ -44,6 +44,8 @@ internal class SquooshResolvedNode(
     var parent: SquooshResolvedNode? = null,
     var computedLayout: Layout? = null,
     var needsChildRender: Boolean = false,
+    // Should we ask for the intrinsic layout size of the external Composable
+    var needsChildLayout: Boolean = false,
 ) {
     fun offsetFromAncestor(ancestor: SquooshResolvedNode? = null): PointF {
         var n: SquooshResolvedNode? = this


### PR DESCRIPTION
Support list-based content replacement in Squoosh by:

- Adding a layout node in the Squoosh tree for each list item.
- Using a Rust Layout `measure` function to bridge between the Compose layout implementation of the child, and the hosting layout node in the Squoosh tree.

These two changes mean we can host DesignCompose items or regular Compose items as replaced content, because we're just using the regular Compose API for layout (which DesignCompose also implements).