### PR TITLE
Blunt-force replace DCD, View and multiple Styles with Proto 

### DIFF
--- a/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
+++ b/common/src/main/java/com/android/designcompose/common/GenericDocContent.kt
@@ -16,11 +16,11 @@
 
 package com.android.designcompose.common
 
-import com.android.designcompose.serdegen.DesignComposeDefinition
+import com.android.designcompose.definition.DesignComposeDefinition
 import com.android.designcompose.serdegen.DesignComposeDefinitionHeader
 import com.android.designcompose.serdegen.FigmaDocInfo
-import com.android.designcompose.serdegen.ServerFigmaDoc
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.live_update.figma.ServerFigmaDoc
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.serdegen.ViewDataType
 import com.novi.bincode.BincodeDeserializer
 import com.novi.bincode.BincodeSerializer

--- a/common/src/main/java/com/android/designcompose/common/NodeQuery.kt
+++ b/common/src/main/java/com/android/designcompose/common/NodeQuery.kt
@@ -16,8 +16,8 @@
 
 package com.android.designcompose.common
 
-import com.android.designcompose.serdegen.DesignComposeDefinition
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.DesignComposeDefinition
+import com.android.designcompose.definition.view.View
 
 sealed class NodeQuery {
     data class NodeId(val id: String) : NodeQuery()

--- a/common/src/main/java/com/android/designcompose/common/Utils.kt
+++ b/common/src/main/java/com/android/designcompose/common/Utils.kt
@@ -16,7 +16,7 @@
 
 package com.android.designcompose.common
 
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 
 // Given a variant name with comma separated properties in the form of property=variant, return the
 // same node name with the properties sorted.

--- a/designcompose/src/main/java/com/android/designcompose/ComputePaths.kt
+++ b/designcompose/src/main/java/com/android/designcompose/ComputePaths.kt
@@ -41,7 +41,7 @@ import com.android.designcompose.serdegen.Shape
 import com.android.designcompose.serdegen.StrokeCap
 import com.android.designcompose.serdegen.VectorArc
 import com.android.designcompose.serdegen.ViewShape
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import kotlin.jvm.optionals.getOrNull
 
 /// ComputedPaths is a set of paths derived from a shape and style definition. These

--- a/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
+++ b/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
@@ -31,7 +31,7 @@ import com.android.designcompose.serdegen.BackgroundType
 import com.android.designcompose.serdegen.ColorOrVarType
 import com.android.designcompose.serdegen.ComponentInfo
 import com.android.designcompose.serdegen.Dimension
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 

--- a/designcompose/src/main/java/com/android/designcompose/DesignText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignText.kt
@@ -21,6 +21,25 @@ import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.unit.Constraints
 import com.android.designcompose.DesignTextMeasure.AVAILABLE_SIZE_CONTENT_MAXIMUM
 import com.android.designcompose.DesignTextMeasure.AVAILABLE_SIZE_CONTENT_MINIMUM
+import com.android.designcompose.proto.blendModeFromInt
+import com.android.designcompose.proto.fontStyleFromInt
+import com.android.designcompose.proto.layoutStyle
+import com.android.designcompose.proto.nodeStyle
+import com.android.designcompose.proto.textAlignFromInt
+import com.android.designcompose.proto.textAlignVerticalFromInt
+import com.android.designcompose.proto.textDecorationFromInt
+import com.android.designcompose.proto.textOverflowFromInt
+import com.android.designcompose.proto.toUniform
+import com.android.designcompose.serdegen.FontStyle
+import com.android.designcompose.serdegen.Layout
+import com.android.designcompose.serdegen.LineHeightType
+import com.android.designcompose.serdegen.StyledTextRun
+import com.android.designcompose.serdegen.TextAlign
+import com.android.designcompose.serdegen.TextAlignVertical
+import com.android.designcompose.serdegen.TextDecoration
+import com.android.designcompose.definition.view.View
+import com.android.designcompose.definition.view.ViewStyle
+import java.util.Optional
 import kotlin.math.ceil
 
 // Measure text height given a width. Called from Rust as a measure function for text that has auto

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -24,10 +24,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithCache

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -66,7 +66,7 @@ import com.android.designcompose.serdegen.Shape
 import com.android.designcompose.serdegen.VectorArc
 import com.android.designcompose.serdegen.View
 import com.android.designcompose.serdegen.ViewShape
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.squoosh.SquooshResolvedNode
 import java.lang.Float.max
 import java.util.Optional

--- a/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
+++ b/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
@@ -31,7 +31,7 @@ import com.android.designcompose.proto.navigationTypeFromInt
 import com.android.designcompose.serdegen.Action
 import com.android.designcompose.serdegen.ActionType
 import com.android.designcompose.serdegen.Transition
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.squoosh.AnimationTransition
 import com.android.designcompose.squoosh.SmartAnimateTransition
 import kotlin.jvm.optionals.getOrNull

--- a/designcompose/src/main/java/com/android/designcompose/Layout.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Layout.kt
@@ -38,8 +38,8 @@ import com.android.designcompose.serdegen.LayoutTransform
 import com.android.designcompose.serdegen.OverflowDirection
 import com.android.designcompose.serdegen.PositionType
 import com.android.designcompose.serdegen.Size
-import com.android.designcompose.serdegen.View
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.View
+import com.android.designcompose.definition.view.ViewStyle
 import java.util.Optional
 import kotlin.math.roundToInt
 

--- a/designcompose/src/main/java/com/android/designcompose/Utils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/Utils.kt
@@ -107,11 +107,11 @@ import com.android.designcompose.serdegen.ItemSpacing
 import com.android.designcompose.serdegen.ItemSpacingType
 import com.android.designcompose.serdegen.JustifyContent
 import com.android.designcompose.serdegen.LayoutSizing
-import com.android.designcompose.serdegen.LayoutStyle
+import com.android.designcompose.definition.layout.LayoutStyle
 import com.android.designcompose.serdegen.LayoutTransform
 import com.android.designcompose.serdegen.LineHeight
 import com.android.designcompose.serdegen.LineHeightType
-import com.android.designcompose.serdegen.NodeStyle
+import com.android.designcompose.definition.view.NodeStyle
 import com.android.designcompose.serdegen.NumOrVarType
 import com.android.designcompose.serdegen.Overflow
 import com.android.designcompose.serdegen.OverflowDirection
@@ -130,10 +130,10 @@ import com.android.designcompose.serdegen.TextDecoration
 import com.android.designcompose.serdegen.TextOverflow
 import com.android.designcompose.serdegen.Transition
 import com.android.designcompose.serdegen.TransitionType
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.serdegen.ViewDataType
 import com.android.designcompose.serdegen.ViewShape
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 import kotlin.math.roundToInt

--- a/designcompose/src/main/java/com/android/designcompose/proto/ProtoUtils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/proto/ProtoUtils.kt
@@ -22,7 +22,7 @@ import com.android.designcompose.serdegen.Box
 import com.android.designcompose.serdegen.FontWeight
 import com.android.designcompose.serdegen.ItemSpacing
 import com.android.designcompose.serdegen.LayoutStyle
-import com.android.designcompose.serdegen.NodeStyle
+import com.android.designcompose.definition.view.NodeStyle
 import com.android.designcompose.serdegen.NumOrVar
 import com.android.designcompose.serdegen.NumOrVarType
 import com.android.designcompose.serdegen.Shape
@@ -34,7 +34,7 @@ import com.android.designcompose.serdegen.TriggerType
 import com.android.designcompose.serdegen.ViewData
 import com.android.designcompose.serdegen.ViewDataType
 import com.android.designcompose.serdegen.ViewShape
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
@@ -33,14 +33,14 @@ import com.android.designcompose.proto.ifTextGetText
 import com.android.designcompose.proto.nodeStyle
 import com.android.designcompose.serdegen.Container
 import com.android.designcompose.serdegen.Layout
-import com.android.designcompose.serdegen.NodeStyle
+import com.android.designcompose.definition.view.NodeStyle
 import com.android.designcompose.serdegen.Shape
 import com.android.designcompose.serdegen.VectorArc
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.serdegen.ViewData
 import com.android.designcompose.serdegen.ViewDataType
 import com.android.designcompose.serdegen.ViewShape
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.toLayoutTransform
 import java.util.Optional
 import kotlin.jvm.optionals.getOrElse

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
@@ -57,7 +57,7 @@ import com.android.designcompose.serdegen.Layout
 import com.android.designcompose.serdegen.TextAlignVertical
 import com.android.designcompose.serdegen.TextOverflow
 import com.android.designcompose.serdegen.ViewDataType
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.squooshShapeRender
 import com.android.designcompose.useLayer
 import kotlin.jvm.optionals.getOrNull

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
@@ -18,9 +18,9 @@ package com.android.designcompose.squoosh
 
 import android.graphics.PointF
 import com.android.designcompose.TextMeasureData
-import com.android.designcompose.serdegen.Layout
-import com.android.designcompose.serdegen.View
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.android_interface.LayoutChangedResponse
+import com.android.designcompose.definition.view.View
+import com.android.designcompose.definition.view.ViewStyle
 
 /// A SquooshResolvedNode represents a design element from the DesignCompose tree after variants
 /// and other customizations have been applied. The SquooshResolvedNode tree is handed to layout
@@ -42,7 +42,7 @@ internal class SquooshResolvedNode(
     var firstChild: SquooshResolvedNode? = null,
     var nextSibling: SquooshResolvedNode? = null,
     var parent: SquooshResolvedNode? = null,
-    var computedLayout: Layout? = null,
+    var computedLayout: LayoutChangedResponse.Layout? = null,
     // overrideLayoutSize is set to true when we want the renderer to use the computed
     // layout size instead of any other size it might calculate.
     var overrideLayoutSize: Boolean = false,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
@@ -53,7 +53,7 @@ import com.android.designcompose.proto.textAlignFromInt
 import com.android.designcompose.proto.textDecorationFromInt
 import com.android.designcompose.serdegen.LineHeightType
 import com.android.designcompose.serdegen.TextDecoration
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.serdegen.ViewDataType
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -75,10 +75,10 @@ import com.android.designcompose.serdegen.RenderMethod
 import com.android.designcompose.serdegen.ScrollInfo
 import com.android.designcompose.serdegen.Trigger
 import com.android.designcompose.serdegen.TriggerType
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import com.android.designcompose.serdegen.ViewData
 import com.android.designcompose.serdegen.ViewDataType
-import com.android.designcompose.serdegen.ViewStyle
+import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.squooshNodeVariant
 import com.android.designcompose.squooshRootNode
 import java.util.Optional

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshVariantTransition.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshVariantTransition.kt
@@ -30,7 +30,7 @@ import com.android.designcompose.serdegen.SmartAnimate
 import com.android.designcompose.serdegen.Spring
 import com.android.designcompose.serdegen.Transition
 import com.android.designcompose.serdegen.TransitionType
-import com.android.designcompose.serdegen.View
+import com.android.designcompose.definition.view.View
 import java.util.Optional
 
 // We want to perform an animated transition when a variant customization causes a presented


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2024-12-18

* **PR #1879 (THIS ONE)**:
  `feature/protoconv` ← `wb/froeht/swap-dcd-to-proto`

    * PR #1874:
      `wb/froeht/swap-dcd-to-proto` ← `wb/froeht/test-convert`

<!-- end git-machete generated -->

This will cause syntax errors across the codebase, but will mean that converting code in a file should clear those errors. As an example, replacing all instances of the Serde NodeStyle with the Proto NodeStyle means that this line of code is now an error: