### PR TITLE
Fix crashes related to scrolling

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -608,7 +608,7 @@ fun SquooshRoot(
                                 val contentHeight =
                                     presentationRoot.computedLayout?.content_height ?: 0F
                                 val frameHeight = presentationRoot.computedLayout?.height ?: 0F
-                                val maxScroll = frameHeight - contentHeight
+                                val maxScroll = (frameHeight - contentHeight).coerceAtMost(0F)
                                 scrollOffset.value =
                                     Offset(
                                         0F,
@@ -620,7 +620,7 @@ fun SquooshRoot(
                                 val contentWidth =
                                     presentationRoot.computedLayout?.content_width ?: 0F
                                 val frameWidth = presentationRoot.computedLayout?.width ?: 0F
-                                val maxScroll = frameWidth - contentWidth
+                                val maxScroll = (frameWidth - contentWidth).coerceAtMost(0F)
                                 scrollOffset.value =
                                     Offset(
                                         (scrollOffset.value.x + delta).coerceIn(maxScroll, 0F),
@@ -699,7 +699,7 @@ fun SquooshRoot(
                                 customizationContext,
                                 serverParams,
                                 setDocId,
-                                designSwitcherPolicy,
+                                designSwitcherPolicy = DesignSwitcherPolicy.SHOW_IF_ROOT,
                                 liveUpdateMode,
                                 designComposeCallbacks,
                                 true, // Is scroll component


### PR DESCRIPTION
Fixes #1833, #1834. Fix a crash with expanding the design switcher when the scrollable message list is added. This recursive call to SquooshRoot was using the previous IS_DESIGN_SWITCHER policy, causing an infinite recursion composing overlays. Fix another crash with scrollable views whose content size is not large enough to warrant scrolling.