### PR TITLE
Fix #1503: ensure child composables are drawn, by using Layout ID rather than SquooshResolvedNode identity.

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -687,7 +687,10 @@ fun SquooshRoot(
                 for (child in childComposables) {
                     var composableChildModifier =
                         Modifier.drawWithContent {
-                                if (child.node == childRenderSelector.selectedRenderChild)
+                                if (
+                                    child.node.layoutId ==
+                                        childRenderSelector.selectedRenderChild?.layoutId
+                                )
                                     drawContent()
                             }
                             .then(SquooshParentData(node = child.node))


### PR DESCRIPTION
The previous check (that the SquooshResolvedNodes were equal) failed, because during a transition we generate a new set of SquooshResolvedNodes from the source tree and dest tree. With this change, we consult the layout ID, which is unique within a tree (so still useful for this purpose of identifying the selected node for child rendering).