### PR TITLE
Add a group option which allows to use different string resource name for nodes with same text

### DIFF
--- a/support-figma/extended-layout-plugin/src/code.ts
+++ b/support-figma/extended-layout-plugin/src/code.ts
@@ -345,7 +345,7 @@ function clipyCheckTypeMismatches(
       switch (kind) {
         case DesignSpecs.DesignCustomizationKind.Text:
         case DesignSpecs.DesignCustomizationKind.TextStyle:
-        case DesignSpecs.DesignCustomizationKind.TextFunction:
+        case DesignSpecs.DesignCustomizationKind.TextState:
           if (node.type != "TEXT") {
             warnings.push(
               createWarning(ClippyWarningKind.TYPE_MISMATCH, [

--- a/support-figma/extended-layout-plugin/src/design-spec-module.ts
+++ b/support-figma/extended-layout-plugin/src/design-spec-module.ts
@@ -19,7 +19,7 @@ import * as Utils from "./utils";
 /** See: com.android.designcompose.codegen.CustomizationType */
 export enum DesignCustomizationKind {
   Text = "Text",
-  TextFunction = "TextFunction",
+  TextState = "TextState",
   TextStyle = "TextStyle",
   Image = "Image",
   ImageWithContext = "ImageWithContext",
@@ -164,7 +164,7 @@ export async function mergeReactionsAsync(
 
 /**
  * Get the destination nodes on the reaction chain for the given node.
- * 
+ *
  * For a top level component, if any descendant has an action that does to another node,
  * we will use the same customization definitions from the top level component to check
  * text customizations.
@@ -177,7 +177,7 @@ async function populateReactionChainAsync(
   topLevelReactionComponents: Map<string, BaseNode[]>
 ) {
   // If this action goes to another node, put the destination node into the map.
-  // Then recursively call #populateReactionChainAsync for find the next level 
+  // Then recursively call #populateReactionChainAsync for find the next level
   // destination nodes originated from descendents of this destination node.
   async function handleReactionNodeAsync(action?: Action) {
     if (action?.type == "NODE") {
@@ -277,7 +277,7 @@ export async function findTextCustomizationNodesAsync(
       if (node.name != customization.node) continue;
       if (
         customization.kind == DesignCustomizationKind.Text ||
-        customization.kind == DesignCustomizationKind.TextFunction ||
+        customization.kind == DesignCustomizationKind.TextState ||
         customization.kind == DesignCustomizationKind.ComponentReplacement
       ) {
         if (node.type == "TEXT") {

--- a/support-figma/extended-layout-plugin/src/ui.html
+++ b/support-figma/extended-layout-plugin/src/ui.html
@@ -1149,7 +1149,7 @@
             }
             if (!hasChanged) {
               input.value = stringRes["name"];
-              showToast(`${newValue} already exists. Revert since duplicates are not allowed.`);
+              showToast(`${newValue} already exists. Reverting resource name since duplicates are not allowed.`);
             }
           } else if (stringRes["name"] != this.value) {
             outputStringData.delete(stringRes["name"]);

--- a/support-figma/extended-layout-plugin/src/ui.html
+++ b/support-figma/extended-layout-plugin/src/ui.html
@@ -320,14 +320,18 @@
 
 <!-- BEGINNING OF LOCALIZATION PLUGIN UI -->
 <div id="localizationOptions" class="page page-padding-large">
-  <div style="border-bottom: solid #000000; font-weight: bold;">Localization exclude options:</div>
+  <div style="border-bottom: solid #000000; font-weight: bold;">Localization options:</div>
   <div style="margin-top: 8px;">
-    <input type="checkbox" id="excludeHashTagName" name="excludeOptions" value="excludeHashTagName" checked>
+    <input type="checkbox" id="excludeHashTagName" name="localizationOptions" value="excludeHashTagName" checked>
     <label for="excludeHashTagName">Exclude text nodes whose name starts with '#'</label>
   </div>
   <div style="margin-top: 8px;">
-    <input type="checkbox" id="excludeCustomization" name="excludeOptions" value="excludeCustomization" checked>
+    <input type="checkbox" id="excludeCustomization" name="localizationOptions" value="excludeCustomization" checked>
     <label for="excludeCustomization">Exclude text nodes customized by client</label>
+  </div>
+  <div style="margin-top: 8px;">
+    <input type="checkbox" id="groupSameText" name="localizationOptions" value="groupSameText" checked>
+    <label for="groupSameText">Group nodes with same text and use the same string resource name</label>
   </div>
   <div style="display: flex; justify-content: flex-end; align-items: flex-end;"><a href="#uploadStringPanel"
       style="text-decoration: underline;">&nbsp;Next >>&nbsp;</a></div>
@@ -864,14 +868,14 @@
   }
 
   function showOutputStrings() {
-    const excludeOptionElements = document.querySelectorAll('input[name="excludeOptions"]:checked');
-    const excludeOptions = Array.from(excludeOptionElements).map(checkbox => checkbox.value);
+    const localizationOptionElements = document.querySelectorAll('input[name="localizationOptions"]:checked');
+    const localizationOptions = Array.from(localizationOptionElements).map(checkbox => checkbox.value);
 
     parent.postMessage({
       pluginMessage: {
         msg: 'generate-localization-data',
         contents: inputStringArray,
-        options: excludeOptions,
+        options: localizationOptions,
       }
     }, '*');
   }
@@ -1114,8 +1118,39 @@
         input.addEventListener('change', function (evt) {
           const newValue = this.value;
           if (outputStringData.has(newValue)) {
-            input.value = stringRes["name"];
-            showToast(`${newValue} already exists. Revert since duplicates are not allowed.`);
+            let newStringRes = outputStringData.get(newValue);
+            let hasChanged = false;
+            // Use toString() to compare string and string array.
+            if (stringRes["text"].toString() === newStringRes["text"].toString()) {
+              let result = confirm(`Would you like to merge the translations with ${newStringRes["name"]}?`);
+              if (result) {
+                // Merge the text nodes and upate the UI.
+                for (const node of stringRes["textNodes"]) {
+                  if (newStringRes["textNodes"]) {
+                    newStringRes["textNodes"].push(node);
+                  } else {
+                    newStringRes["textNodes"] = [node];
+                  }
+                }
+                // Remove the string resource from the map.
+                outputStringData.delete(stringRes["name"]);
+                // Notify figma to update the plugin data.
+                stringRes["name"] = newValue;
+                parent.postMessage({
+                  pluginMessage: {
+                    msg: 'update-localization-data',
+                    item: stringRes
+                  }
+                }, '*');
+                // Refresh the table, which recreate the whole table...
+                createOutputStringTable('outputStrings');
+                hasChanged = true;
+              }
+            }
+            if (!hasChanged) {
+              input.value = stringRes["name"];
+              showToast(`${newValue} already exists. Revert since duplicates are not allowed.`);
+            }
           } else if (stringRes["name"] != this.value) {
             outputStringData.delete(stringRes["name"]);
             stringRes["name"] = this.value;


### PR DESCRIPTION
Fixes: #1371
Also made a change when user rename a string resource name to an existing one, it allows to merge the two together.

This user action will not be saved to the plugin data so it gets lost the next time running the plugin. This is also because user can use a different group option which may change the string resource name assigned to a text node.