### PR TITLE
Update Github Gradle Action to v4.1

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -44,13 +44,12 @@ runs:
 
       - name: Set up Gradle
         if: ${{ inputs.setup-gradle }}
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
         with:
           # Upload in the dependency-review workflow
           # Dependency graph isn't supported on Windows and we don't need it to run on Mac either
           # This is GitHub's ternary operator
           dependency-graph: ${{ contains(matrix.os, 'ubuntu') && 'generate' ||  'disabled' }}
-          gradle-home-cache-cleanup: true
 
       - name: Install Protoc
         if: ${{ inputs.setup-protoc }}

--- a/.github/workflows/gradle-dependency-graph-submit.yml
+++ b/.github/workflows/gradle-dependency-graph-submit.yml
@@ -41,6 +41,6 @@ jobs:
           egress-policy: audit
 
       - name: Retrieve dependency graph artifact from the Gradle builds and submit
-        uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
         with:
           dependency-graph: download-and-submit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,17 +47,12 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           setup-gradle: true
-
       - name: Test build-logic
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: build-logic
-          arguments: test
+        working-directory: build-logic
+        run: ./gradlew test
       - name: Test the plugins
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: plugins
-          arguments: test
+        working-directory: plugins
+        run: ./gradlew test
   # Run a full build, including instrumented tests.
   sdk-build:
     runs-on: "ubuntu-latest"
@@ -74,9 +69,7 @@ jobs:
           setup-protoc: true
           setup-rust: true
       - name: Full Gradle Test
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: assembleDebug assembleAndroidTest assembleUnitTest test
+        run: ./gradlew assembleDebug assembleAndroidTest assembleUnitTest test
   build-maven-repo:
     runs-on: "ubuntu-latest"
     steps:
@@ -96,9 +89,7 @@ jobs:
           setup-protoc: true
           setup-rust: true
       - name: Full Gradle Test and publish
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: publishAllPublicationsToLocalDirRepository
+        run: ./gradlew publishAllPublicationsToLocalDirRepository
       - name: Upload maven repo
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
@@ -118,11 +109,8 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           setup-gradle: true
-
       - name: Generate full comparison
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: compareRoborazziDebug
+        run: ./gradlew compareRoborazziDebug
       - name: Upload diff report
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
@@ -132,10 +120,8 @@ jobs:
             **/build/reports/roborazzi
           retention-days: 30
       - name: Verify Roborazzi
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: verifyRoborazziDebug
-          ########### Reference apps
+        run: ./gradlew verifyRoborazziDebug
+        ########### Reference apps
   reference-apps:
     strategy:
       matrix:
@@ -154,7 +140,6 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           setup-gradle: true
-
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: designcompose_m2repo
@@ -169,19 +154,11 @@ jobs:
           chcp 65001 #set code page to utf-8
           echo "ORG_GRADLE_PROJECT_DesignComposeMavenRepo=$env:GITHUB_WORKSPACE/designcompose_m2repo" >> "$env:GITHUB_ENV"
       - name: Check HelloWorld App
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: reference-apps/helloworld
-          arguments: |
-            --init-script ../local-design-compose-repo.init.gradle.kts
-            build
+        working-directory: reference-apps/helloworld
+        run: ./gradlew --init-script ../local-design-compose-repo.init.gradle.kts build
       - name: Check Tutorial App
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: reference-apps/tutorial
-          arguments: |
-            --init-script ../local-design-compose-repo.init.gradle.kts
-            build
+        working-directory: reference-apps/tutorial
+        run: ./gradlew  --init-script ../local-design-compose-repo.init.gradle.kts build
   build-unbundled:
     runs-on: ubuntu-latest
     steps:
@@ -194,7 +171,6 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           setup-gradle: true
-
       - run: sudo apt-get install repo
       - name: "Set environment variables"
         run: |
@@ -208,10 +184,8 @@ jobs:
           repo init -u $HOST -b $BRANCH -g pdk,pdk-fs --depth=1
           repo sync -cq -j4
       - name: Build the repo
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: unbundled-aaos/packages/apps/Car/libs/aaos-apps-gradle-project/
-          arguments: publishAllPublicationsToLocalRepository
+        working-directory: unbundled-aaos/packages/apps/Car/libs/aaos-apps-gradle-project/
+        run: ./gradlew publishAllPublicationsToLocalRepository
       - name: Upload maven repo
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
@@ -254,13 +228,9 @@ jobs:
           echo "ORG_GRADLE_PROJECT_DesignComposeMavenRepo=$GITHUB_WORKSPACE/designcompose_m2repo" >> "$GITHUB_ENV"
           echo "ORG_GRADLE_PROJECT_unbundledAAOSDir=$GITHUB_WORKSPACE/unbundled-aaos" >> "$GITHUB_ENV"
       - name: Check MediaCompose
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          build-root-directory: reference-apps/aaos-unbundled
-          arguments: |
-            --init-script ../local-design-compose-repo.init.gradle.kts
-            check
-          ############# Rust
+        working-directory: reference-apps/aaos-unbundled
+        run: ./gradlew  --init-script ../local-design-compose-repo.init.gradle.kts check
+  ############# Rust
   rust-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,7 @@ jobs:
           setup-rust: true
 
       - name: Build Maven repo
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: -PdesignComposeReleaseVersion=${{ github.ref_name }} publishAllPublicationsToLocalDirRepository
+        run: ./gradlew -PdesignComposeReleaseVersion=${{ github.ref_name }} publishAllPublicationsToLocalDirRepository
 
       - name: Upload
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/roborazzi-record-screenshot.yml
+++ b/.github/workflows/roborazzi-record-screenshot.yml
@@ -51,9 +51,7 @@ jobs:
           setup-protoc: true
 
       - name: Record fresh screenshots
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          arguments: recordRoborazziDebug
+        run: ./gradlew recordRoborazziDebug
 
       # These screenshots are stored to use as a baseline for future runs of the
       # roborazzi-compare-screenshot workflow

--- a/.github/workflows/super-lint.yml
+++ b/.github/workflows/super-lint.yml
@@ -66,10 +66,7 @@ jobs:
         uses: ./.github/actions/setup-build
         with:
           setup-gradle: true
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
-        with:
-          cache-read-only: true
-          arguments: spotCheck
+      - run: ./gradlew spotCheck
   validate-gradle-wrapper:
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +75,6 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: gradle/actions/wrapper-validation@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
   cargo-deny:
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
This required some migrations which were detailed in https://github.com/gradle/actions/releases/tag/v4.0.0

Key migrations include:

Removing the cache cleanup argument which is now the default behavior
Changing the Gradle invocations to nomal `run: ./gradlew` commands
Removing the seperate wrapper validation action, which is now integrated into the setup-gradle action.