### PR TITLE
Making figma_import tools arguments public

### DIFF
--- a/crates/figma_import/src/tools/dcf_info.rs
+++ b/crates/figma_import/src/tools/dcf_info.rs
@@ -48,10 +48,10 @@ impl From<crate::Error> for ParseError {
 #[derive(Parser, Debug)]
 pub struct Args {
     // Path to the .dcf file to deserialize
-    dcf_file: std::path::PathBuf,
+    pub dcf_file: std::path::PathBuf,
     // Optional string argument to dump file structure from a given node root.
     #[clap(long, short)]
-    node: Option<String>,
+    pub node: Option<String>,
 }
 
 pub fn dcf_info(args: Args) -> Result<(), ParseError> {

--- a/crates/figma_import/src/tools/fetch.rs
+++ b/crates/figma_import/src/tools/fetch.rs
@@ -50,22 +50,22 @@ impl From<std::io::Error> for ConvertError {
 pub struct Args {
     /// Figma Document ID to fetch and convert
     #[arg(short, long)]
-    doc_id: String,
+    pub doc_id: String,
     /// Figma Document Version ID to fetch and convert
     #[arg(short, long)]
-    version_id: Option<String>,
+    pub version_id: Option<String>,
     /// Figma API key to use for Figma requests
     #[arg(short, long)]
-    api_key: String,
+    pub api_key: String,
     /// HTTP proxy server - <host>:<port>
     #[arg(long)]
-    http_proxy: Option<String>,
+    pub http_proxy: Option<String>,
     /// Root nodes to find in the doc and convert
     #[arg(short, long)]
-    nodes: Vec<String>,
+    pub nodes: Vec<String>,
     /// Output file to write serialized doc into
     #[arg(short, long)]
-    output: std::path::PathBuf,
+    pub output: std::path::PathBuf,
 }
 
 pub fn fetch(args: Args) -> Result<(), ConvertError> {

--- a/crates/figma_import/src/tools/fetch_layout.rs
+++ b/crates/figma_import/src/tools/fetch_layout.rs
@@ -75,22 +75,22 @@ impl From<TaffyError> for ConvertError {
 pub struct Args {
     /// Figma Document ID to fetch and convert
     #[arg(short, long)]
-    doc_id: String,
+    pub doc_id: String,
     /// Figma Document Version ID to fetch and convert
     #[arg(short, long)]
-    version_id: Option<String>,
+    pub version_id: Option<String>,
     /// Figma API key to use for Figma requests
     #[arg(short, long)]
-    api_key: String,
+    pub api_key: String,
     /// HTTP proxy server - <host>:<port>
     #[arg(long)]
-    http_proxy: Option<String>,
+    pub http_proxy: Option<String>,
     /// Root nodes to find in the doc and convert
     #[arg(short, long)]
-    nodes: Vec<String>,
+    pub nodes: Vec<String>,
     /// Output file to write serialized doc into
     #[arg(short, long)]
-    output: std::path::PathBuf,
+    pub output: std::path::PathBuf,
 }
 fn measure_func(
     layout_id: i32,

--- a/crates/figma_import/src/tools/reflection.rs
+++ b/crates/figma_import/src/tools/reflection.rs
@@ -24,7 +24,7 @@ use serde_generate::SourceInstaller;
 #[derive(Parser)]
 pub struct Cli {
     #[arg(short, long, default_value = "out")]
-    out_dir: std::path::PathBuf,
+    pub out_dir: std::path::PathBuf,
 }
 
 pub fn reflection(args: Cli) -> Result<(), crate::Error> {


### PR DESCRIPTION
Previous update to tools assumed they would be used solely as CLI implementations, but we have a use case where we would like to call these programmatically. Currently we do this using a `std::process::Command` running `cargo run ...`, but by making these args public we can reuse the tools directly from code

Tested: Verified new versions build without errors