### PR TITLE
Refactor: Rename interior MeterData to MeterDataType

### DIFF
--- a/crates/dc_bundle/src/legacy_definition/view/node_style.rs
+++ b/crates/dc_bundle/src/legacy_definition/view/node_style.rs
@@ -27,7 +27,7 @@ use crate::definition::modifier::{
     BlendMode, FilterOp, TextAlign, TextAlignVertical, TextOverflow,
 };
 use crate::definition::modifier::{BoxShadow, LayoutTransform, TextShadow};
-use crate::definition::plugin::meter_data::MeterData;
+use crate::definition::plugin::meter_data::MeterDataType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -102,7 +102,7 @@ pub struct NodeStyle {
     pub vertical_sizing: LayoutSizing,
     pub aspect_ratio: Number,
     pub pointer_events: PointerEvents,
-    pub meter_data: Option<MeterData>,
+    pub meter_data: Option<MeterDataType>,
 }
 
 impl Default for NodeStyle {

--- a/crates/figma_import/src/reflection.rs
+++ b/crates/figma_import/src/reflection.rs
@@ -107,7 +107,7 @@ pub fn registry() -> serde_reflection::Result<serde_reflection::Registry> {
         .trace_type::<dc_bundle::definition::plugin::ProgressVectorMeterData>(&samples)
         .expect("couldn't trace ProgressVectorMeterData");
     tracer
-        .trace_type::<dc_bundle::definition::plugin::meter_data::MeterData>(&samples)
+        .trace_type::<dc_bundle::definition::plugin::meter_data::MeterDataType>(&samples)
         .expect("couldn't trace MeterData");
     tracer
         .trace_type::<dc_bundle::definition::layout::PositionType>(&samples)

--- a/crates/figma_import/src/transform_flexbox.rs
+++ b/crates/figma_import/src/transform_flexbox.rs
@@ -56,7 +56,7 @@ use dc_bundle::definition::plugin::{
     ProgressVectorMeterData, RotationMeterData,
 };
 
-use dc_bundle::definition::plugin::meter_data::MeterData;
+use dc_bundle::definition::plugin::meter_data::MeterDataType;
 use dc_bundle::legacy_definition::view::component::ComponentInfo;
 use dc_bundle::legacy_definition::view::view::{RenderMethod, ScrollInfo, View};
 use dc_bundle::legacy_definition::view::view_style::ViewStyle;
@@ -1581,7 +1581,7 @@ fn visit_node(
             match meter_data {
                 Ok(meter_data) => {
                     style.node_style.meter_data = Some(match meter_data {
-                        MeterJson::ArcData(data) => MeterData::ArcData(ArcMeterData {
+                        MeterJson::ArcData(data) => MeterDataType::ArcData(ArcMeterData {
                             enabled: data.enabled,
                             start: data.start,
                             end: data.end,
@@ -1590,7 +1590,7 @@ fn visit_node(
                             corner_radius: data.corner_radius,
                         }),
                         MeterJson::RotationData(data) => {
-                            MeterData::RotationData(RotationMeterData {
+                            MeterDataType::RotationData(RotationMeterData {
                                 enabled: data.enabled,
                                 start: data.start,
                                 end: data.end,
@@ -1599,7 +1599,7 @@ fn visit_node(
                             })
                         }
                         MeterJson::ProgressBarData(data) => {
-                            MeterData::ProgressBarData(ProgressBarMeterData {
+                            MeterDataType::ProgressBarData(ProgressBarMeterData {
                                 enabled: data.enabled,
                                 discrete: data.discrete,
                                 discrete_value: data.discrete_value,
@@ -1609,7 +1609,7 @@ fn visit_node(
                             })
                         }
                         MeterJson::ProgressMarkerData(data) => {
-                            MeterData::ProgressMarkerData(ProgressMarkerMeterData {
+                            MeterDataType::ProgressMarkerData(ProgressMarkerMeterData {
                                 enabled: data.enabled,
                                 discrete: data.discrete,
                                 discrete_value: data.discrete_value,
@@ -1627,7 +1627,7 @@ fn visit_node(
                             if data.enabled {
                                 stroke_paths = data.paths.iter().filter_map(parse_path).collect();
                             }
-                            MeterData::ProgressVectorData(ProgressVectorMeterData {
+                            MeterDataType::ProgressVectorData(ProgressVectorMeterData {
                                 enabled: data.enabled,
                                 discrete: data.discrete,
                                 discrete_value: data.discrete_value,

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -45,7 +45,7 @@ import com.android.designcompose.proto.strokeAlignFromInt
 import com.android.designcompose.proto.toUniform
 import com.android.designcompose.proto.top
 import com.android.designcompose.serdegen.ArcMeterData
-import com.android.designcompose.serdegen.MeterData
+import com.android.designcompose.serdegen.MeterDataType
 import com.android.designcompose.serdegen.Overflow
 import com.android.designcompose.serdegen.ProgressBarMeterData
 import com.android.designcompose.serdegen.ProgressMarkerMeterData
@@ -357,14 +357,14 @@ internal fun ContentDrawScope.render(
         // Check if there is meter data for a dial/gauge/progress bar
         if (style.node_style.meter_data.isPresent) {
             when (val meterData = style.node_style.meter_data.get()) {
-                is MeterData.RotationData -> {
+                is MeterDataType.RotationData -> {
                     val rotationData = meterData.value
                     if (rotationData.enabled) {
                         overrideTransform =
                             calculateRotationData(rotationData, meterValue, style, density)
                     }
                 }
-                is MeterData.ProgressBarData -> {
+                is MeterDataType.ProgressBarData -> {
                     val progressBarData = meterData.value
                     if (progressBarData.enabled) {
                         val progressBarSizeTransform =
@@ -379,7 +379,7 @@ internal fun ContentDrawScope.render(
                         overrideTransform = progressBarSizeTransform.second
                     }
                 }
-                is MeterData.ProgressMarkerData -> {
+                is MeterDataType.ProgressMarkerData -> {
                     val progressMarkerData = meterData.value
                     if (progressMarkerData.enabled) {
                         overrideTransform =
@@ -393,14 +393,14 @@ internal fun ContentDrawScope.render(
                             )
                     }
                 }
-                is MeterData.ArcData -> {
+                is MeterDataType.ArcData -> {
                     val arcData = meterData.value
                     if (arcData.enabled) {
                         shape = calculateArcData(arcData, meterValue, shape)
                         customArcAngle = true
                     }
                 }
-                is MeterData.ProgressVectorData -> {
+                is MeterDataType.ProgressVectorData -> {
                     // If this is a vector path progress bar, save it here so we can convert it to a
                     // set of path instructions and render it instead of the normal stroke.
                     if (meterData.value.enabled) progressVectorMeterData = meterData.value
@@ -633,14 +633,14 @@ internal fun ContentDrawScope.squooshShapeRender(
         // Check if there is meter data for a dial/gauge/progress bar
         if (style.node_style.meter_data.isPresent) {
             when (val meterData = style.node_style.meter_data.get()) {
-                is MeterData.RotationData -> {
+                is MeterDataType.RotationData -> {
                     val rotationData = meterData.value
                     if (rotationData.enabled) {
                         overrideTransform =
                             calculateRotationData(rotationData, meterValue, style, density)
                     }
                 }
-                is MeterData.ProgressBarData -> {
+                is MeterDataType.ProgressBarData -> {
                     val progressBarData = meterData.value
                     if (progressBarData.enabled) {
                         val progressBarSizeTransform =
@@ -655,7 +655,7 @@ internal fun ContentDrawScope.squooshShapeRender(
                         overrideTransform = progressBarSizeTransform.second
                     }
                 }
-                is MeterData.ProgressMarkerData -> {
+                is MeterDataType.ProgressMarkerData -> {
                     val progressMarkerData = meterData.value
                     if (progressMarkerData.enabled) {
                         overrideTransform =
@@ -669,14 +669,14 @@ internal fun ContentDrawScope.squooshShapeRender(
                             )
                     }
                 }
-                is MeterData.ArcData -> {
+                is MeterDataType.ArcData -> {
                     val arcData = meterData.value
                     if (arcData.enabled) {
                         shape = calculateArcData(arcData, meterValue, shape)
                         customArcAngle = true
                     }
                 }
-                is MeterData.ProgressVectorData -> {
+                is MeterDataType.ProgressVectorData -> {
                     // If this is a vector path progress bar, save it here so we can convert it to a
                     // set of path instructions and render it instead of the normal stroke.
                     if (meterData.value.enabled) progressVectorMeterData = meterData.value

--- a/proto/definition/plugin/meter_data.proto
+++ b/proto/definition/plugin/meter_data.proto
@@ -78,7 +78,7 @@ message ProgressVectorMeterData {
 // A container message that holds one of the meter data types (rotation, arc,
 // progress bar, or progress marker).
 message MeterData {
-  oneof meter_data {
+  oneof meter_data_type {
     RotationMeterData rotation_data = 1;
     ArcMeterData arc_data = 2;
     ProgressBarMeterData progress_bar_data = 3;


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1795

## Chain of upstream PRs & tree of downstream PRs as of 2024-11-19

* PR #1795:
  `main` ← `wb/froeht/1734-textstyle`

  * **PR #1796 (THIS ONE)**:
    `wb/froeht/1734-textstyle` ← `wb/froeht/fix-up-meterdata`

      * PR #1806:
        `wb/froeht/fix-up-meterdata` ← `wb/froeht/1736-nodestyle`

<!-- end git-machete generated -->

This change refactors the `MeterData` message to `MeterDataType` to better reflect its role as a container for different meter data types within the exterior MeterData message