### PR TITLE
Fix animations from Figma

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
@@ -287,7 +287,8 @@ internal fun createMergedAnimationTree(
                         parent,
                         animations,
                         alreadyMatchedSet,
-                        customVariantTransition
+                        customVariantTransition,
+                        requestedAnim.transition,
                     )
                 if (animations.isNotEmpty()) {
                     requestedAnim.animationControl = SquooshAnimationControl(animations)


### PR DESCRIPTION
Fixes #1636. For animations defined in Figma, use the animation spec defined in Figma instead of the default transition for variants.