### PR TITLE
Fix the string resource mismatch

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -1644,6 +1644,8 @@ internal fun getTextContent(
         val resId = context.resources.getIdentifier(resName, "string", context.packageName)
         if (resId != Resources.ID_NULL) {
             return context.getString(resId)
+        } else {
+            Log.w(TAG, "No string resource $resName found")
         }
     }
     return textData.content
@@ -1656,15 +1658,29 @@ internal fun getTextContent(
 ): List<StyledTextRun> {
     if (useLocalStringRes != false && styledTextData.res_name.isPresent) {
         val resName = styledTextData.res_name.get()
-        val resId = context.resources.getIdentifier(resName, "array", context.packageName)
-        if (resId != Resources.ID_NULL) {
-            val textArray = context.resources.getStringArray(resId)
+        val strArrayResId = context.resources.getIdentifier(resName, "array", context.packageName)
+        if (strArrayResId != Resources.ID_NULL) {
+            val textArray = context.resources.getStringArray(strArrayResId)
             if (textArray.size == styledTextData.content.size) {
                 val output = mutableListOf<StyledTextRun>()
                 for (i in textArray.indices) {
                     output.add(StyledTextRun(textArray[i], styledTextData.content[i].style))
                 }
                 return output
+            } else {
+                Log.w(TAG, "String array size mismatched the styled runs")
+            }
+        }
+        Log.w(TAG, "No string array resource $resName found for styled runs")
+        if (styledTextData.content.size == 1) {
+            val strResId = context.resources.getIdentifier(resName, "string", context.packageName)
+            if (strResId != Resources.ID_NULL) {
+                Log.w(TAG, "Single style found, fallback to string resource")
+                return mutableListOf(
+                    StyledTextRun(context.getString(strResId), styledTextData.content[0].style)
+                )
+            } else {
+                Log.w(TAG, "No string resource $resName found for styled runs")
             }
         }
     }

--- a/support-figma/extended-layout-plugin/src/localization-module.ts
+++ b/support-figma/extended-layout-plugin/src/localization-module.ts
@@ -307,6 +307,13 @@ function saveResName(
       STRING_RES_PLUGIN_DATA_KEY,
       ""
     );
+    Utils.log(
+      CONSOLE_TAG,
+      "Save string res name %s-%s with %s to plugin data",
+      node.name,
+      node.id,
+      stringResName
+    );
   } else {
     node.setSharedPluginData(
       Utils.SHARED_PLUGIN_NAMESPACE,
@@ -314,14 +321,14 @@ function saveResName(
       stringResName
     );
     node.setPluginData(STRING_RES_PLUGIN_DATA_KEY, "");
+    Utils.log(
+      CONSOLE_TAG,
+      "Save string res name %s-%s with %s to shared plugin data",
+      node.name,
+      node.id,
+      stringResName
+    );
   }
-  Utils.log(
-    CONSOLE_TAG,
-    "Save string res name %s-%s with %s",
-    node.name,
-    node.id,
-    stringResName
-  );
 }
 
 function getResName(node: TextNode) {
@@ -389,22 +396,21 @@ function normalizeTextNode(node: TextNode): string | string[] {
   // All styles.
   try {
     let segments = node.getStyledTextSegments([
+      "boundVariables",
       "fontSize",
       "fontWeight",
+      "fontName",
+      "fills",
+      "fillStyleId",
+      "hyperlink",
+      "indentation",
       "letterSpacing",
       "lineHeight",
-      "fontName",
-      "textDecoration",
-      "textCase",
-      "fills",
-      "textStyleId",
-      "fillStyleId",
-      // Comment out the following due to "Error: in getStyledTextSegments: Unknown list option"
-      // "listOptions",
-      "indentation",
-      "hyperlink",
+      "listOptions",
       "openTypeFeatures",
-      "boundVariables",
+      "textDecoration",
+      "textStyleId",
+      "textCase",
     ]);
     segments.forEach((it) => stringArray.push(normalizeString(it.characters)));
   } catch (error) {

--- a/support-figma/extended-layout-plugin/src/ui.html
+++ b/support-figma/extended-layout-plugin/src/ui.html
@@ -966,6 +966,7 @@
     r.textContent = node["nodeId"];
     r.style.textDecoration = 'underline';
     r.style.marginInlineStart = '8px';
+    r.style.overflowWrap = "anywhere";
     r.onclick = () => {
       parent.postMessage({
         pluginMessage: {


### PR DESCRIPTION
* Also fixes the node id overflow issue in the plugin ui.
* Also add the listOptions back in the plugin api call getStyledTextSegments

It is not quite possible to make the plugin to match the REST api behavior so in this change, it will check if styles are the same and merge when transforming.

Fixes: #1518