### PR TITLE
Configure Robolectric to output android logs to stderr

### DIFF
--- a/build-logic/src/main/kotlin/designcompose/conventions/roborazzi.gradle.kts
+++ b/build-logic/src/main/kotlin/designcompose/conventions/roborazzi.gradle.kts
@@ -32,6 +32,7 @@ project.pluginManager.withPlugin("com.android.base") {
                     // Run the tests in parallel
                     maxParallelForks =
                         (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+                    systemProperty("robolectric.logging", "stderr")
 
                     environment("RUST_BACKTRACE", "1")
                     failFast = true


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1886

## Chain of upstream PRs as of 2024-12-30

* PR #1886:
  `main` ← `feature/protoconv`

  * **PR #1954 (THIS ONE)**:
    `feature/protoconv` ← `wb/froeht/enable-robolectric-log-printing`

<!-- end git-machete generated -->

This should help debug test failures