### PR TITLE
Have all uses of `figma_schema` types qualify their module

### DIFF
--- a/crates/figma_import/src/component_context.rs
+++ b/crates/figma_import/src/component_context.rs
@@ -16,7 +16,7 @@ use dc_bundle::legacy_definition::element::node::NodeQuery;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    figma_schema::Node,
+    figma_schema,
     reaction_schema::{Action, Reaction},
 };
 
@@ -37,7 +37,7 @@ pub struct ComponentContext {
 
 impl ComponentContext {
     /// Create a new ComponentContext which knows that the given nodes will be converted.
-    pub fn new(nodes: &Vec<(NodeQuery, &Node)>) -> ComponentContext {
+    pub fn new(nodes: &Vec<(NodeQuery, &figma_schema::Node)>) -> ComponentContext {
         let mut converted_nodes = HashSet::new();
         for (_, node) in nodes {
             converted_nodes.insert(node.id.clone());
@@ -82,8 +82,8 @@ impl ComponentContext {
     /// Get the list of nodes to convert next, and reset the list of referenced nodes.
     pub fn referenced_list<'a>(
         &mut self,
-        id_index: &HashMap<String, &'a Node>,
-    ) -> Vec<(NodeQuery, &'a Node)> {
+        id_index: &HashMap<String, &'a figma_schema::Node>,
+    ) -> Vec<(NodeQuery, &'a figma_schema::Node)> {
         let mut list = Vec::new();
 
         // Create a NodeId query and try to find the node for each referenced node we know about.

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -44,7 +44,6 @@ pub use design_definition::{
 pub use document::Document;
 pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse, ProxyConfig};
-pub use figma_schema::Node;
 pub use image_context::{ImageContextSession, ImageKey};
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -157,13 +157,13 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<crate::toolkit_schema::ComponentInfo>(&samples)
         .expect("couldn't trace ComponentInfo");
     tracer
-        .trace_type::<crate::toolkit_schema::OverflowDirection>(&samples)
+        .trace_type::<crate::figma_schema::OverflowDirection>(&samples)
         .expect("couldn't trace OverflowDirection");
     tracer
         .trace_type::<crate::toolkit_schema::RenderMethod>(&samples)
         .expect("couldn't trace RenderMethod");
     tracer
-        .trace_type::<crate::toolkit_schema::StrokeCap>(&samples)
+        .trace_type::<crate::figma_schema::StrokeCap>(&samples)
         .expect("couldn't trace StrokeCap");
     tracer
         .trace_type::<dc_bundle::legacy_definition::element::variable::Mode>(&samples)

--- a/crates/figma_import/src/toolkit_schema.rs
+++ b/crates/figma_import/src/toolkit_schema.rs
@@ -19,14 +19,13 @@ use std::sync::atomic::AtomicU16;
 // retain image references.
 use serde::{Deserialize, Serialize};
 
+use crate::figma_schema;
 use crate::reaction_schema::FrameExtras;
 use crate::reaction_schema::Reaction;
 use crate::toolkit_style::{StyledTextRun, ViewStyle};
 pub use dc_bundle::legacy_definition::element::geometry::Rectangle;
 use dc_bundle::legacy_definition::element::variable::NumOrVar;
 use std::collections::HashMap;
-
-pub use crate::figma_schema::{FigmaColor, OverflowDirection, StrokeCap, VariableAlias};
 
 /// Shape of a view, either a rect or a path of some kind.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -47,7 +46,7 @@ pub enum ViewShape {
     Arc {
         path: Vec<crate::vector_schema::Path>,
         stroke: Vec<crate::vector_schema::Path>,
-        stroke_cap: StrokeCap,
+        stroke_cap: figma_schema::StrokeCap,
         start_angle_degrees: f32,
         sweep_angle_degrees: f32,
         inner_radius: f32,
@@ -105,12 +104,12 @@ pub struct ComponentInfo {
 /// paged_scrolling, which comes from the vsw-extended-layout plugin.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct ScrollInfo {
-    pub overflow: OverflowDirection,
+    pub overflow: figma_schema::OverflowDirection,
     pub paged_scrolling: bool,
 }
 impl Default for ScrollInfo {
     fn default() -> Self {
-        ScrollInfo { overflow: OverflowDirection::None, paged_scrolling: false }
+        ScrollInfo { overflow: figma_schema::OverflowDirection::None, paged_scrolling: false }
     }
 }
 


### PR DESCRIPTION
This will help with with DesignDefinition migration to dc_bundle. Many of the types share names with `figma_schema` types. In general we would like the `dc_bundle` types to be the "default" ones, so the `figma_schema` types, when used, should be qualified with their name.