### PR TITLE
Improve performance by caching text layouts and computed paths.

### DIFF
--- a/crates/dc_jni/src/layout_manager.rs
+++ b/crates/dc_jni/src/layout_manager.rs
@@ -130,12 +130,7 @@ pub(crate) fn jni_add_nodes<'local>(
 
     match deprotolize_layout_node_list(&mut env, serialized_views) {
         Ok(node_list) => {
-            info!(
-                "jni_add_nodes: {} nodes, layout_id {}",
-                node_list.layout_nodes.len(),
-                root_layout_id
-            );
-            handle_layout_node_list(node_list, root_layout_id, &mut manager);
+            handle_layout_node_list(node_list, &mut manager);
 
             let layout_response = manager.compute_node_layout(root_layout_id);
             layout_response_to_bytearray(env, layout_response)
@@ -148,12 +143,7 @@ pub(crate) fn jni_add_nodes<'local>(
     }
 }
 
-fn handle_layout_node_list(
-    node_list: LayoutNodeList,
-    root_layout_id: i32,
-    manager: &mut MutexGuard<LayoutManager>,
-) {
-    info!("jni_add_nodes: {} nodes, layout_id {}", node_list.layout_nodes.len(), root_layout_id);
+fn handle_layout_node_list(node_list: LayoutNodeList, manager: &mut MutexGuard<LayoutManager>) {
     for node in node_list.layout_nodes.into_iter() {
         if node.use_measure_func {
             manager.add_style_measure(

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -426,10 +426,9 @@ internal fun ContentDrawScope.render(
             size,
             rectSize,
             customArcAngle,
-            vectorScaleX,
-            vectorScaleY,
             layoutId,
             variableState,
+            ComputedPathCache()
         )
 
     val customFillBrushFunction = customizations.getBrushFunction(name)
@@ -602,6 +601,7 @@ internal fun squooshShapeRender(
     document: DocContent,
     customizations: CustomizationContext,
     variableState: VariableState,
+    computedPathCache: ComputedPathCache,
     drawContent: () -> Unit
 ) {
     if (size.width <= 0F && size.height <= 0F) return
@@ -702,10 +702,9 @@ internal fun squooshShapeRender(
             // layout doesn't actually consider rotation yet.
             rectSize,
             customArcAngle,
-            vectorScaleX,
-            vectorScaleY,
-            0, // XXX: layoutId
+            node.layoutId,
             variableState,
+            computedPathCache,
         )
 
     // Blend mode

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.unit.Density
+import com.android.designcompose.ComputedPathCache
 import com.android.designcompose.CustomizationContext
 import com.android.designcompose.DocContent
 import com.android.designcompose.TextMeasureData
@@ -71,9 +72,11 @@ internal fun Modifier.squooshRender(
     animations: Map<Int, SquooshAnimationRenderingInfo>,
     animationValues: State<Map<Int, Float>>,
     variableState: VariableState,
+    computedPathCache: ComputedPathCache,
 ): Modifier =
     this.then(
         Modifier.drawWithContent {
+            computedPathCache.collect()
             val animValues = animationValues.value
             for ((id, transition) in animations) {
                 val animationOffset = animValues[id]
@@ -154,6 +157,7 @@ internal fun Modifier.squooshRender(
                             document,
                             customizations,
                             variableState,
+                            computedPathCache
                         ) {
                             var child = node.firstChild
                             var pendingMask: SquooshResolvedNode? = null

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -145,6 +145,7 @@ internal fun resolveVariantsRecursively(
     appContext: Context,
     useLocalStringRes: Boolean?,
     customVariantTransition: CustomVariantTransition?,
+    textMeasureCache: TextMeasureCache,
     componentLayoutId: Int = 0,
     overlays: List<View>? = null,
 ): SquooshResolvedNode? {
@@ -244,6 +245,7 @@ internal fun resolveVariantsRecursively(
     val textInfo =
         squooshComputeTextInfo(
             view,
+            layoutId,
             density,
             document,
             customizations,
@@ -251,6 +253,7 @@ internal fun resolveVariantsRecursively(
             variableState,
             appContext = appContext,
             useLocalStringRes = useLocalStringRes,
+            textMeasureCache = textMeasureCache,
         )
     val resolvedView = SquooshResolvedNode(view, style, layoutId, textInfo, v.id, layoutNode = null)
 
@@ -277,6 +280,7 @@ internal fun resolveVariantsRecursively(
                     variableState,
                     appContext = appContext,
                     useLocalStringRes = useLocalStringRes,
+                    textMeasureCache = textMeasureCache,
                     customVariantTransition = customVariantTransition,
                     componentLayoutId = componentLayoutId,
                 ) ?: continue
@@ -401,6 +405,7 @@ internal fun resolveVariantsRecursively(
                     variableState,
                     appContext = appContext,
                     useLocalStringRes = useLocalStringRes,
+                    textMeasureCache = textMeasureCache,
                     customVariantTransition = customVariantTransition,
                     componentLayoutId = componentLayoutId,
                 ) ?: continue


### PR DESCRIPTION
Profiling showed that computing text layouts and computing paths was taking the bulk of runtime in a simple demo app. This change adds two generational caches -- one for computed text layout (e.g.: the Compose `ParagraphIntrinsics`), and one for computed paths (the `ComputedPath` type which contains all of the paths needed to render a node).

Additionally some unused logging has been removed.

In a profile of "FutureV2" design, `squooshComputeTextInfo` run time was reduced by a half, and `computePaths` was reduced by around 5x.