### PR TITLE
Fix: Trim whitespace from Figma token when read from file

### DIFF
--- a/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
+++ b/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
@@ -16,6 +16,7 @@
 
 package com.android.designcompose.gradle
 
+import java.awt.SystemColor.text
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -71,7 +72,7 @@ fun Project.initializeExtension(extension: PluginExtension) {
         providers
             .environmentVariable("FIGMA_ACCESS_TOKEN")
             .orElse(providers.gradleProperty(tokenGradlePropertyName))
-            .orElse(providers.fileContents(extension.figmaTokenFile).asText)
+            .orElse(providers.fileContents(extension.figmaTokenFile).asText.map { text -> text.trim() })
     )
     // Avoid odd behavior by only allowing changes to be made to the token before it's read
     extension.figmaToken.finalizeValueOnRead()


### PR DESCRIPTION
This change trims any leading or trailing whitespace from the Figma access token when it's read from a file.
This ensures that the token is valid and avoids any unexpected behavior caused by extra whitespace.