### PR TITLE
Update protoc to 4.28.2

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -14,7 +14,7 @@
 
 
 name: Setup Build
-description: Configure Rust for the rest of the bui
+description: Configure Rust for the rest of the build
 
 inputs:
 
@@ -56,7 +56,7 @@ runs:
         if: ${{ inputs.setup-protoc }}
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b
         with:
-          version: "27.1"
+          version: "28.2"
           repo-token: ${{ github.token }}
 
       - name: Setup Android SDK

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ robolectric = "4.13"
 roborazzi = "1.26.0"
 androidx-material3 = "1.2.1"
 # Keep in sync with the "Install Protoc" steps in .github/workflows
-protoc = "4.28.1"
+protoc = "4.28.2"
 protobuf-plugin = "0.9.4"
 
 [libraries]


### PR DESCRIPTION
Updates protoc version to 4.28.2 in libs.versions.toml and the
 setup-build action.

This addresses CVE-2024-7254
https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8