### PR TITLE
Cherry-pick Gradle actions fix

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,69 @@
+
+name: Setup Build
+description: Configure Rust for the rest of the bui
+
+inputs:
+
+  setup-gradle:
+    description: Whether to set up Gradle
+    required: false
+    default: "false"
+  setup-protoc:
+    description: Whether to set up Protoc
+    required: false
+    default: "false"
+  setup-rust:
+    description: Whether to set up Rust
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+
+      - name: Set up Java
+        if: ${{ inputs.setup-gradle }}
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Set up Gradle
+        if: ${{ inputs.setup-gradle }}
+        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        with:
+          # Upload in the dependency-review workflow
+          # Dependency graph isn't supported on Windows and we don't need it to run on Mac either
+          # This is GitHub's ternary operator
+          dependency-graph: ${{ contains(matrix.os, 'ubuntu') && 'generate' ||  'disabled' }}
+          gradle-home-cache-cleanup: true
+
+      - name: Install Protoc
+        if: ${{ inputs.setup-protoc }}
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
+        with:
+          version: "27.1"
+          repo-token: ${{ github.token }}
+
+      - name: Setup Android SDK
+        if: ${{ inputs.setup-rust }}
+        uses: android-actions/setup-android@v3
+        with:
+          packages: "ndk;27.0.12077973"
+
+      - name: Update Rust
+        if: ${{ inputs.setup-rust }}
+        shell: bash
+        run: rustup toolchain install stable --profile minimal
+      - name: Install Rust toolchains
+        if: ${{ inputs.setup-rust  }}
+        shell: bash
+        run: ./install-rust-toolchains.sh
+      - name: Set up Rust Cache
+        if: ${{ inputs.setup-rust }}
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
+        with:
+          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
+          shared-key: "gradle-rust"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,17 +43,11 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          # Upload in the dependency-review workflow
-          dependency-graph: generate
-          gradle-home-cache-cleanup: true
+          setup-gradle: true
+
       - name: Test build-logic
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
@@ -73,32 +67,12 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          # Upload in the dependency-review workflow
-          dependency-graph: generate
-          gradle-home-cache-cleanup: true
-      - name: Update Rust
-        run: rustup toolchain install stable --profile minimal
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Rust toolchains
-        run: ./install-rust-toolchains.sh
-      - name: Set up Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
-        with:
-          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
-          shared-key: "gradle-rust"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          setup-gradle: true
+          setup-protoc: true
+          setup-rust: true
       - name: Full Gradle Test
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
@@ -110,36 +84,17 @@ jobs:
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
         with:
           egress-policy: audit
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
       - name: "Set environment variables"
         run: |
           echo "ORG_GRADLE_PROJECT_DesignComposeMavenRepo=$GITHUB_WORKSPACE/designcompose_m2repo" >> "$GITHUB_ENV"
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          # Upload in the dependency-review workflow
-          dependency-graph: generate
-          gradle-home-cache-cleanup: true
-      - name: Update Rust
-        run: rustup toolchain install stable --profile minimal
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Rust toolchains
-        run: ./install-rust-toolchains.sh
-      - name: Set up Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
-        with:
-          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
-          shared-key: "gradle-rust"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          setup-gradle: true
+          setup-protoc: true
+          setup-rust: true
       - name: Full Gradle Test and publish
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
@@ -159,22 +114,11 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          # Upload in the dependency-review workflow
-          dependency-graph: generate
-          gradle-home-cache-cleanup: true
+          setup-gradle: true
+
       - name: Generate full comparison
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
@@ -206,18 +150,11 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          # Dependency graph isn't supported on Windows and we don't need it to run on Mac either
-          # This is GitHub's ternary operator
-          dependency-graph: ${{ matrix.os == 'ubuntu-latest' && 'generate' ||  'disabled' }}
-          gradle-home-cache-cleanup: true
+          setup-gradle: true
+
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: designcompose_m2repo
@@ -253,11 +190,11 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
+          setup-gradle: true
+
       - run: sudo apt-get install repo
       - name: "Set environment variables"
         run: |
@@ -295,16 +232,10 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          dependency-graph: generate
-          gradle-home-cache-cleanup: true
+          setup-gradle: true
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: designcompose_m2repo
@@ -339,14 +270,11 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
       - run: rustup toolchain install stable --profile minimal
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          setup-protoc: true
+          setup-rust: true
       - name: Build all
         run: cargo build --all-targets --all-features
       - name: Test all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,36 +60,12 @@ jobs:
           echo "ORG_GRADLE_PROJECT_DesignComposeMavenRepo=$GITHUB_WORKSPACE/designcompose_m2repo" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.5.2
-
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          cache-read-only: true
-
-      - name: Update Rust
-        run: rustup toolchain install stable --profile minimal
-
-      - name: Install Rust toolchains
-        run: ./install-rust-toolchains.sh
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Rust Cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
-        with:
-          workspaces: ". -> designcompose/build/intermediates/cargoTarget"
-          shared-key: "gradle-rust"
-          save-if: false
+          setup-gradle: true
+          setup-protoc: true
+          setup-rust: true
 
       - name: Build Maven repo
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0

--- a/.github/workflows/roborazzi-compare-screenshot.yml
+++ b/.github/workflows/roborazzi-compare-screenshot.yml
@@ -40,20 +40,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+          setup-gradle: true
+          setup-protoc: true
 
       - name: Download screenshots from base branch
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6

--- a/.github/workflows/roborazzi-record-screenshot.yml
+++ b/.github/workflows/roborazzi-record-screenshot.yml
@@ -44,21 +44,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
-        with:
-          version: "27.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+          setup-gradle: true
+          setup-protoc: true
 
       - name: Record fresh screenshots
         uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -62,11 +62,10 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Set up Java
-        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
         with:
-          distribution: "temurin"
-          java-version: "17"
+          setup-gradle: true
       - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           cache-read-only: true


### PR DESCRIPTION
Since we need to manually install the required NDK it's time to just
properly abstract the setup tasks out into a reusable action.