### PR TITLE
Closes #1375: Migrate Variables from figma_import to dc_bundle

### DIFF
--- a/crates/dc_bundle/src/legacy_definition/element.rs
+++ b/crates/dc_bundle/src/legacy_definition/element.rs
@@ -19,3 +19,4 @@ pub mod font;
 pub mod geometry;
 pub mod node;
 pub mod path;
+pub mod variable;

--- a/crates/dc_bundle/src/legacy_definition/element/variable.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/variable.rs
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::legacy_definition::element::color::Color;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// Enum for fields that represent either a fixed number or a number variable
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum NumOrVar {
+    Num(f32),
+    Var { id: String, fallback: f32 },
+}
+
+// Enum for fields that represent either a fixed color or a color variable
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub enum ColorOrVar {
+    Color(Color),
+    Var { id: String, fallback: Color },
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct VariableAlias {
+    pub r#type: String,
+    pub id: String,
+}
+
+// We redeclare VariableValue instead of using the one from figma_schema because
+// the "untagged" attribute there prevents serde_reflection from being able to
+// run properly.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum VariableValue {
+    Bool(bool),
+    Number(f32),
+    Text(String),
+    Color(Color),
+    Alias(VariableAlias),
+}
+
+// Each variable contains a map of possible values. This data structure helps
+// keep track of that data and contains functions to retrieve the value of a
+// variable given a mode.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct VariableValueMap {
+    pub values_by_mode: HashMap<String, VariableValue>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum VariableType {
+    Bool,
+    Number,
+    Text,
+    Color,
+}
+
+// Representation of a Figma variable. We convert a figma_schema::Variable into
+// this format to make the fields a bit easier to access.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Variable {
+    pub id: String,
+    pub name: String,
+    pub remote: bool,
+    pub key: String,
+    pub variable_collection_id: String,
+    pub var_type: VariableType,
+    pub values_by_mode: VariableValueMap,
+}
+
+// Representation of a variable mode. Variables can have fixed values for each available mode
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Mode {
+    pub id: String,
+    pub name: String,
+}
+
+// Representation of a variable collection. Every variable belongs to a collection, and a
+// collection contains one or more modes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Collection {
+    pub id: String,
+    pub name: String,
+    pub default_mode_id: String,
+    pub mode_name_hash: HashMap<String, String>, // name -> id
+    pub mode_id_hash: HashMap<String, Mode>,     // id -> Mode
+}
+
+/// Stores variable mappings
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct VariableMap {
+    pub collections: HashMap<String, Collection>, // ID -> Collection
+    pub collection_name_map: HashMap<String, String>, // Name -> ID
+    pub variables: HashMap<String, Variable>,     // ID -> Variable
+    pub variable_name_map: HashMap<String, HashMap<String, String>>, // Collection ID -> [Name -> ID]
+}

--- a/crates/figma_import/src/design_definition.rs
+++ b/crates/figma_import/src/design_definition.rs
@@ -20,6 +20,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 use dc_bundle::legacy_definition::element::node::NodeQuery;
+use dc_bundle::legacy_definition::element::variable::VariableMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{document::FigmaDocInfo, image_context::EncodedImageMap, toolkit_schema};
@@ -55,7 +56,7 @@ pub struct DesignComposeDefinition {
     pub component_sets: HashMap<String, String>,
     pub version: String,
     pub id: String,
-    pub variable_map: toolkit_schema::VariableMap,
+    pub variable_map: VariableMap,
 }
 
 impl fmt::Display for DesignComposeDefinition {

--- a/crates/figma_import/src/document.rs
+++ b/crates/figma_import/src/document.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use dc_bundle::legacy_definition::element::node::NodeQuery;
+use dc_bundle::legacy_definition::element::variable::{Collection, Mode, Variable, VariableMap};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -30,11 +31,9 @@ use crate::{
         NodeData, NodesResponse, ProjectFilesResponse, VariablesResponse,
     },
     image_context::{EncodedImageMap, ImageContext, ImageContextSession, ImageKey},
-    toolkit_schema::{
-        Collection, ComponentContentOverride, ComponentOverrides, Mode, Variable, VariableMap,
-        View, ViewData,
-    },
+    toolkit_schema::{ComponentContentOverride, ComponentOverrides, View, ViewData},
     transform_flexbox::create_component_flexbox,
+    variable_utils::create_variable,
 };
 use log::error;
 
@@ -895,7 +894,7 @@ impl Document {
         let mut variable_name_map: HashMap<String, HashMap<String, String>> = HashMap::new();
         if let Some(variables_response) = self.variables_response.clone() {
             for (id, v) in variables_response.meta.variables.iter() {
-                let var = Variable::from_figma_var(v);
+                let var = create_variable(v);
                 let maybe_name_map = variable_name_map.get_mut(&var.variable_collection_id);
                 if let Some(name_map) = maybe_name_map {
                     name_map.insert(var.name.clone(), id.clone());

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -33,6 +33,7 @@ pub mod toolkit_schema;
 pub mod toolkit_style;
 mod transform_flexbox;
 mod utils;
+mod variable_utils;
 pub mod vector_schema;
 // Exports for library users
 pub use dc_bundle::legacy_definition::element::geometry::Rectangle;

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -165,33 +165,35 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
     tracer
         .trace_type::<crate::toolkit_schema::StrokeCap>(&samples)
         .expect("couldn't trace StrokeCap");
-    tracer.trace_type::<crate::toolkit_schema::Mode>(&samples).expect("couldn't trace Mode");
     tracer
-        .trace_type::<crate::toolkit_schema::Collection>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::Mode>(&samples)
+        .expect("couldn't trace Mode");
+    tracer
+        .trace_type::<dc_bundle::legacy_definition::element::variable::Collection>(&samples)
         .expect("couldn't trace Collection");
     tracer
-        .trace_type::<crate::figma_schema::VariableType>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::VariableType>(&samples)
         .expect("couldn't trace VariableType");
     tracer
         .trace_type::<crate::figma_schema::FigmaColor>(&samples)
         .expect("couldn't trace FigmaColor");
     tracer
-        .trace_type::<crate::figma_schema::VariableAlias>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::VariableAlias>(&samples)
         .expect("couldn't trace VariableAlias");
     tracer
-        .trace_type::<crate::toolkit_schema::NumOrVar>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::NumOrVar>(&samples)
         .expect("couldn't trace NumOrVar");
     tracer
-        .trace_type::<crate::toolkit_schema::ColorOrVar>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::ColorOrVar>(&samples)
         .expect("couldn't trace ColorOrVar");
     tracer
-        .trace_type::<crate::toolkit_schema::VariableValue>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::VariableValue>(&samples)
         .expect("couldn't trace VariableValue");
     tracer
-        .trace_type::<crate::toolkit_schema::Variable>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::Variable>(&samples)
         .expect("couldn't trace Variable");
     tracer
-        .trace_type::<crate::toolkit_schema::VariableMap>(&samples)
+        .trace_type::<dc_bundle::legacy_definition::element::variable::VariableMap>(&samples)
         .expect("couldn't trace VariableMap");
     tracer
         .trace_type::<crate::toolkit_schema::ViewShape>(&samples)

--- a/crates/figma_import/src/toolkit_font_style.rs
+++ b/crates/figma_import/src/toolkit_font_style.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::toolkit_schema::NumOrVar;
+// This implementation is derived from font-kit 0.6.0, which is dual licensed under
+// MIT and Apache 2.0. We are using it under the Apache 2.0 terms.
 use crate::utils::f32_eq;
+use dc_bundle::legacy_definition::element::variable::NumOrVar;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Debug, Display, Formatter},

--- a/crates/figma_import/src/toolkit_schema.rs
+++ b/crates/figma_import/src/toolkit_schema.rs
@@ -19,57 +19,14 @@ use std::sync::atomic::AtomicU16;
 // retain image references.
 use serde::{Deserialize, Serialize};
 
-use crate::figma_schema;
-use crate::figma_schema::VariableCommon;
 use crate::reaction_schema::FrameExtras;
 use crate::reaction_schema::Reaction;
 use crate::toolkit_style::{StyledTextRun, ViewStyle};
-use dc_bundle::legacy_definition::element::color::Color;
 pub use dc_bundle::legacy_definition::element::geometry::Rectangle;
+use dc_bundle::legacy_definition::element::variable::NumOrVar;
 use std::collections::HashMap;
 
 pub use crate::figma_schema::{FigmaColor, OverflowDirection, StrokeCap, VariableAlias};
-
-// Enum for fields that represent either a fixed number or a number variable
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum NumOrVar {
-    Num(f32),
-    Var { id: String, fallback: f32 },
-}
-impl NumOrVar {
-    pub(crate) fn from_var(
-        bound_variables: &figma_schema::BoundVariables,
-        var_name: &str,
-        num: f32,
-    ) -> NumOrVar {
-        let var = bound_variables.get_variable(var_name);
-        if let Some(var) = var {
-            NumOrVar::Var { id: var, fallback: num }
-        } else {
-            NumOrVar::Num(num)
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub enum ColorOrVar {
-    Color(Color),
-    Var { id: String, fallback: Color },
-}
-impl ColorOrVar {
-    pub(crate) fn from_var(
-        bound_variables: &figma_schema::BoundVariables,
-        var_name: &str,
-        color: &FigmaColor,
-    ) -> ColorOrVar {
-        let var = bound_variables.get_variable(var_name);
-        if let Some(var) = var {
-            ColorOrVar::Var { id: var, fallback: color.into() }
-        } else {
-            ColorOrVar::Color(color.into())
-        }
-    }
-}
 
 /// Shape of a view, either a rect or a path of some kind.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -282,131 +239,4 @@ impl View {
             children.push(child);
         }
     }
-}
-
-// Representation of a variable mode. Variables can have fixed values for each available mode
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Mode {
-    pub id: String,
-    pub name: String,
-}
-
-// Representation of a variable collection. Every variable belongs to a collection, and a
-// collection contains one or more modes.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Collection {
-    pub id: String,
-    pub name: String,
-    pub default_mode_id: String,
-    pub mode_name_hash: HashMap<String, String>, // name -> id
-    pub mode_id_hash: HashMap<String, Mode>,     // id -> Mode
-}
-
-// We redeclare VariableValue instead of using the one from figma_schema because
-// the "untagged" attribute there prevents serde_reflection from being able to
-// run properly.
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub enum VariableValue {
-    Bool(bool),
-    Number(f32),
-    Text(String),
-    Color(Color),
-    Alias(VariableAlias),
-}
-impl VariableValue {
-    fn from_figma_value(v: &figma_schema::VariableValue) -> VariableValue {
-        match v {
-            figma_schema::VariableValue::Boolean(b) => VariableValue::Bool(b.clone()),
-            figma_schema::VariableValue::Float(f) => VariableValue::Number(f.clone()),
-            figma_schema::VariableValue::String(s) => VariableValue::Text(s.clone()),
-            figma_schema::VariableValue::Color(c) => VariableValue::Color(c.into()),
-            figma_schema::VariableValue::Alias(a) => VariableValue::Alias(a.clone()),
-        }
-    }
-}
-
-// Each variable contains a map of possible values. This data structure helps
-// keep track of that data and contains functions to retrieve the value of a
-// variable given a mode.
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct VariableValueMap {
-    pub values_by_mode: HashMap<String, VariableValue>,
-}
-impl VariableValueMap {
-    fn from_figma_map(map: &HashMap<String, figma_schema::VariableValue>) -> VariableValueMap {
-        let mut values_by_mode: HashMap<String, VariableValue> = HashMap::new();
-        for (mode_id, value) in map.iter() {
-            values_by_mode.insert(mode_id.clone(), VariableValue::from_figma_value(value));
-        }
-        VariableValueMap { values_by_mode }
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-pub enum VariableType {
-    Bool,
-    Number,
-    Text,
-    Color,
-}
-
-// Representation of a Figma variable. We convert a figma_schema::Variable into
-// this format to make the fields a bit easier to access.
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct Variable {
-    pub id: String,
-    pub name: String,
-    pub remote: bool,
-    pub key: String,
-    pub variable_collection_id: String,
-    pub var_type: VariableType,
-    pub values_by_mode: VariableValueMap,
-}
-impl Variable {
-    fn new(
-        var_type: VariableType,
-        common: &VariableCommon,
-        values_by_mode: &HashMap<String, figma_schema::VariableValue>,
-    ) -> Self {
-        Variable {
-            id: common.id.clone(),
-            name: common.name.clone(),
-            remote: common.remote,
-            key: common.key.clone(),
-            variable_collection_id: common.variable_collection_id.clone(),
-            var_type,
-            values_by_mode: VariableValueMap::from_figma_map(values_by_mode),
-        }
-    }
-    pub fn from_figma_var(v: &figma_schema::Variable) -> Variable {
-        match v {
-            figma_schema::Variable::Boolean { common, values_by_mode } => {
-                Variable::new(VariableType::Bool, common, values_by_mode)
-            }
-            figma_schema::Variable::Float { common, values_by_mode } => {
-                Variable::new(VariableType::Number, common, values_by_mode)
-            }
-            figma_schema::Variable::String { common, values_by_mode } => {
-                Variable::new(VariableType::Bool, common, values_by_mode)
-            }
-            figma_schema::Variable::Color { common, values_by_mode } => {
-                Variable::new(VariableType::Text, common, values_by_mode)
-            }
-        }
-    }
-}
-
-/// Stores variable mappings
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VariableMap {
-    pub collections: HashMap<String, Collection>, // ID -> Collection
-    pub collection_name_map: HashMap<String, String>, // Name -> ID
-    pub variables: HashMap<String, Variable>,     // ID -> Variable
-    pub variable_name_map: HashMap<String, HashMap<String, String>>, // Collection ID -> [Name -> ID]
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct BoundVariables {
-    pub variables: HashMap<String, VariableAlias>,
 }

--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -20,6 +20,7 @@ use dc_bundle::legacy_definition::element::color::Color;
 use dc_bundle::legacy_definition::element::font::{FontFeature, FontStretch, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Size;
 use dc_bundle::legacy_definition::element::path::{LineHeight, StrokeAlign, StrokeWeight};
+use dc_bundle::legacy_definition::element::variable::{ColorOrVar, NumOrVar};
 use dc_bundle::legacy_definition::layout::layout_style::LayoutStyle;
 use dc_bundle::legacy_definition::modifier::blend::BlendMode;
 use dc_bundle::legacy_definition::modifier::filter::FilterOp;
@@ -30,7 +31,6 @@ use std::collections::HashMap;
 use crate::{
     toolkit_font_style::{FontWeight, TextDecoration},
     toolkit_layout_style::{Display, LayoutSizing, Number, Overflow},
-    toolkit_schema::{ColorOrVar, NumOrVar},
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -35,16 +35,15 @@ use crate::{
     },
     image_context::ImageContext,
     reaction_schema::{FrameExtras, Reaction, ReactionJson},
-    toolkit_schema::{
-        ColorOrVar, ComponentInfo, NumOrVar, OverflowDirection, RenderMethod, ScrollInfo, View,
-        ViewShape,
-    },
+    toolkit_schema::{ComponentInfo, OverflowDirection, RenderMethod, ScrollInfo, View, ViewShape},
+    variable_utils::FromFigmaVar,
 };
 
 use dc_bundle::definition::layout::FlexWrap;
 use dc_bundle::legacy_definition::element::font::{FontFeature, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Dimension;
 use dc_bundle::legacy_definition::element::path::{LineHeight, StrokeAlign, StrokeWeight};
+use dc_bundle::legacy_definition::element::variable::{ColorOrVar, NumOrVar};
 use dc_bundle::legacy_definition::layout::grid::ItemSpacing;
 use dc_bundle::legacy_definition::layout::positioning::{
     AlignContent, AlignItems, AlignSelf, FlexDirection, JustifyContent, PositionType,

--- a/crates/figma_import/src/variable_utils.rs
+++ b/crates/figma_import/src/variable_utils.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::figma_schema;
+use dc_bundle::legacy_definition::element::variable::{
+    ColorOrVar, NumOrVar, Variable, VariableAlias, VariableType, VariableValue, VariableValueMap,
+};
+use std::collections::HashMap;
+
+// Trait to create a XOrVar from Figma data
+pub(crate) trait FromFigmaVar<VarType> {
+    fn from_var(
+        bound_variables: &crate::figma_schema::BoundVariables,
+        var_name: &str,
+        var_value: VarType,
+    ) -> Self;
+}
+// Create a NumOrVar from Figma variable name and number value
+impl FromFigmaVar<f32> for NumOrVar {
+    fn from_var(
+        bound_variables: &crate::figma_schema::BoundVariables,
+        var_name: &str,
+        var_value: f32,
+    ) -> Self {
+        let var = bound_variables.get_variable(var_name);
+        if let Some(var) = var {
+            NumOrVar::Var { id: var, fallback: var_value }
+        } else {
+            NumOrVar::Num(var_value)
+        }
+    }
+}
+// Create a ColorOrVar from Figma variable name and color value
+impl FromFigmaVar<&figma_schema::FigmaColor> for ColorOrVar {
+    fn from_var(
+        bound_variables: &figma_schema::BoundVariables,
+        var_name: &str,
+        color: &figma_schema::FigmaColor,
+    ) -> Self {
+        let var = bound_variables.get_variable(var_name);
+        if let Some(var) = var {
+            ColorOrVar::Var { id: var, fallback: color.into() }
+        } else {
+            ColorOrVar::Color(color.into())
+        }
+    }
+}
+
+// Create a VariableAlias from figma_schema::VariableAlias
+fn create_variable_alias(figma_var_alias: &figma_schema::VariableAlias) -> VariableAlias {
+    VariableAlias { r#type: figma_var_alias.r#type.clone(), id: figma_var_alias.id.clone() }
+}
+
+// Create a VariableValue from figma_schema::VariableValue
+fn create_variable_value(v: &figma_schema::VariableValue) -> VariableValue {
+    match v {
+        figma_schema::VariableValue::Boolean(b) => VariableValue::Bool(b.clone()),
+        figma_schema::VariableValue::Float(f) => VariableValue::Number(f.clone()),
+        figma_schema::VariableValue::String(s) => VariableValue::Text(s.clone()),
+        figma_schema::VariableValue::Color(c) => VariableValue::Color(c.into()),
+        figma_schema::VariableValue::Alias(a) => VariableValue::Alias(create_variable_alias(a)),
+    }
+}
+
+// Create a VariableValueMap from a hash of mode IDs to Figma VariableValues
+fn create_variable_value_map(
+    map: &HashMap<String, figma_schema::VariableValue>,
+) -> VariableValueMap {
+    let mut values_by_mode: HashMap<String, VariableValue> = HashMap::new();
+    for (mode_id, value) in map.iter() {
+        values_by_mode.insert(mode_id.clone(), create_variable_value(value));
+    }
+    VariableValueMap { values_by_mode }
+}
+
+// Helper function to create a Variable
+fn create_variable_helper(
+    var_type: VariableType,
+    common: &figma_schema::VariableCommon,
+    values_by_mode: &HashMap<String, figma_schema::VariableValue>,
+) -> Variable {
+    Variable {
+        id: common.id.clone(),
+        name: common.name.clone(),
+        remote: common.remote,
+        key: common.key.clone(),
+        variable_collection_id: common.variable_collection_id.clone(),
+        var_type,
+        values_by_mode: create_variable_value_map(values_by_mode),
+    }
+}
+
+// Create a variable from figma_schema::Variable
+pub(crate) fn create_variable(v: &figma_schema::Variable) -> Variable {
+    match v {
+        figma_schema::Variable::Boolean { common, values_by_mode } => {
+            create_variable_helper(VariableType::Bool, common, values_by_mode)
+        }
+        figma_schema::Variable::Float { common, values_by_mode } => {
+            create_variable_helper(VariableType::Number, common, values_by_mode)
+        }
+        figma_schema::Variable::String { common, values_by_mode } => {
+            create_variable_helper(VariableType::Bool, common, values_by_mode)
+        }
+        figma_schema::Variable::Color { common, values_by_mode } => {
+            create_variable_helper(VariableType::Text, common, values_by_mode)
+        }
+    }
+}


### PR DESCRIPTION
Move variable declarations into variable.rs. This includes creating some structs that are basically copies of their counterpart in figma_schema.

Add a variable_utils.rs file that includes functions to create variables from figma_schema data.

Fixes #1375 