### PR TITLE
Add additional `.idea` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,5 @@ fabric.properties
 .idea/httpRequests
 
 # Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
+.idea/caches
+.idea/runConfigurations.xml


### PR DESCRIPTION
Adding the .idea/cache directory, because that seems obvious, and `runConfigurations.xml`. The `runConfigurations.xml` file showed up for me recently.
I believe it were created by the latest Android Studio canary