### PR TITLE
Associate raw resource files with a doc ID

### DIFF
--- a/designcompose/src/testDebug/kotlin/com/android/designcompose/DesignRawResourceTest.kt
+++ b/designcompose/src/testDebug/kotlin/com/android/designcompose/DesignRawResourceTest.kt
@@ -60,7 +60,7 @@ class DesignRawResourceTest {
     fun testHelloWorldDoc_setRawResourceId_passes() {
         with(composeTestRule) {
             DesignSettings.setRawResourceId(
-                DesignDocId("pxVlixodJqZL95zo2RzTHl", ""),
+                DesignDocId("pxVlixodJqZL95zo2RzTHl"),
                 R.raw.raw_resource_test_hello_world_doc,
             )
             composeTestRule.setContent { HelloWorld() }

--- a/designcompose/src/testDebug/kotlin/com/android/designcompose/DesignRawResourceTest.kt
+++ b/designcompose/src/testDebug/kotlin/com/android/designcompose/DesignRawResourceTest.kt
@@ -24,6 +24,7 @@ import com.android.designcompose.TestUtils.ClearStateTestRule
 import com.android.designcompose.annotation.Design
 import com.android.designcompose.annotation.DesignComponent
 import com.android.designcompose.annotation.DesignDoc
+import com.android.designcompose.common.DesignDocId
 import com.android.designcompose.test.R
 import com.android.designcompose.test.assertRenderStatus
 import com.android.designcompose.test.onDCDoc
@@ -58,7 +59,10 @@ class DesignRawResourceTest {
     @Test
     fun testHelloWorldDoc_setRawResourceId_passes() {
         with(composeTestRule) {
-            DesignSettings.setRawResourceId(R.raw.raw_resource_test_hello_world_doc)
+            DesignSettings.setRawResourceId(
+                DesignDocId("pxVlixodJqZL95zo2RzTHl", ""),
+                R.raw.raw_resource_test_hello_world_doc,
+            )
             composeTestRule.setContent { HelloWorld() }
 
             onDCDoc(HelloWorldDoc).assertRenderStatus(DocRenderStatus.Rendered)

--- a/designcompose/src/testFixtures/java/com/android/designcompose/TestUtils.java
+++ b/designcompose/src/testFixtures/java/com/android/designcompose/TestUtils.java
@@ -56,7 +56,7 @@ public class TestUtils {
 
     private static void clearDesignSettings() {
         DesignSettings.INSTANCE.testOnlyClearFileFetchStatus();
-        DesignSettings.INSTANCE.setRawResourceId(Resources.ID_NULL);
+        DesignSettings.INSTANCE.clearRawResources();
     }
 
 


### PR DESCRIPTION
Fixes #1802. This lets multiple docs to load from raw resources, fixes the design switcher, and allows live update to work even when loading from raw resources.