### PR TITLE
Update to API 35

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,9 @@ agp-minSupported = "8.4.2"
 # SDK Levels
 minSdk = "26"
 appMinSdk = "30"
-compileSdk = "34"
+compileSdk = "35"
 targetSdk = "34"
+unbundledStubsSdk="34"
 
 #Compose and Kotlin Versions - tightly coupled
 kotlin = "1.9.23"

--- a/reference-apps/aaos-unbundled/mediacompose/build.gradle.kts
+++ b/reference-apps/aaos-unbundled/mediacompose/build.gradle.kts
@@ -107,7 +107,7 @@ dependencies {
     api("com.android.car:car-media-common:UNBUNDLED")
     compileOnly(
         files(
-            "$unbundledAAOSDir/prebuilts/sdk/${ libs.versions.compileSdk.get().toInt()}/system/android.car-system-stubs.jar"
+            "$unbundledAAOSDir/prebuilts/sdk/${ libs.versions.unbundledStubsSdk.get().toInt()}/system/android.car-system-stubs.jar"
         )
     )
 


### PR DESCRIPTION
Needed to add a seperate variable for MediaCompose because Unbundled hasn't released stubs for api-35 yet.