### PR TITLE
Update Reference apps to AGP 8.4.2.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ndk = "27.0.12077973"
 #Android Gradle Plugin
 agp = "8.4.2"
 # The minimum supported AGP version for DesignCompose Apps
-agp-minSupported = "7.3.1"
+agp-minSupported = "8.4.2"
 
 # SDK Levels
 minSdk = "26"


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1644

## Full chain of PRs as of 2024-09-19

* PR #1645:
  `wb/froeht/update-ref-app-dependencies` ➔ `wb/froeht/update-gradle-8-10-1`
* PR #1644:
  `wb/froeht/update-gradle-8-10-1` ➔ `main`

<!-- end git-machete generated -->

This brings them much more up to date. Android Studio Jellyfish will be required to use them.