### PR TITLE
Strip whitespace from Figma API key when read from .config file

### DIFF
--- a/crates/figma_import/src/tools/fetch.rs
+++ b/crates/figma_import/src/tools/fetch.rs
@@ -83,6 +83,9 @@ pub fn fetch(args: Args) -> Result<(), ConvertError> {
 
         std::fs::read_to_string(config_path)
             .expect("Could not read API key from ~/.config/figma_access_token")
+            .trim()
+            .parse()
+            .unwrap()
     });
 
     let mut doc: Document = Document::new(


### PR DESCRIPTION
This makes sure that we don't try to authenticate to Figma with the key with newlines or spaces in it.