### PR TITLE
Temporarily disable the VariantAnimationTimelineTest.

### DIFF
--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/examples/AllExamples.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/examples/AllExamples.kt
@@ -133,11 +133,13 @@ val EXAMPLES: ArrayList<Triple<String, @Composable () -> Unit, String?>> =
         // Animations
         Triple("SA", { SmartAnimateTest() }, SmartAnimateTestDoc.javaClass.name),
         Triple("SA Variant", { VariantAnimationTest() }, VariantAnimationTestDoc.javaClass.name),
+        /** Temporarily disabled: GH-1945
         Triple(
             "SA Variant Timelines",
             { VariantAnimationTimelineTest() },
             VariantAnimationTimelineTestDoc.javaClass.name,
         ),
+        */
         // No support for hyperlinks in squoosh.
         Triple("Hyperlink", { HyperlinkTest() }, HyperlinkValidationDoc.javaClass.name),
         // GH-636: Test takes too long to execute.

--- a/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/examples/VariantAnimationTimelineTest.kt
+++ b/integration-tests/validation/src/main/java/com/android/designcompose/testapp/validation/examples/VariantAnimationTimelineTest.kt
@@ -59,6 +59,8 @@ enum class SceneState {
     Closed,
 }
 
+/** Temporarily disabled: GH-1945
+
 @DesignDoc(id = "vJRf4zxY4QX4zzSSUd1nJ5")
 interface VariantAnimationTimelineTest {
     @DesignComponent(node = "root/display_1")
@@ -212,3 +214,4 @@ fun VariantAnimationTimelineTest() {
         }
     }
 }
+*/

--- a/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/AnimationTimelines.kt
+++ b/integration-tests/validation/src/testDebug/kotlin/com/android/designcompose/testapp/validation/AnimationTimelines.kt
@@ -15,6 +15,7 @@
  */
 
 package com.android.designcompose.testapp.validation
+/** Temporarily disabled: GH-1945
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -108,3 +109,4 @@ class AnimationTimelines {
         composeTestRule.captureRootRoboImage("${name}Animation-End")
     }
 }
+*/


### PR DESCRIPTION
It tries to access parts of the DesignDoc that aren't meant to be accessed, and fails to compile because Validation does not have the protobuf libraries as a dependency. We don't want to expose the Protobuf API, because this can lead to compilation problems when another library uses a different version of the Protobuf library. We'll need to change the test to resolve the compilation error without modifying it's Gradle dependencies.

Task to fix it is #1945