### PR TITLE
Have Dependapool track screenshots

### DIFF
--- a/.github/workflows/roborazzi-record-screenshot.yml
+++ b/.github/workflows/roborazzi-record-screenshot.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
     - main
+    - dependapool
     - 'stable/**'
     - 'feature/**'
   pull_request:


### PR DESCRIPTION
In order to get proper screenshot comparisons in Dependabot PRs, the Dependapool branch needs to be recording updated screenshots when it's pushed to.