### PR TITLE
Have Android Studio stop collecting imports into a wildcard.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ fabric.properties
 # Other
 .idea/kotlinc.xml
 .idea/emulatorDisplays.xml
+.idea/androidTestResultsUserPreferences.xml
+.idea/rust.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <ProtobufCodeStyleSettings>

--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,22 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2023 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
 <project version="4">
   <component name="KtfmtSettings">
+    <option name="enableKtfmt" value="Enabled" />
     <option name="enabled" value="true" />
     <option name="uiFormatterStyle" value="Kotlinlang" />
   </component>


### PR DESCRIPTION
Android Studio was collecting all of the `designcompose.serdegen` and `designcompose.proto` imports into `designcompose.[serdegen|proto].*`, which made it difficult to ensure you were using the right version.

This change disables that and also adds a new .idea preferences file that I'd manage to generate to the .gitignore