### PR TITLE
Migrate Transforms and ImageKey to dc_bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
 name = "dc_bundle"
 version = "0.1.0"
 dependencies = [
+ "euclid",
  "prost",
  "prost-build",
  "serde",

--- a/crates/dc_bundle/Cargo.toml
+++ b/crates/dc_bundle/Cargo.toml
@@ -12,5 +12,9 @@ prost.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 
+# Temporary dependencies during the transition to protobuf structures
+euclid.workspace = true
+
+
 [build-dependencies]
 prost-build.workspace = true

--- a/crates/dc_bundle/src/legacy_definition/element.rs
+++ b/crates/dc_bundle/src/legacy_definition/element.rs
@@ -17,6 +17,7 @@
 pub mod color;
 pub mod font;
 pub mod geometry;
+pub mod image;
 pub mod node;
 pub mod path;
 pub mod variable;

--- a/crates/dc_bundle/src/legacy_definition/element/image.rs
+++ b/crates/dc_bundle/src/legacy_definition/element/image.rs
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
-pub mod blend;
-pub mod filter;
-pub mod text;
-pub mod transform;
+use serde::{Deserialize, Serialize};
+
+/// Instead of keeping decoded images in ViewStyle objects, we keep keys to the images in the
+/// ImageContext and then fetch decoded images when rendering. This means we can serialize the
+/// whole ImageContext, and always get the right image when we render.
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Debug)]
+pub struct ImageKey(String);
+
+impl ImageKey {
+    pub fn key(&self) -> String {
+        self.0.clone()
+    }
+
+    pub fn new(str: String) -> ImageKey {
+        ImageKey(str)
+    }
+}

--- a/crates/dc_bundle/src/legacy_definition/modifier/transform.rs
+++ b/crates/dc_bundle/src/legacy_definition/modifier/transform.rs
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-pub mod blend;
-pub mod filter;
-pub mod text;
-pub mod transform;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct LayoutPixel;
+
+pub type LayoutTransform = euclid::Transform3D<f32, LayoutPixel, LayoutPixel>;
+pub type AffineTransform = euclid::Transform2D<f32, LayoutPixel, LayoutPixel>;

--- a/crates/figma_import/src/document.rs
+++ b/crates/figma_import/src/document.rs
@@ -27,11 +27,12 @@ use crate::{
     extended_layout_schema::ExtendedAutoLayout,
     fetch::ProxyConfig,
     figma_schema,
-    image_context::{EncodedImageMap, ImageContext, ImageContextSession, ImageKey},
+    image_context::{EncodedImageMap, ImageContext, ImageContextSession},
     toolkit_schema::{ComponentContentOverride, ComponentOverrides, View, ViewData},
     transform_flexbox::create_component_flexbox,
     variable_utils::create_variable,
 };
+use dc_bundle::legacy_definition::element::image::ImageKey;
 use log::error;
 
 const FIGMA_TOKEN_HEADER: &str = "X-Figma-Token";

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -44,10 +44,11 @@ pub use design_definition::{
 pub use document::Document;
 pub use error::Error;
 pub use fetch::{fetch_doc, ConvertRequest, ConvertResponse, ProxyConfig};
-pub use image_context::{ImageContextSession, ImageKey};
+pub use image_context::ImageContextSession;
 pub use toolkit_schema::{View, ViewData}; // ugly hack
                                           // Internal convenience
 pub use dc_bundle::legacy_definition::element::color::Color;
+pub use dc_bundle::legacy_definition::element::image::ImageKey;
 pub use dc_bundle::legacy_definition::element::node::NodeQuery;
 
 #[cfg(feature = "http_mock")]

--- a/crates/figma_import/src/toolkit_style.rs
+++ b/crates/figma_import/src/toolkit_style.rs
@@ -19,12 +19,15 @@ use dc_bundle::definition::layout::FlexWrap;
 use dc_bundle::legacy_definition::element::color::Color;
 use dc_bundle::legacy_definition::element::font::{FontFeature, FontStretch, FontStyle};
 use dc_bundle::legacy_definition::element::geometry::Size;
+use dc_bundle::legacy_definition::element::image::ImageKey;
 use dc_bundle::legacy_definition::element::path::{LineHeight, StrokeAlign, StrokeWeight};
 use dc_bundle::legacy_definition::element::variable::{ColorOrVar, NumOrVar};
 use dc_bundle::legacy_definition::layout::layout_style::LayoutStyle;
 use dc_bundle::legacy_definition::modifier::blend::BlendMode;
 use dc_bundle::legacy_definition::modifier::filter::FilterOp;
 use dc_bundle::legacy_definition::modifier::text::{TextAlign, TextAlignVertical, TextOverflow};
+use dc_bundle::legacy_definition::modifier::transform::AffineTransform;
+use dc_bundle::legacy_definition::modifier::transform::LayoutTransform;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -70,7 +73,7 @@ pub enum Background {
     },
     // DiamondGradient support possibly in the future.
     Image {
-        key: Option<crate::image_context::ImageKey>,
+        key: Option<ImageKey>,
         filters: Vec<FilterOp>,
         transform: Option<AffineTransform>,
         scale_mode: ScaleMode,
@@ -86,7 +89,7 @@ impl Background {
             _ => true,
         }
     }
-    pub fn from_image_key(key: crate::image_context::ImageKey) -> Background {
+    pub fn from_image_key(key: ImageKey) -> Background {
         Background::Image {
             key: Some(key),
             filters: Vec::new(),
@@ -295,12 +298,6 @@ pub enum PointerEvents {
     #[default]
     Inherit,
 }
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct LayoutPixel;
-
-pub type LayoutTransform = euclid::Transform3D<f32, LayoutPixel, LayoutPixel>;
-pub type AffineTransform = euclid::Transform2D<f32, LayoutPixel, LayoutPixel>;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GridSpan {

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -19,8 +19,7 @@ use crate::toolkit_font_style::FontWeight;
 use crate::toolkit_layout_style::Overflow;
 
 use crate::toolkit_style::{
-    Background, GridLayoutType, GridSpan, LayoutTransform, MeterData, ShadowBox, StyledTextRun,
-    TextStyle, ViewStyle,
+    Background, GridLayoutType, GridSpan, MeterData, ShadowBox, StyledTextRun, TextStyle, ViewStyle,
 };
 
 use crate::figma_schema;
@@ -46,6 +45,7 @@ use dc_bundle::legacy_definition::layout::positioning::{
 use dc_bundle::legacy_definition::modifier::blend::BlendMode;
 use dc_bundle::legacy_definition::modifier::filter::FilterOp;
 use dc_bundle::legacy_definition::modifier::text::{TextAlign, TextAlignVertical, TextOverflow};
+use dc_bundle::legacy_definition::modifier::transform::LayoutTransform;
 use log::error;
 use unicode_segmentation::UnicodeSegmentation;
 //::{Taffy, Dimension, JustifyContent, Size, AvailableSpace, FlexDirection};

--- a/crates/figma_import/src/vector_schema.rs
+++ b/crates/figma_import/src/vector_schema.rs
@@ -15,9 +15,10 @@
 use std::convert::TryFrom;
 
 use dc_bundle::legacy_definition::modifier::blend::BlendMode;
+use dc_bundle::legacy_definition::modifier::transform::AffineTransform;
 use serde::{Deserialize, Serialize};
 
-use crate::toolkit_style::{AffineTransform, Background, BoxShadow, Stroke};
+use crate::toolkit_style::{Background, BoxShadow, Stroke};
 
 // This is a simple vector representation that should reproduce Figma or
 // another design tool's rendering. It simplifies the renderer's task by


### PR DESCRIPTION
The Transforms types are basically re-exports of euclid types, so dc_bundle will need to temporarily depend on euclid