### PR TITLE
Moving binaries to `tools` directory

### DIFF
--- a/crates/figma_import/src/bin/dcf_info.rs
+++ b/crates/figma_import/src/bin/dcf_info.rs
@@ -22,63 +22,9 @@
 // `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill`
 
 use clap::Parser;
-use figma_import::load_design_def;
 
-#[derive(Debug)]
-struct ParseError(String);
-impl From<bincode::Error> for ParseError {
-    fn from(e: bincode::Error) -> Self {
-        eprintln!("Error during deserialization: {:?}", e);
-        ParseError(format!("Error during deserialization: {:?}", e))
-    }
-}
-impl From<std::io::Error> for ParseError {
-    fn from(e: std::io::Error) -> Self {
-        eprintln!("Error opening file: {:?}", e);
-        ParseError(format!("Error opening file: {:?}", e))
-    }
-}
-impl From<figma_import::Error> for ParseError {
-    fn from(e: figma_import::Error) -> Self {
-        ParseError(format!("Figma Import Error: {:?}", e))
-    }
-}
-
-#[derive(Parser, Debug)]
-struct Args {
-    // Path to the .dcf file to deserialize
-    dcf_file: std::path::PathBuf,
-    // Optional string argument to dump file structure from a given node root.
-    #[clap(long, short)]
-    node: Option<String>,
-}
-
-fn dcf_info(args: Args) -> Result<(), ParseError> {
-    let file_path = &args.dcf_file;
-    let node = args.node;
-
-    let (header, doc) = load_design_def(file_path)?;
-
-    println!("Deserialized file");
-    println!("  Header Version: {}", header.version);
-    println!("  Doc ID: {}", doc.id);
-    println!("  Figma Version: {}", doc.version);
-    println!("  Name: {}", doc.name);
-    println!("  Last Modified: {}", doc.last_modified);
-
-    if let Some(node) = node {
-        println!("Dumping file from node: {}:", node);
-        if let Some(view) = doc.views.get(&figma_import::NodeQuery::name(&node)) {
-            // NOTE: uses format and Debug implementation to pretty print the node and all children.
-            // See: https://doc.rust-lang.org/std/fmt/#usage
-            println!("{:#?}", view);
-        } else {
-            return Err(ParseError(format!("Node: {} not found in document.", node)));
-        }
-    }
-
-    Ok(())
-}
+use figma_import::tools::dcf_info::dcf_info;
+use figma_import::tools::dcf_info::Args;
 
 fn main() {
     let args = Args::parse();

--- a/crates/figma_import/src/bin/fetch.rs
+++ b/crates/figma_import/src/bin/fetch.rs
@@ -12,112 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Write;
-
-/// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
-use dc_bundle::legacy_definition::element::node::NodeQuery;
-use figma_import::{DesignComposeDefinition, DesignComposeDefinitionHeader, Document, ProxyConfig};
-#[derive(Debug)]
-struct ConvertError(String);
-impl From<figma_import::Error> for ConvertError {
-    fn from(e: figma_import::Error) -> Self {
-        eprintln!("Error during Figma conversion: {:?}", e);
-        ConvertError(format!("Internal Server Error during Figma conversion: {:?}", e))
-    }
-}
-impl From<bincode::Error> for ConvertError {
-    fn from(e: bincode::Error) -> Self {
-        eprintln!("Error during serialization: {:?}", e);
-        ConvertError(format!("Error during serialization: {:?}", e))
-    }
-}
-impl From<serde_json::Error> for ConvertError {
-    fn from(e: serde_json::Error) -> Self {
-        eprintln!("Error during image session serialization: {:?}", e);
-        ConvertError(format!("Error during image session serialization: {:?}", e))
-    }
-}
-impl From<std::io::Error> for ConvertError {
-    fn from(e: std::io::Error) -> Self {
-        eprintln!("Error creating output file: {:?}", e);
-        ConvertError(format!("Error creating output file: {:?}", e))
-    }
-}
-#[derive(Parser, Debug)]
-struct Args {
-    /// Figma Document ID to fetch and convert
-    #[arg(short, long)]
-    doc_id: String,
-    /// Figma Document Version ID to fetch and convert
-    #[arg(short, long)]
-    version_id: Option<String>,
-    /// Figma API key to use for Figma requests
-    #[arg(short, long)]
-    api_key: String,
-    /// HTTP proxy server - <host>:<port>
-    #[arg(long)]
-    http_proxy: Option<String>,
-    /// Root nodes to find in the doc and convert
-    #[arg(short, long)]
-    nodes: Vec<String>,
-    /// Output file to write serialized doc into
-    #[arg(short, long)]
-    output: std::path::PathBuf,
-}
-fn fetch_impl(args: Args) -> Result<(), ConvertError> {
-    let proxy_config: ProxyConfig = match args.http_proxy {
-        Some(x) => ProxyConfig::HttpProxyConfig(x),
-        None => ProxyConfig::None,
-    };
-    let mut doc = Document::new(
-        args.api_key.as_str(),
-        args.doc_id,
-        args.version_id.unwrap_or(String::new()),
-        &proxy_config,
-        None,
-    )?;
-    let mut error_list = Vec::new();
-    // Convert the requested nodes from the Figma doc.
-    let views = doc.nodes(
-        &args.nodes.iter().map(|name| NodeQuery::name(name)).collect(),
-        &Vec::new(),
-        &mut error_list,
-    )?;
-    for error in error_list {
-        eprintln!("Warning: {error}");
-    }
 
-    let variable_map = doc.build_variable_map();
+use figma_import::tools::fetch::fetch;
+use figma_import::tools::fetch::Args;
 
-    // Build the serializable doc structure
-    let serializable_doc = DesignComposeDefinition {
-        views,
-        component_sets: doc.component_sets().clone(),
-        images: doc.encoded_image_map(),
-        last_modified: doc.last_modified().clone(),
-        name: doc.get_name(),
-        version: doc.get_version(),
-        id: doc.get_document_id(),
-        variable_map: variable_map,
-    };
-    println!("Fetched document");
-    println!("  DC Version: {}", DesignComposeDefinitionHeader::current().version);
-    println!("  Doc ID: {}", doc.get_document_id());
-    println!("  Version: {}", doc.get_version());
-    println!("  Name: {}", doc.get_name());
-    println!("  Last Modified: {}", doc.last_modified().clone());
-    // We don't bother with serialization of image sessions with this tool.
-    let mut output = std::fs::File::create(args.output)?;
-    let header = bincode::serialize(&DesignComposeDefinitionHeader::current())?;
-    let doc = bincode::serialize(&serializable_doc)?;
-    output.write_all(header.as_slice())?;
-    output.write_all(doc.as_slice())?;
-    Ok(())
-}
 fn main() {
     let args = Args::parse();
-    if let Err(e) = fetch_impl(args) {
+    if let Err(e) = fetch(args) {
         eprintln!("Fetch failed: {:?}", e);
         std::process::exit(1);
     }

--- a/crates/figma_import/src/bin/reflection.rs
+++ b/crates/figma_import/src/bin/reflection.rs
@@ -13,37 +13,14 @@
 // limitations under the License.
 
 use clap::Parser;
-use serde_generate::SourceInstaller;
-/// This program uses the serde-reflection and serde-generate crates to emit a Java
-/// implementation of a deserializer for our serialized view trees. We have to trace
-/// all of the types used in our schema manually.
-///
-/// We can also emit a yaml representation of the schema, which could be used to diff
-/// our schema in CI.
 
-#[derive(Parser)]
-struct Cli {
-    #[arg(short, long, default_value = "out")]
-    out_dir: std::path::PathBuf,
-}
+use figma_import::tools::reflection::reflection;
+use figma_import::tools::reflection::Cli;
 
-#[cfg(feature = "reflection")]
 fn main() {
     let args = Cli::parse();
-
-    let registry = figma_import::reflection::registry().expect("no tracer registry");
-
-    let config =
-        serde_generate::CodeGeneratorConfig::new("com.android.designcompose.serdegen".into())
-            .with_encodings(vec![serde_generate::Encoding::Bincode]);
-
-    let installer = serde_generate::java::Installer::new(args.out_dir);
-    installer.install_module(&config, &registry).expect("couldn't write java sources");
-    installer.install_serde_runtime().expect("couldn't write runtime");
-    installer.install_bincode_runtime().expect("couldn't write runtime");
-}
-
-#[cfg(not(feature = "reflection"))]
-fn main() {
-    panic!("Reflection feature not enabled")
+    if let Err(e) = reflection(args) {
+        eprintln!("Fetch failed: {:?}", e);
+        std::process::exit(1);
+    }
 }

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -30,8 +30,9 @@ pub mod reaction_schema;
 pub mod toolkit_layout_style;
 pub mod toolkit_schema;
 pub mod toolkit_style;
+pub mod tools;
 mod transform_flexbox;
-mod utils;
+pub mod utils;
 mod variable_utils;
 pub mod vector_schema;
 // Exports for library users

--- a/crates/figma_import/src/tools/dcf_info.rs
+++ b/crates/figma_import/src/tools/dcf_info.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Utility program to parse a .dcf file and print its contents.
+// By default prints the header and file info.
+// Provide the optional `--node` or `-n` switch to dump figma document using
+// that node as root.
+// Example:
+// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf`
+// or
+// `cargo run --bin dcf_info --features="dcf_info" -- tests/layout-unit-tests.dcf -n HorizontalFill`
+
+use crate::load_design_def;
+use clap::Parser;
+
+#[derive(Debug)]
+pub struct ParseError(String);
+impl From<bincode::Error> for ParseError {
+    fn from(e: bincode::Error) -> Self {
+        eprintln!("Error during deserialization: {:?}", e);
+        ParseError(format!("Error during deserialization: {:?}", e))
+    }
+}
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        eprintln!("Error opening file: {:?}", e);
+        ParseError(format!("Error opening file: {:?}", e))
+    }
+}
+impl From<crate::Error> for ParseError {
+    fn from(e: crate::Error) -> Self {
+        ParseError(format!("Figma Import Error: {:?}", e))
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    // Path to the .dcf file to deserialize
+    dcf_file: std::path::PathBuf,
+    // Optional string argument to dump file structure from a given node root.
+    #[clap(long, short)]
+    node: Option<String>,
+}
+
+pub fn dcf_info(args: Args) -> Result<(), ParseError> {
+    let file_path = &args.dcf_file;
+    let node = args.node;
+
+    let (header, doc) = load_design_def(file_path)?;
+
+    println!("Deserialized file");
+    println!("  Header Version: {}", header.version);
+    println!("  Doc ID: {}", doc.id);
+    println!("  Figma Version: {}", doc.version);
+    println!("  Name: {}", doc.name);
+    println!("  Last Modified: {}", doc.last_modified);
+
+    if let Some(node) = node {
+        println!("Dumping file from node: {}:", node);
+        if let Some(view) = doc.views.get(&crate::NodeQuery::name(&node)) {
+            // NOTE: uses format and Debug implementation to pretty print the node and all children.
+            // See: https://doc.rust-lang.org/std/fmt/#usage
+            println!("{:#?}", view);
+        } else {
+            return Err(ParseError(format!("Node: {} not found in document.", node)));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/figma_import/src/tools/fetch.rs
+++ b/crates/figma_import/src/tools/fetch.rs
@@ -1,0 +1,119 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use crate::{DesignComposeDefinition, DesignComposeDefinitionHeader, Document, ProxyConfig};
+/// Utility program to fetch a doc and serialize it to file
+use clap::Parser;
+use dc_bundle::legacy_definition::element::node::NodeQuery;
+
+#[derive(Debug)]
+pub struct ConvertError(String);
+impl From<crate::Error> for ConvertError {
+    fn from(e: crate::Error) -> Self {
+        eprintln!("Error during Figma conversion: {:?}", e);
+        ConvertError(format!("Internal Server Error during Figma conversion: {:?}", e))
+    }
+}
+impl From<bincode::Error> for ConvertError {
+    fn from(e: bincode::Error) -> Self {
+        eprintln!("Error during serialization: {:?}", e);
+        ConvertError(format!("Error during serialization: {:?}", e))
+    }
+}
+impl From<serde_json::Error> for ConvertError {
+    fn from(e: serde_json::Error) -> Self {
+        eprintln!("Error during image session serialization: {:?}", e);
+        ConvertError(format!("Error during image session serialization: {:?}", e))
+    }
+}
+impl From<std::io::Error> for ConvertError {
+    fn from(e: std::io::Error) -> Self {
+        eprintln!("Error creating output file: {:?}", e);
+        ConvertError(format!("Error creating output file: {:?}", e))
+    }
+}
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Figma Document ID to fetch and convert
+    #[arg(short, long)]
+    doc_id: String,
+    /// Figma Document Version ID to fetch and convert
+    #[arg(short, long)]
+    version_id: Option<String>,
+    /// Figma API key to use for Figma requests
+    #[arg(short, long)]
+    api_key: String,
+    /// HTTP proxy server - <host>:<port>
+    #[arg(long)]
+    http_proxy: Option<String>,
+    /// Root nodes to find in the doc and convert
+    #[arg(short, long)]
+    nodes: Vec<String>,
+    /// Output file to write serialized doc into
+    #[arg(short, long)]
+    output: std::path::PathBuf,
+}
+
+pub fn fetch(args: Args) -> Result<(), ConvertError> {
+    let proxy_config: ProxyConfig = match args.http_proxy {
+        Some(x) => ProxyConfig::HttpProxyConfig(x),
+        None => ProxyConfig::None,
+    };
+    let mut doc = Document::new(
+        args.api_key.as_str(),
+        args.doc_id,
+        args.version_id.unwrap_or(String::new()),
+        &proxy_config,
+        None,
+    )?;
+    let mut error_list = Vec::new();
+    // Convert the requested nodes from the Figma doc.
+    let views = doc.nodes(
+        &args.nodes.iter().map(|name| NodeQuery::name(name)).collect(),
+        &Vec::new(),
+        &mut error_list,
+    )?;
+    for error in error_list {
+        eprintln!("Warning: {error}");
+    }
+
+    let variable_map = doc.build_variable_map();
+
+    // Build the serializable doc structure
+    let serializable_doc = DesignComposeDefinition {
+        views,
+        component_sets: doc.component_sets().clone(),
+        images: doc.encoded_image_map(),
+        last_modified: doc.last_modified().clone(),
+        name: doc.get_name(),
+        version: doc.get_version(),
+        id: doc.get_document_id(),
+        variable_map: variable_map,
+    };
+    println!("Fetched document");
+    println!("  DC Version: {}", DesignComposeDefinitionHeader::current().version);
+    println!("  Doc ID: {}", doc.get_document_id());
+    println!("  Version: {}", doc.get_version());
+    println!("  Name: {}", doc.get_name());
+    println!("  Last Modified: {}", doc.last_modified().clone());
+    // We don't bother with serialization of image sessions with this tool.
+    let mut output = std::fs::File::create(args.output)?;
+    let header = bincode::serialize(&DesignComposeDefinitionHeader::current())?;
+    let doc = bincode::serialize(&serializable_doc)?;
+    output.write_all(header.as_slice())?;
+    output.write_all(doc.as_slice())?;
+    Ok(())
+}

--- a/crates/figma_import/src/tools/fetch_layout.rs
+++ b/crates/figma_import/src/tools/fetch_layout.rs
@@ -1,0 +1,277 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    toolkit_layout_style::LayoutSizing, toolkit_schema::View, DesignComposeDefinition, Document,
+    ProxyConfig, ViewData,
+};
+/// Utility program to fetch a doc and serialize it to file
+use clap::Parser;
+use dc_bundle::legacy_definition::element::geometry::Dimension;
+use dc_bundle::legacy_definition::element::node::NodeQuery;
+use layout::LayoutManager;
+use std::collections::HashMap;
+use std::io;
+use std::io::prelude::*;
+use taffy::error::TaffyError;
+
+fn _pause() {
+    let mut stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    // We want the cursor to stay at the end of the line, so we print without a newline and flush manually.
+    write!(stdout, "Update Figma doc then press any key to continue...").unwrap();
+    stdout.flush().unwrap();
+
+    // Read a single byte and discard
+    let _ = stdin.read(&mut [0u8]).unwrap();
+}
+
+#[derive(Debug)]
+pub struct ConvertError(String);
+impl From<crate::Error> for ConvertError {
+    fn from(e: crate::Error) -> Self {
+        eprintln!("Error during Figma conversion: {:?}", e);
+        ConvertError(format!("Internal Server Error during Figma conversion: {:?}", e))
+    }
+}
+impl From<bincode::Error> for ConvertError {
+    fn from(e: bincode::Error) -> Self {
+        eprintln!("Error during serialization: {:?}", e);
+        ConvertError(format!("Error during serialization: {:?}", e))
+    }
+}
+impl From<serde_json::Error> for ConvertError {
+    fn from(e: serde_json::Error) -> Self {
+        eprintln!("Error during image session serialization: {:?}", e);
+        ConvertError(format!("Error during image session serialization: {:?}", e))
+    }
+}
+impl From<std::io::Error> for ConvertError {
+    fn from(e: std::io::Error) -> Self {
+        eprintln!("Error creating output file: {:?}", e);
+        ConvertError(format!("Error creating output file: {:?}", e))
+    }
+}
+impl From<TaffyError> for ConvertError {
+    fn from(e: TaffyError) -> Self {
+        eprintln!("Error with taffy layout: {:?}", e);
+        ConvertError(format!("Error with taffy layout: {:?}", e))
+    }
+}
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Figma Document ID to fetch and convert
+    #[arg(short, long)]
+    doc_id: String,
+    /// Figma Document Version ID to fetch and convert
+    #[arg(short, long)]
+    version_id: Option<String>,
+    /// Figma API key to use for Figma requests
+    #[arg(short, long)]
+    api_key: String,
+    /// HTTP proxy server - <host>:<port>
+    #[arg(long)]
+    http_proxy: Option<String>,
+    /// Root nodes to find in the doc and convert
+    #[arg(short, long)]
+    nodes: Vec<String>,
+    /// Output file to write serialized doc into
+    #[arg(short, long)]
+    output: std::path::PathBuf,
+}
+fn measure_func(
+    layout_id: i32,
+    width: f32,
+    height: f32,
+    avail_width: f32,
+    avail_height: f32,
+) -> (f32, f32) {
+    let mut result_height = if height > 0.0 { height } else { 30.0 };
+    let result_width = if width > 0.0 {
+        width
+    } else if avail_width > 0.0 {
+        //avail_width
+        212.0
+        //300.0
+    } else {
+        result_height = 60.0;
+        100.0
+    };
+
+    println!(
+        "measure_func layout_id {} width {} height {} available_width {} available_height {} -> {}, {}",
+        layout_id, width, height, avail_width, avail_height, result_width, result_height
+    );
+
+    (result_width, result_height)
+}
+fn test_layout(
+    layout_manager: &mut LayoutManager,
+    view: &View,
+    id: &mut i32,
+    parent_layout_id: i32,
+    child_index: i32,
+    views: &HashMap<NodeQuery, View>,
+) {
+    println!("test_layout {}, {}, {}, {}", view.name, id, parent_layout_id, child_index);
+    let my_id: i32 = id.clone();
+    *id = *id + 1;
+    if let ViewData::Text { content: _, res_name: _ } = &view.data {
+        let mut use_measure_func = false;
+        if let Dimension::Auto = view.style.layout_style.width {
+            if let Dimension::Auto = view.style.layout_style.height {
+                if view.style.node_style.horizontal_sizing == LayoutSizing::Fill {
+                    use_measure_func = true;
+                }
+            }
+        }
+        if use_measure_func {
+            layout_manager.add_style_measure(
+                my_id,
+                parent_layout_id,
+                child_index,
+                view.style.layout_style.clone(),
+                view.name.clone(),
+                measure_func,
+            );
+        } else {
+            let mut fixed_view = view.clone();
+            fixed_view.style.layout_style.width =
+                Dimension::Points(view.style.layout_style.bounding_box.width);
+            fixed_view.style.layout_style.height =
+                Dimension::Points(view.style.layout_style.bounding_box.height);
+            layout_manager.add_style(
+                my_id,
+                parent_layout_id,
+                child_index,
+                fixed_view.style.layout_style.clone(),
+                fixed_view.name.clone(),
+                None,
+                Some(view.style.layout_style.bounding_box.width as i32),
+                Some(view.style.layout_style.bounding_box.height as i32),
+            );
+        }
+    } else if let ViewData::Container { shape: _, children } = &view.data {
+        if view.name.starts_with("#Replacement") {
+            let square = views.get(&NodeQuery::NodeName("#BlueSquare".to_string()));
+            if let Some(square) = square {
+                layout_manager.add_style(
+                    my_id,
+                    parent_layout_id,
+                    child_index,
+                    square.style.layout_style.clone(),
+                    square.name.clone(),
+                    None,
+                    None,
+                    None,
+                );
+            }
+        } else {
+            layout_manager.add_style(
+                my_id,
+                parent_layout_id,
+                child_index,
+                view.style.layout_style.clone(),
+                view.name.clone(),
+                None,
+                None,
+                None,
+            );
+        }
+        let mut index = 0;
+        for child in children {
+            test_layout(layout_manager, child, id, my_id, index, views);
+            index = index + 1;
+        }
+    }
+
+    if parent_layout_id == -1 {
+        layout_manager.set_node_size(0, 0, 1200, 800);
+        layout_manager.compute_node_layout(my_id);
+    }
+}
+pub fn fetch_layout(args: Args) -> Result<(), ConvertError> {
+    let proxy_config: ProxyConfig = match args.http_proxy {
+        Some(x) => ProxyConfig::HttpProxyConfig(x),
+        None => ProxyConfig::None,
+    };
+    let mut doc: Document = Document::new(
+        args.api_key.as_str(),
+        args.doc_id.clone(),
+        args.version_id.unwrap_or(String::new()),
+        &proxy_config,
+        None,
+    )?;
+    let mut error_list = Vec::new();
+    // Convert the requested nodes from the Figma doc.
+    let views = doc.nodes(
+        &args.nodes.iter().map(|name| NodeQuery::name(name)).collect(),
+        &Vec::new(),
+        &mut error_list,
+    )?;
+    for error in error_list {
+        eprintln!("Warning: {error}");
+    }
+
+    let stage = views.get(&NodeQuery::NodeName("#stage".to_string()));
+    if let Some(stage) = stage {
+        let mut id = 0;
+        let mut layout_manager = LayoutManager::new();
+        test_layout(&mut layout_manager, stage, &mut id, -1, -1, &views);
+        layout_manager.print_layout(0, |msg| println!("{}", msg));
+    }
+
+    /*
+    pause();
+
+    println!("");
+    println!("Fetching Again...");
+    doc = Document::new(args.api_key.as_str(), args.doc_id, &proxy_config, None)?;
+    error_list = Vec::new();
+    let views = doc.nodes(
+        &args.nodes.iter().map(|name| NodeQuery::name(name)).collect(),
+        &Vec::new(),
+        &mut error_list,
+    )?;
+    for error in error_list {
+        eprintln!("Warning: {error}");
+    }
+    let init_response = init_layout(&views);
+    println!("Init result: {:?}", init_response);
+    for view in views.values() {
+        print_layout(view);
+    }
+    */
+
+    let variable_map = doc.build_variable_map();
+
+    // Build the serializable doc structure
+    let serializable_doc = DesignComposeDefinition {
+        views,
+        component_sets: doc.component_sets().clone(),
+        images: doc.encoded_image_map(),
+        last_modified: doc.last_modified().clone(),
+        name: doc.get_name(),
+        version: doc.get_version(),
+        id: doc.get_document_id(),
+        variable_map: variable_map,
+    };
+
+    // We don't bother with serialization headers or image sessions with
+    // this tool.
+    let output = std::fs::File::create(args.output)?;
+    bincode::serialize_into(output, &serializable_doc)?;
+    Ok(())
+}

--- a/crates/figma_import/src/tools/mod.rs
+++ b/crates/figma_import/src/tools/mod.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// Utility program to fetch a doc and serialize it to file
-use clap::Parser;
+#[cfg(feature = "dcf_info")]
+pub mod dcf_info;
 
-use figma_import::tools::fetch_layout::fetch_layout;
-use figma_import::tools::fetch_layout::Args;
+#[cfg(feature = "fetch_layout")]
+pub mod fetch_layout;
 
-fn main() {
-    let args = Args::parse();
-    if let Err(e) = fetch_layout(args) {
-        eprintln!("Fetch failed: {:?}", e);
-        std::process::exit(1);
-    }
-}
+#[cfg(feature = "fetch")]
+pub mod fetch;
+
+#[cfg(feature = "reflection")]
+pub mod reflection;

--- a/crates/figma_import/src/tools/reflection.rs
+++ b/crates/figma_import/src/tools/reflection.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Parser;
+use serde_generate::SourceInstaller;
+/// This program uses the serde-reflection and serde-generate crates to emit a Java
+/// implementation of a deserializer for our serialized view trees. We have to trace
+/// all of the types used in our schema manually.
+///
+/// We can also emit a yaml representation of the schema, which could be used to diff
+/// our schema in CI.
+
+#[derive(Parser)]
+pub struct Cli {
+    #[arg(short, long, default_value = "out")]
+    out_dir: std::path::PathBuf,
+}
+
+pub fn reflection(args: Cli) -> Result<(), crate::Error> {
+    let registry = crate::reflection::registry().expect("no tracer registry");
+
+    let config =
+        serde_generate::CodeGeneratorConfig::new("com.android.designcompose.serdegen".into())
+            .with_encodings(vec![serde_generate::Encoding::Bincode]);
+
+    let installer = serde_generate::java::Installer::new(args.out_dir);
+    installer.install_module(&config, &registry).expect("couldn't write java sources");
+    installer.install_serde_runtime().expect("couldn't write runtime");
+    installer.install_bincode_runtime().expect("couldn't write runtime");
+    Ok(())
+}


### PR DESCRIPTION
Separating binary tool implementations to be part of library so that downstream dependencies can import them as a crate dependency

Tested building and running each app via 
```
cargo run --bin fetch --features fetch
cargo run --bin dcf_info --features dcf_info
cargo run --bin reflection --features reflection
cargo run --bin fetch_layout --features fetch_layout
```
each command succeeded to build and start app (printing "required flags missing")
