### PR TITLE
Add new Cargo fetch tests and remove old mocked pseudo-test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Build all
         run: cargo build --all-targets --all-features
       - name: Test all
-        run: cargo test --all-targets --all-features
+        run: cargo test --all-targets --features=reflection,fetch,dcf_info
         ############ Figma resources
   figma-resources:
     runs-on: ubuntu-latest

--- a/.idea/runConfigurations/Fetch_HelloWorld.xml
+++ b/.idea/runConfigurations/Fetch_HelloWorld.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Fetch HelloWorld" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
+    <option name="command" value="run --package figma_import --bin fetch -- --doc-id=pxVlixodJqZL95zo2RzTHl --nodes=#MainFrame --output=/tmp/out.dcf" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="false" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Figma_Fetch_Tests.xml
+++ b/.idea/runConfigurations/Figma_Fetch_Tests.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Figma Fetch Tests" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="test --package figma_import --test test_fetches -- --exact" />
+    <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
+    <option name="emulateTerminal" value="true" />
+    <option name="channel" value="DEFAULT" />
+    <option name="requiredFeatures" value="true" />
+    <option name="allFeatures" value="true" />
+    <option name="withSudo" value="false" />
+    <option name="buildTarget" value="REMOTE" />
+    <option name="backtrace" value="SHORT" />
+    <option name="isRedirectInput" value="false" />
+    <option name="redirectInputPath" value="" />
+    <method v="2">
+      <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,6 @@ dependencies = [
  "layout",
  "lazy_static",
  "log",
- "phf 0.11.2",
  "prost",
  "serde",
  "serde-generate",
@@ -761,19 +760,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
+ "phf_macros",
+ "phf_shared",
  "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_macros 0.11.2",
- "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -782,17 +771,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared 0.10.0",
- "rand",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared 0.11.2",
+ "phf_shared",
  "rand",
 ]
 
@@ -802,8 +781,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator",
+ "phf_shared",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -811,32 +790,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_macros"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
-dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher 0.3.11",
 ]
@@ -1137,7 +1094,7 @@ checksum = "f8c9331265d81c61212dc75df7b0836544ed8e32dba77a522f113805ff9a948e"
 dependencies = [
  "heck 0.3.3",
  "include_dir",
- "phf 0.10.1",
+ "phf",
  "serde",
  "serde-reflection",
  "textwrap",

--- a/crates/figma_import/Cargo.toml
+++ b/crates/figma_import/Cargo.toml
@@ -10,10 +10,10 @@ rust-version.workspace = true
 [features]
 default = []
 reflection = ["serde-reflection", "serde-generate", "clap"]
-http_mock = ["phf"]
 fetch = ["clap"]
 dcf_info = ["clap"]
 fetch_layout = ["clap"]
+test_fetches = ["fetch"]
 
 
 [dependencies]
@@ -31,7 +31,6 @@ svgtypes.workspace = true
 unicode-segmentation.workspace = true
 image.workspace = true
 euclid.workspace = true
-phf = { workspace = true, optional = true }
 
 # layout dependencies
 taffy.workspace = true

--- a/crates/figma_import/src/document.rs
+++ b/crates/figma_import/src/document.rs
@@ -16,7 +16,6 @@ use dc_bundle::definition::element::{
     variable_map::NameIdMap, Collection, Mode, Variable, VariableMap,
 };
 use dc_bundle::legacy_definition::element::node::NodeQuery;
-#[cfg(not(feature = "http_mock"))]
 use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
@@ -40,13 +39,11 @@ use dc_bundle::legacy_definition::EncodedImageMap;
 use dc_bundle::legacy_figma_live_update::FigmaDocInfo;
 use log::error;
 
-#[cfg(not(feature = "http_mock"))]
 const FIGMA_TOKEN_HEADER: &str = "X-Figma-Token";
 const BASE_FILE_URL: &str = "https://api.figma.com/v1/files/";
 const BASE_COMPONENT_URL: &str = "https://api.figma.com/v1/components/";
 const BASE_PROJECT_URL: &str = "https://api.figma.com/v1/projects/";
 
-#[cfg(not(feature = "http_mock"))]
 fn http_fetch(api_key: &str, url: String, proxy_config: &ProxyConfig) -> Result<String, Error> {
     let mut agent_builder = ureq::AgentBuilder::new();
     let mut buffer = Vec::new();
@@ -68,9 +65,6 @@ fn http_fetch(api_key: &str, url: String, proxy_config: &ProxyConfig) -> Result<
 
     Ok(body)
 }
-
-#[cfg(feature = "http_mock")]
-use crate::figma_v1_document_mocks::http_fetch;
 
 /// Document update requests return this value to indicate if an update was
 /// made or not.

--- a/crates/figma_import/src/fetch.rs
+++ b/crates/figma_import/src/fetch.rs
@@ -45,7 +45,7 @@ pub enum ProxyConfig {
 pub struct ConvertRequest<'r> {
     figma_api_key: &'r str,
     // Node names
-    queries: Vec<&'r str>,
+    pub queries: Vec<&'r str>,
     // Ignored images
     ignored_images: Vec<IgnoredImage<'r>>,
 
@@ -65,6 +65,19 @@ pub struct ConvertRequest<'r> {
     image_session: Option<ImageContextSession>,
 }
 
+impl<'r> ConvertRequest<'r> {
+    pub fn new(figma_api_key: &'r str, queries: Vec<&'r str>, version: Option<String>) -> Self {
+        Self {
+            figma_api_key,
+            queries,
+            ignored_images: Vec::new(),
+            last_modified: None,
+            version,
+            image_session: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub enum ConvertResponse {
     Document(Vec<u8>),
@@ -74,7 +87,7 @@ pub enum ConvertResponse {
 pub fn fetch_doc(
     id: &str,
     requested_version_id: &str,
-    rq: ConvertRequest,
+    rq: &ConvertRequest,
     proxy_config: &ProxyConfig,
 ) -> Result<ConvertResponse, crate::Error> {
     if let Some(mut doc) = Document::new_if_changed(
@@ -82,8 +95,8 @@ pub fn fetch_doc(
         id.into(),
         requested_version_id.into(),
         proxy_config,
-        rq.last_modified.unwrap_or(String::new()),
-        rq.version.unwrap_or(String::new()),
+        rq.last_modified.clone().unwrap_or(String::new()),
+        rq.version.clone().unwrap_or(String::new()),
         rq.image_session.clone(),
     )? {
         // The document has changed since the version the client has, so we should fetch

--- a/crates/figma_import/src/figma_schema.rs
+++ b/crates/figma_import/src/figma_schema.rs
@@ -1230,6 +1230,7 @@ pub struct VariableAlias {
 pub enum VariableAliasOrList {
     Alias(VariableAlias),
     List(Vec<VariableAlias>),
+    Map(HashMap<String, VariableAlias>),
 }
 impl VariableAliasOrList {
     fn get_name(&self) -> Option<String> {
@@ -1242,6 +1243,9 @@ impl VariableAliasOrList {
                 if let Some(alias) = alias {
                     return Some(alias.id.clone());
                 }
+            }
+            VariableAliasOrList::Map(_) => {
+                panic!("We don't support Maps of Variables!");
             }
         }
         None

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -49,8 +49,6 @@ pub use dc_bundle::legacy_definition::element::node::NodeQuery;
 pub use dc_bundle::legacy_definition::view::view::View;
 pub use dc_bundle::legacy_definition::view::view::ViewData;
 
-#[cfg(feature = "http_mock")]
-mod figma_v1_document_mocks;
 /// Functionality related to reflection for deserializing our bincode archives in other
 /// languages
 #[cfg(feature = "reflection")]

--- a/crates/figma_import/tests/test_fetches.rs
+++ b/crates/figma_import/tests/test_fetches.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#![cfg(feature = "fetch")]
+
+use figma_import::tools::fetch::{build_definition, load_figma_token};
+use figma_import::{Document, ProxyConfig};
+
+// Simply fetches and serializes a doc
+#[test]
+#[cfg_attr(not(feature = "test_fetches"), ignore)]
+fn fetch_variable_modes() {
+    const DOC_ID: &str = "HhGxvL4aHhP8ALsLNz56TP";
+    const QUERIES: &[&str] = &["#stage", "#Box"];
+    let queries: Vec<String> = QUERIES.iter().map(|s| s.to_string()).collect();
+
+    let figma_token = load_figma_token().unwrap();
+
+    let mut doc: Document = Document::new(
+        figma_token.as_str(),
+        DOC_ID.to_string(),
+        String::new(),
+        &ProxyConfig::None,
+        None,
+    )
+    .unwrap();
+
+    let dc_definition = build_definition(&mut doc, &queries).unwrap();
+
+    bincode::serialize(&dc_definition).unwrap();
+}

--- a/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
+++ b/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
@@ -72,7 +72,9 @@ fun Project.initializeExtension(extension: PluginExtension) {
         providers
             .environmentVariable("FIGMA_ACCESS_TOKEN")
             .orElse(providers.gradleProperty(tokenGradlePropertyName))
-            .orElse(providers.fileContents(extension.figmaTokenFile).asText.map { text -> text.trim() })
+            .orElse(
+                providers.fileContents(extension.figmaTokenFile).asText.map { text -> text.trim() }
+            )
     )
     // Avoid odd behavior by only allowing changes to be made to the token before it's read
     extension.figmaToken.finalizeValueOnRead()


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2024-11-12

* **PR #1776 (THIS ONE)**:
  `main` ← `wb/froeht/new-fetch-test`

    * PR #1774:
      `wb/froeht/new-fetch-test` ← `wb/froeht/protoconv-layout-positioning`

      * PR #1782:
        `wb/froeht/protoconv-layout-positioning` ← `wb/froeht/1731-meter-data`

<!-- end git-machete generated -->

This adds a new Cargo fetch test to check that a doc can be fetched and serialized. Because we don't want GitHub to be trying to fetch files, it's locked behind a new feature, "test_fetches".

This also removes the figma_v1_mock file and feature. This was a pseudo test that wasn't being executed by anything. It worked by using a feature flag to mock the http fetch, which meant that if the feature flag was included that no http queries would work, including the new fetch test.