### PR TITLE
Update to ndk 27.0.12077973

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Currently testing with Android Studio Flamingo | 2022.2.1
 
 ### Android NDK
 
-Version `25.2.9519653` is required. It can be installed
+Version `27.0.12077973` is required. It can be installed
 via [Android Studio's SDK Manager](https://developer.android.com/studio/projects/install-ndk#specific-version)
 or on the command line using the `sdkmanager` binary.
 
 ```shell
-"${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;25.2.9519653"
+"${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install "ndk;27.0.12077973"
 ```
 
 ### Rust
@@ -157,7 +157,7 @@ rustup-init -y
 brew install protobuf
 ```
 
-Install Android studio and install ndk `25.2.9519653` (Sorry, no easy way to automate that part!)
+Install Android studio and install ndk `27.0.12077973` (Sorry, no easy way to automate that part!)
 
 Finally, if needed, install the below
 

--- a/designcompose/build.gradle.kts
+++ b/designcompose/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 android {
     namespace = "com.android.designcompose"
     compileSdk = libs.versions.compileSdk.get().toInt()
-    ndkVersion = "25.2.9519653"
+    ndkVersion = libs.versions.ndk.get()
 
     testFixtures { enable = true }
 

--- a/docs/_docs/working-with-source/building-sdk.md
+++ b/docs/_docs/working-with-source/building-sdk.md
@@ -21,12 +21,12 @@ The source requires Android Studio Flamingo or later.
 
 ### Android NDK {#AndroidNDK}
 
-Version `25.2.9519653` is required. You can install the NDK with Android
+Version `27.0.12077973` is required. You can install the NDK with Android
 Studio's SDK Manager or on the command line using the sdkmanager binary:
 
 ```shell
 "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" \
-    --install "ndk;25.2.9519653"
+    --install "ndk;27.0.12077973"
 ```
 
 ### Rust {#InstallRust}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 designcompose = "0.30.0-SNAPSHOT"
 
 jvmToolchain = "17"
-
+ndk = "27.0.12077973"
 #Android Gradle Plugin
 agp = "8.4.2"
 # The minimum supported AGP version for DesignCompose Apps


### PR DESCRIPTION
This change helps keep us up to date and may address the build failures that we're seeing in GitHub's CI