### PR TITLE
Fix a bug with trying to remove the same node multiple times.

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshLayout.kt
@@ -110,7 +110,7 @@ internal class SquooshLayoutIdAllocator(
     }
 
     /// Get the set of layout nodes to remove.
-    fun removalNodes(): Set<Int> {
+    fun removalNodes(): HashSet<Int> {
         val removalSet = remainingSet
         remainingSet = visitedSet
         visitedSet = HashSet()
@@ -278,7 +278,7 @@ private fun populateComputedLayout(
 internal fun layoutTree(
     root: SquooshResolvedNode,
     manager: SquooshLayoutManager,
-    removalNodes: Set<Int>,
+    removalNodes: HashSet<Int>,
     layoutCache: HashMap<Int, Int>,
     layoutValueCache: HashMap<Int, Layout>,
 ) {
@@ -288,6 +288,8 @@ internal fun layoutTree(
         layoutValueCache.remove(layoutId)
         layoutCache.remove(layoutId)
     }
+    // Clear removalNodes so that multiple calls to this don't try to remove the same nodes
+    removalNodes.clear()
 
     // Update the layout tree which the Rust JNI code is maintaining
     val layoutNodes = arrayListOf<LayoutNode>()

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -380,7 +380,7 @@ fun SquooshRoot(
     val transitionedInteractionState = interactionState.clonedWithAnimatedActionsApplied()
 
     var transitionRoot: SquooshResolvedNode? = null
-    var transitionRootRemovalNodes: Set<Int>? = null
+    var transitionRootRemovalNodes: HashSet<Int>? = null
     // Now see if we need to compute a transition root and generate animated transitions.
     if (
         isRoot && (transitionedInteractionState != null && animatedActions.isNotEmpty()) ||
@@ -783,9 +783,9 @@ private fun measureExternal(
 private fun squooshLayoutMeasurePolicy(
     presentationRoot: SquooshResolvedNode,
     root: SquooshResolvedNode,
-    rootRemovalNodes: Set<Int>,
+    rootRemovalNodes: HashSet<Int>,
     transitionRoot: SquooshResolvedNode?,
-    transitionRootRemovalNodes: Set<Int>?,
+    transitionRootRemovalNodes: HashSet<Int>?,
     layoutCache: HashMap<Int, Int>,
     layoutValueCache: HashMap<Int, Layout>,
     layoutManager: SquooshLayoutManager,


### PR DESCRIPTION
Fixes #1838. When removing nodes from layout manager, clear the set of layout IDs as soon as they are removed so that the same set of IDs can't be used again.