### PR TITLE
Dependabot: Clean up unnecessary `registries` configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,28 +25,14 @@ registries:
 
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - "/.github/actions/build-figma-resource"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
     target-branch: "main"
     groups:
       non-breaking-github-workflow:
-        update-types:
-        - "minor"
-    open-pull-requests-limit: 5
-    schedule:
-      interval: weekly
-      day: friday
-
-  # A directory of "/" only actually includes .github/workflows.
-  # A separate section is needed for our custom actions
-  - package-ecosystem: github-actions
-    directory: "/.github/actions/build-figma-resource"
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    target-branch: "main"
-    groups:
-      non-breaking-github-action:
         update-types:
         - "minor"
     open-pull-requests-limit: 5
@@ -85,26 +71,14 @@ updates:
       day: friday
 
   - package-ecosystem: npm
-    directory: /support-figma/auto-content-preview-widget
+    directories:
+      - "/support-figma/auto-content-preview-widget"
+      - "/support-figma/extended-layout-plugin"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
     target-branch: "main"
     groups:
       non-breaking-figma-widget:
-        update-types:
-        - "minor"
-    open-pull-requests-limit: 5
-    schedule:
-      interval: weekly
-      day: friday
-
-  - package-ecosystem: npm
-    directory: /support-figma/extended-layout-plugin
-    assignees: [timothyfroehlich]
-    reviewers: [timothyfroehlich]
-    target-branch: "main"
-    groups:
-      non-breaking-figma-plugin:
         update-types:
         - "minor"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,6 @@
 
 version: 2
 
-# Required due to https://github.com/dependabot/dependabot-core/issues/6888
-registries:
-  maven-google:
-    type: maven-repository
-    url: "https://dl.google.com/dl/android/maven2/"
-  gradle-plugin-portal:
-    type: maven-repository
-    url: https://plugins.gradle.org/m2
-
 updates:
   - package-ecosystem: github-actions
     directories:
@@ -88,9 +79,6 @@ updates:
 
   - package-ecosystem: gradle
     directory: "/"
-    registries:
-    - maven-google
-    - gradle-plugin-portal
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
     target-branch: "main"


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1332

## Full chain of PRs as of 2024-07-08

* PR #1333: `wb/froeht/dependabot-clean-up-registries-config` ➔ `wb/froeht/dependabot-group-package-ecosystems`
* PR #1332: `wb/froeht/dependabot-group-package-ecosystems` ➔ `main`

<!-- end git-machete generated -->

https://github.com/dependabot/dependabot-core/issues/6888 is fixed so they aren't necessary any more.