### PR TITLE
Continue migrating `figma_import` types to `dc_bundle`

### DIFF
--- a/crates/dc_bundle/src/legacy_definition.rs
+++ b/crates/dc_bundle/src/legacy_definition.rs
@@ -22,3 +22,4 @@
 pub(crate) use crate::definition as proto;
 pub mod element;
 pub mod layout;
+pub mod modifier;

--- a/crates/dc_bundle/src/legacy_definition/element/font.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/font.rs
@@ -1,17 +1,18 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 use crate::utils::f32_eq;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -33,6 +34,20 @@ pub enum FontStyle {
 impl Display for FontStyle {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Debug::fmt(self, f)
+    }
+}
+
+/// This structure represents an OpenType feature, for example "tnum" controls tabular numbers
+/// in fonts that support the feature.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct FontFeature {
+    pub tag: [u8; 4],
+    pub enabled: bool,
+}
+
+impl FontFeature {
+    pub fn new(tag: &[u8; 4]) -> Self {
+        FontFeature { tag: *tag, enabled: true }
     }
 }
 

--- a/crates/dc_bundle/src/legacy_definition/element/path.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/path.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub enum LineHeight {
+    Pixels(f32),
+    Percent(f32),
+}
+
+impl Default for LineHeight {
+    fn default() -> Self {
+        LineHeight::Percent(1.0)
+    }
+}
+
+/// How is a stroke aligned to its containing box?
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub enum StrokeAlign {
+    /// The stroke is entirely within the containing view. The stroke's outer edge matches the
+    /// outer edge of the containing view.
+    Inside,
+    /// The stroke is centered on the edge of the containing view, and extends into the view
+    /// on the inside, and out of the view on the outside.
+    Center,
+    /// The stroke is entirely outside of the view. The stroke's inner edge is the outer edge
+    /// of the containing view.
+    Outside,
+}
+
+/// Stroke weight is either a uniform value for all sides, or individual
+/// weights for each side.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub enum StrokeWeight {
+    /// One weight is used for all sides.
+    Uniform(f32),
+    /// Individual weights for each side (typically only applied on boxes).
+    Individual { top: f32, right: f32, bottom: f32, left: f32 },
+}

--- a/crates/dc_bundle/src/legacy_definition/modifier.rs
+++ b/crates/dc_bundle/src/legacy_definition/modifier.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-pub mod color;
-pub mod font;
-pub mod geometry;
-pub mod node;
-pub mod path;
+pub mod blend;
+pub mod filter;
+pub mod text;

--- a/crates/dc_bundle/src/legacy_definition/modifier/blend.rs
+++ b/crates/dc_bundle/src/legacy_definition/modifier/blend.rs
@@ -14,8 +14,40 @@
  * limitations under the License.
  */
 
-pub mod color;
-pub mod font;
-pub mod geometry;
-pub mod node;
-pub mod path;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
+pub enum BlendMode {
+    ///Normal blends:
+    #[default]
+    PassThrough,
+    ///(only applicable to objects with children)
+    Normal,
+
+    ///Darken:
+    Darken,
+    Multiply,
+    LinearBurn,
+    ColorBurn,
+
+    ///Lighten:
+    Lighten,
+    Screen,
+    LinearDodge,
+    ColorDodge,
+
+    ///Contrast:
+    Overlay,
+    SoftLight,
+    HardLight,
+
+    ///Inversion:
+    Difference,
+    Exclusion,
+
+    ///Component:
+    Hue,
+    Saturation,
+    Color,
+    Luminosity,
+}

--- a/crates/dc_bundle/src/legacy_definition/modifier/filter.rs
+++ b/crates/dc_bundle/src/legacy_definition/modifier/filter.rs
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
-pub mod color;
-pub mod font;
-pub mod geometry;
-pub mod node;
-pub mod path;
+use serde::{Deserialize, Serialize};
+
+/// Filters -- these can be applied to a view and its children (via the "filter" style),
+/// or to the elements behind a view (via the "backdrop_filter" style).
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub enum FilterOp {
+    /// Gaussian blur, radius in px.
+    Blur(f32),
+    //Saturation(f32),
+    Contrast(f32),
+    Grayscale(f32),
+    Brightness(f32),
+}

--- a/crates/dc_bundle/src/legacy_definition/modifier/text.rs
+++ b/crates/dc_bundle/src/legacy_definition/modifier/text.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+/// Horizontal text alignment. This value aligns the text within its bounds.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
+pub enum TextAlign {
+    #[default]
+    Left,
+    Center,
+    Right,
+}
+
+/// Vertical text alignment. This value aligns the text vertically within its bounds.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
+pub enum TextAlignVertical {
+    #[default]
+    Top,
+    Center,
+    Bottom,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
+pub enum TextOverflow {
+    #[default]
+    Clip,
+    Ellipsis,
+}

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use dc_bundle::definition::layout::FlexWrap;
-use dc_bundle::legacy_definition::element::font::FontStyle;
 use dc_bundle::legacy_definition::element::geometry::Dimension;
 use serde_reflection::{Samples, Tracer, TracerConfig};
 
@@ -37,7 +35,7 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<crate::toolkit_style::Background>(&samples)
         .expect("couldn't trace Background");
     tracer
-        .trace_type::<crate::toolkit_style::BlendMode>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::modifier::blend::BlendMode>(&samples)
         .expect("couldn't trace BlendMode");
     tracer
         .trace_type::<crate::toolkit_style::BoxShadow>(&samples)
@@ -46,12 +44,18 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
     tracer
         .trace_type::<crate::toolkit_layout_style::Display>(&samples)
         .expect("couldn't trace Display");
-    tracer.trace_type::<crate::toolkit_style::FilterOp>(&samples).expect("couldn't trace FilterOp");
+    tracer
+        .trace_type::<dc_bundle::legacy_definition::modifier::filter::FilterOp>(&samples)
+        .expect("couldn't trace FilterOp");
     tracer
         .trace_type::<dc_bundle::legacy_definition::layout::positioning::FlexDirection>(&samples)
         .expect("couldn't trace FlexDirection");
-    tracer.trace_type::<FlexWrap>(&samples).expect("couldn't trace FlexWrap");
-    tracer.trace_type::<FontStyle>(&samples).expect("couldn't trace FontStyle");
+    tracer
+        .trace_type::<dc_bundle::definition::layout::FlexWrap>(&samples)
+        .expect("couldn't trace FlexWrap");
+    tracer
+        .trace_type::<dc_bundle::legacy_definition::element::font::FontStyle>(&samples)
+        .expect("couldn't trace FontStyle");
     tracer
         .trace_type::<crate::toolkit_font_style::TextDecoration>(&samples)
         .expect("couldn't trace TextDecoration");
@@ -59,7 +63,7 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<dc_bundle::legacy_definition::layout::positioning::JustifyContent>(&samples)
         .expect("couldn't trace JustifyContent");
     tracer
-        .trace_type::<crate::toolkit_style::LineHeight>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::path::LineHeight>(&samples)
         .expect("couldn't trace LineHeight");
     tracer
         .trace_type::<crate::toolkit_layout_style::Number>(&samples)
@@ -95,19 +99,19 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<crate::toolkit_style::ShadowBox>(&samples)
         .expect("couldn't trace ShadowBox");
     tracer
-        .trace_type::<crate::toolkit_style::StrokeAlign>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::path::StrokeAlign>(&samples)
         .expect("couldn't trace StrokeAlign");
     tracer
-        .trace_type::<crate::toolkit_style::StrokeWeight>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::path::StrokeWeight>(&samples)
         .expect("couldn't trace StrokeWeight");
     tracer
-        .trace_type::<crate::toolkit_style::TextAlign>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::modifier::text::TextAlign>(&samples)
         .expect("couldn't trace TextAlign");
     tracer
-        .trace_type::<crate::toolkit_style::TextAlignVertical>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::modifier::text::TextAlignVertical>(&samples)
         .expect("couldn't trace TextAlignVertical");
     tracer
-        .trace_type::<crate::toolkit_style::TextOverflow>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::modifier::text::TextOverflow>(&samples)
         .expect("couldn't trace TextOverflow");
     tracer
         .trace_type::<crate::toolkit_layout_style::LayoutSizing>(&samples)

--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -17,9 +17,13 @@
 
 use dc_bundle::definition::layout::FlexWrap;
 use dc_bundle::legacy_definition::element::color::Color;
-use dc_bundle::legacy_definition::element::font::{FontStretch, FontStyle};
+use dc_bundle::legacy_definition::element::font::{FontFeature, FontStretch, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Size;
+use dc_bundle::legacy_definition::element::path::{LineHeight, StrokeAlign, StrokeWeight};
 use dc_bundle::legacy_definition::layout::layout_style::LayoutStyle;
+use dc_bundle::legacy_definition::modifier::blend::BlendMode;
+use dc_bundle::legacy_definition::modifier::filter::FilterOp;
+use dc_bundle::legacy_definition::modifier::text::{TextAlign, TextAlignVertical, TextOverflow};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -90,19 +94,6 @@ impl Background {
             scale_mode: ScaleMode::Tile,
             opacity: 1.0,
         }
-    }
-}
-
-/// This structure represents an OpenType feature, for example "tnum" controls tabular numbers
-/// in fonts that support the feature.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct FontFeature {
-    pub tag: [u8; 4],
-    pub enabled: bool,
-}
-impl FontFeature {
-    pub fn new(tag: &[u8; 4]) -> Self {
-        FontFeature { tag: *tag, enabled: true }
     }
 }
 
@@ -268,83 +259,11 @@ impl BoxShadow {
     }
 }
 
-/// Filters -- these can be applied to a view and its children (via the "filter" style),
-/// or to the elements behind a view (via the "backdrop_filter" style).
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-pub enum FilterOp {
-    /// Gaussian blur, radius in px.
-    Blur(f32),
-    //Saturation(f32),
-    Contrast(f32),
-    Grayscale(f32),
-    Brightness(f32),
-}
-
-/// Horizontal text alignment. This value aligns the text within its bounds.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
-pub enum TextAlign {
-    #[default]
-    Left,
-    Center,
-    Right,
-}
-
-/// Vertical text alignment. This value aligns the text vertically within its bounds.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
-pub enum TextAlignVertical {
-    #[default]
-    Top,
-    Center,
-    Bottom,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
-pub enum TextOverflow {
-    #[default]
-    Clip,
-    Ellipsis,
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub struct TextShadow {
     pub blur_radius: f32,
     pub color: Color,
     pub offset: (f32, f32),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-pub enum LineHeight {
-    Pixels(f32),
-    Percent(f32),
-}
-impl Default for LineHeight {
-    fn default() -> Self {
-        LineHeight::Percent(1.0)
-    }
-}
-
-/// How is a stroke aligned to its containing box?
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-pub enum StrokeAlign {
-    /// The stroke is entirely within the containing view. The stroke's outer edge matches the
-    /// outer edge of the containing view.
-    Inside,
-    /// The stroke is centered on the edge of the containing view, and extends into the view
-    /// on the inside, and out of the view on the outside.
-    Center,
-    /// The stroke is entirely outside of the view. The stroke's inner edge is the outer edge
-    /// of the containing view.
-    Outside,
-}
-
-/// Stroke weight is either a uniform value for all sides, or individual
-/// weights for each side.
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-pub enum StrokeWeight {
-    /// One weight is used for all sides.
-    Uniform(f32),
-    /// Individual weights for each side (typically only applied on boxes).
-    Individual { top: f32, right: f32, bottom: f32, left: f32 },
 }
 
 /// A stroke is similar to a border, except that it does not change layout (a border insets
@@ -367,42 +286,6 @@ impl Default for Stroke {
             strokes: Vec::new(),
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]
-pub enum BlendMode {
-    ///Normal blends:
-    #[default]
-    PassThrough,
-    ///(only applicable to objects with children)
-    Normal,
-
-    ///Darken:
-    Darken,
-    Multiply,
-    LinearBurn,
-    ColorBurn,
-
-    ///Lighten:
-    Lighten,
-    Screen,
-    LinearDodge,
-    ColorDodge,
-
-    ///Contrast:
-    Overlay,
-    SoftLight,
-    HardLight,
-
-    ///Inversion:
-    Difference,
-    Exclusion,
-
-    ///Component:
-    Hue,
-    Saturation,
-    Color,
-    Luminosity,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, Default)]

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -19,8 +19,8 @@ use crate::toolkit_font_style::FontWeight;
 use crate::toolkit_layout_style::Overflow;
 
 use crate::toolkit_style::{
-    Background, FilterOp, FontFeature, GridLayoutType, GridSpan, LayoutTransform, LineHeight,
-    MeterData, ShadowBox, StyledTextRun, TextAlign, TextOverflow, TextStyle, ViewStyle,
+    Background, GridLayoutType, GridSpan, LayoutTransform, MeterData, ShadowBox, StyledTextRun,
+    TextStyle, ViewStyle,
 };
 
 use crate::vector_schema;
@@ -28,10 +28,10 @@ use crate::{
     component_context::ComponentContext,
     extended_layout_schema::{ExtendedAutoLayout, LayoutType, SizePolicy}, //ExtendedTextLayout
     figma_schema::{
-        BlendMode, Component, ComponentSet, EffectType, HorizontalLayoutConstraintValue,
-        LayoutAlign, LayoutAlignItems, LayoutMode, LayoutSizing, LayoutSizingMode, LineHeightUnit,
-        Node, NodeData, PaintData, StrokeAlign, TextAlignHorizontal, TextAlignVertical,
-        TextAutoResize, TextTruncation, VerticalLayoutConstraintValue,
+        self, Component, ComponentSet, EffectType, HorizontalLayoutConstraintValue, LayoutAlign,
+        LayoutAlignItems, LayoutMode, LayoutSizing, LayoutSizingMode, LineHeightUnit, Node,
+        NodeData, PaintData, TextAlignHorizontal, TextAutoResize, TextTruncation,
+        VerticalLayoutConstraintValue,
     },
     image_context::ImageContext,
     reaction_schema::{FrameExtras, Reaction, ReactionJson},
@@ -42,12 +42,16 @@ use crate::{
 };
 
 use dc_bundle::definition::layout::FlexWrap;
-use dc_bundle::legacy_definition::element::font::FontStyle;
+use dc_bundle::legacy_definition::element::font::{FontFeature, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Dimension;
+use dc_bundle::legacy_definition::element::path::{LineHeight, StrokeAlign, StrokeWeight};
 use dc_bundle::legacy_definition::layout::grid::ItemSpacing;
 use dc_bundle::legacy_definition::layout::positioning::{
     AlignContent, AlignItems, AlignSelf, FlexDirection, JustifyContent, PositionType,
 };
+use dc_bundle::legacy_definition::modifier::blend::BlendMode;
+use dc_bundle::legacy_definition::modifier::filter::FilterOp;
+use dc_bundle::legacy_definition::modifier::text::{TextAlign, TextAlignVertical, TextOverflow};
 use log::error;
 use unicode_segmentation::UnicodeSegmentation;
 //::{Taffy, Dimension, JustifyContent, Size, AvailableSpace, FlexDirection};
@@ -493,29 +497,27 @@ fn convert_transform(transform: &crate::figma_schema::Transform) -> LayoutTransf
     )
 }
 
-fn convert_blend_mode(
-    blend_mode: Option<crate::figma_schema::BlendMode>,
-) -> crate::toolkit_style::BlendMode {
+fn convert_blend_mode(blend_mode: Option<crate::figma_schema::BlendMode>) -> BlendMode {
     match blend_mode {
-        Some(BlendMode::PassThrough) | None => crate::toolkit_style::BlendMode::PassThrough,
-        Some(BlendMode::Normal) => crate::toolkit_style::BlendMode::Normal,
-        Some(BlendMode::Darken) => crate::toolkit_style::BlendMode::Darken,
-        Some(BlendMode::Multiply) => crate::toolkit_style::BlendMode::Multiply,
-        Some(BlendMode::LinearBurn) => crate::toolkit_style::BlendMode::LinearBurn,
-        Some(BlendMode::ColorBurn) => crate::toolkit_style::BlendMode::ColorBurn,
-        Some(BlendMode::Lighten) => crate::toolkit_style::BlendMode::Lighten,
-        Some(BlendMode::Screen) => crate::toolkit_style::BlendMode::Screen,
-        Some(BlendMode::LinearDodge) => crate::toolkit_style::BlendMode::LinearDodge,
-        Some(BlendMode::ColorDodge) => crate::toolkit_style::BlendMode::ColorDodge,
-        Some(BlendMode::Overlay) => crate::toolkit_style::BlendMode::Overlay,
-        Some(BlendMode::SoftLight) => crate::toolkit_style::BlendMode::SoftLight,
-        Some(BlendMode::HardLight) => crate::toolkit_style::BlendMode::HardLight,
-        Some(BlendMode::Difference) => crate::toolkit_style::BlendMode::Difference,
-        Some(BlendMode::Exclusion) => crate::toolkit_style::BlendMode::Exclusion,
-        Some(BlendMode::Hue) => crate::toolkit_style::BlendMode::Hue,
-        Some(BlendMode::Saturation) => crate::toolkit_style::BlendMode::Saturation,
-        Some(BlendMode::Color) => crate::toolkit_style::BlendMode::Color,
-        Some(BlendMode::Luminosity) => crate::toolkit_style::BlendMode::Luminosity,
+        Some(crate::figma_schema::BlendMode::PassThrough) | None => BlendMode::PassThrough,
+        Some(crate::figma_schema::BlendMode::Normal) => BlendMode::Normal,
+        Some(crate::figma_schema::BlendMode::Darken) => BlendMode::Darken,
+        Some(crate::figma_schema::BlendMode::Multiply) => BlendMode::Multiply,
+        Some(crate::figma_schema::BlendMode::LinearBurn) => BlendMode::LinearBurn,
+        Some(crate::figma_schema::BlendMode::ColorBurn) => BlendMode::ColorBurn,
+        Some(crate::figma_schema::BlendMode::Lighten) => BlendMode::Lighten,
+        Some(crate::figma_schema::BlendMode::Screen) => BlendMode::Screen,
+        Some(crate::figma_schema::BlendMode::LinearDodge) => BlendMode::LinearDodge,
+        Some(crate::figma_schema::BlendMode::ColorDodge) => BlendMode::ColorDodge,
+        Some(crate::figma_schema::BlendMode::Overlay) => BlendMode::Overlay,
+        Some(crate::figma_schema::BlendMode::SoftLight) => BlendMode::SoftLight,
+        Some(crate::figma_schema::BlendMode::HardLight) => BlendMode::HardLight,
+        Some(crate::figma_schema::BlendMode::Difference) => BlendMode::Difference,
+        Some(crate::figma_schema::BlendMode::Exclusion) => BlendMode::Exclusion,
+        Some(crate::figma_schema::BlendMode::Hue) => BlendMode::Hue,
+        Some(crate::figma_schema::BlendMode::Saturation) => BlendMode::Saturation,
+        Some(crate::figma_schema::BlendMode::Color) => BlendMode::Color,
+        Some(crate::figma_schema::BlendMode::Luminosity) => BlendMode::Luminosity,
     }
 }
 
@@ -1122,9 +1124,9 @@ fn visit_node(
             TextAlignHorizontal::Justified => style.node_style.text_align = TextAlign::Center, // XXX
         }
         style.node_style.text_align_vertical = match text_style.text_align_vertical {
-            TextAlignVertical::Center => crate::toolkit_style::TextAlignVertical::Center,
-            TextAlignVertical::Top => crate::toolkit_style::TextAlignVertical::Top,
-            TextAlignVertical::Bottom => crate::toolkit_style::TextAlignVertical::Bottom,
+            figma_schema::TextAlignVertical::Center => TextAlignVertical::Center,
+            figma_schema::TextAlignVertical::Top => TextAlignVertical::Top,
+            figma_schema::TextAlignVertical::Bottom => TextAlignVertical::Bottom,
         };
         style.node_style.line_height = match text_style.line_height_unit {
             // It's a percentage of the font size.
@@ -1331,20 +1333,19 @@ fn visit_node(
     // Copy out the common styles from frames and supported content.
     style.node_style.opacity = if node.opacity < 1.0 { Some(node.opacity) } else { None };
     if let Some(individual_stroke_weights) = node.individual_stroke_weights {
-        style.node_style.stroke.stroke_weight = crate::toolkit_style::StrokeWeight::Individual {
+        style.node_style.stroke.stroke_weight = StrokeWeight::Individual {
             top: individual_stroke_weights.top,
             right: individual_stroke_weights.right,
             bottom: individual_stroke_weights.bottom,
             left: individual_stroke_weights.left,
         };
     } else if let Some(stroke_weight) = node.stroke_weight {
-        style.node_style.stroke.stroke_weight =
-            crate::toolkit_style::StrokeWeight::Uniform(stroke_weight);
+        style.node_style.stroke.stroke_weight = StrokeWeight::Uniform(stroke_weight);
     }
     style.node_style.stroke.stroke_align = match node.stroke_align {
-        Some(StrokeAlign::Inside) => crate::toolkit_style::StrokeAlign::Inside,
-        Some(StrokeAlign::Center) => crate::toolkit_style::StrokeAlign::Center,
-        Some(StrokeAlign::Outside) | None => crate::toolkit_style::StrokeAlign::Outside,
+        Some(figma_schema::StrokeAlign::Inside) => StrokeAlign::Inside,
+        Some(figma_schema::StrokeAlign::Center) => StrokeAlign::Center,
+        Some(figma_schema::StrokeAlign::Outside) | None => StrokeAlign::Outside,
     };
 
     // Convert any path data we have; we'll use it for non-frame types.

--- a/crates/figma_import/src/vector_schema.rs
+++ b/crates/figma_import/src/vector_schema.rs
@@ -14,9 +14,10 @@
 
 use std::convert::TryFrom;
 
+use dc_bundle::legacy_definition::modifier::blend::BlendMode;
 use serde::{Deserialize, Serialize};
 
-use crate::toolkit_style::{AffineTransform, Background, BlendMode, BoxShadow, Stroke};
+use crate::toolkit_style::{AffineTransform, Background, BoxShadow, Stroke};
 
 // This is a simple vector representation that should reproduce Figma or
 // another design tool's rendering. It simplifies the renderer's task by


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1293

## Full chain of PRs as of 2024-07-16

* PR #1349: `wb/froeht/more-bundle-migration` ➔ `wb/froeht/split-fi-ViewStyle`
* PR #1293: `wb/froeht/split-fi-ViewStyle` ➔ `main`

<!-- end git-machete generated -->
Most of the migrations are still blocked by #1292, so this only moves a small collection of code. It's progress, though.