### PR TITLE
Reduce the size of the sdk-build Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,10 +99,10 @@ jobs:
           workspaces: ". -> designcompose/build/intermediates/cargoTarget"
           shared-key: "gradle-rust"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Full Gradle Test and publish
+      - name: Full Gradle Test
         uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         with:
-          arguments: check build publish assembleAndroidTest assembleUnitTest
+          arguments: assembleDebug assembleAndroidTest assembleUnitTest test
   build-maven-repo:
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
The runners were starting to run out of space. This changes removes some of the Gradle targets that were being built. It's not necessary to build "Benchmark" versions and it's not necessary to do a full publish. A full publish is already done by the build-maven-repo action.