### PR TITLE
Fix TapCallback on nodes that change from an interaction

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
+++ b/designcompose/src/main/java/com/android/designcompose/InteractionState.kt
@@ -224,6 +224,12 @@ internal class InteractionState {
     var navOverlaySubscriptions: ArrayList<() -> Unit> = ArrayList()
     var variantSubscriptions: HashMap<String, ArrayList<() -> Unit>> = HashMap()
     var animationSubscriptions: ArrayList<() -> Unit> = ArrayList()
+
+    // A set of node IDs that have been pressed due to an interaction or TapCallback. This is
+    // necessary to keep track of so that nodes that change to another variant due to an
+    // interaction can still be found to have a press/click/tap event on them and be added to
+    // SquooshRoot's list of composable children.
+    var isPressed: HashSet<String> = HashSet()
 }
 
 /// Perform the "navigate" action, by appending the given node id to
@@ -471,6 +477,8 @@ internal fun InteractionState.clonedWithAnimatedActionsApplied(): InteractionSta
     deltaInteractionState.navigationHistory = ArrayList(navigationHistory)
     deltaInteractionState.overlayMemory = ArrayList(overlayMemory)
     deltaInteractionState.undoMemory = HashMap(undoMemory)
+    deltaInteractionState.openLinkCallbacks = HashSet(openLinkCallbacks)
+    deltaInteractionState.isPressed = HashSet(isPressed)
     // Apply all of our transition actions.
     for (anim in animations) {
         deltaInteractionState.changeTo(
@@ -772,6 +780,14 @@ internal fun InteractionState.squooshRootNode(
         doc.c.nodeIdMap,
         customizations,
     )
+}
+
+internal fun InteractionState.isPressed(nodeId: String): Boolean {
+    return isPressed.contains(nodeId)
+}
+
+internal fun InteractionState.setPressed(nodeId: String, pressed: Boolean) {
+    if (pressed) isPressed.add(nodeId) else isPressed.remove(nodeId)
 }
 
 /// InteractionState is managed in a global, per document. We don't pass it down via a

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -644,6 +644,17 @@ fun SquooshRoot(
         } else {
             Modifier
         }
+
+    // If we are currently being pressed, then we must continue to include a `pointerInput` block,
+    // even if the variant we're currently showing doesn't have any click or press interactions. If
+    // we don't do this, then when we CHANGE_TO a variant that has no interactions but is an
+    // ON_PRESS target, then Compose will think we've lost interest in the gesture and cancel it for
+    // us. Even though we re-run this block on recompose, our `onPress` closure runs with its scope
+    // for the duration of the gesture.
+    //
+    // This is covered in the interaction test document's "Combos" screen; the purple button has no
+    // interactions in its ON_PRESS variant.
+    val isPressed = remember { mutableStateOf(false) }
     CompositionLocalProvider(LocalSquooshIsRootContext provides SquooshIsRoot(false)) {
         androidx.compose.ui.layout.Layout(
             modifier =
@@ -747,7 +758,7 @@ fun SquooshRoot(
                             }
                         }
 
-                        if (hasPressClick)
+                        if (hasPressClick || isPressed.value)
                             composableChildModifier =
                                 composableChildModifier.squooshInteraction(
                                     doc,
@@ -755,6 +766,7 @@ fun SquooshRoot(
                                     interactionScope,
                                     customizationContext,
                                     child,
+                                    isPressed,
                                 )
                         else needsComposition = false
                     }

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -96,6 +96,7 @@ import com.android.designcompose.getMatchingVariant
 import com.android.designcompose.getTapCallback
 import com.android.designcompose.getVisible
 import com.android.designcompose.getVisibleState
+import com.android.designcompose.isPressed
 import com.android.designcompose.squooshNodeVariant
 import com.android.designcompose.squooshRootNode
 import com.android.designcompose.utils.hasScrolling
@@ -317,6 +318,8 @@ internal fun resolveVariantsRecursively(
     }
     val tapCallback = customizations.getTapCallback(view)
     if (tapCallback != null) hasSupportedInteraction = true
+
+    if (interactionState.isPressed(viewFromTree.id)) hasSupportedInteraction = true
 
     // If this node has a content customization, then we make a special record of it so that we can
     // zip through all of them after layout and render them in the right location.


### PR DESCRIPTION
Fixes #1995. When a node has both an interaction that changes the variant and a TapCallback, the TapCallback was not being found because it was customized using the node's original name. This has been fixed with the following changes:

1. Add an isPressed mutableState that gets set to true when the press happens, and false when released. This causes a recomposition which builds a new UI tree using the new variant that has changed.
2. Add a set of pressed node IDs in interaction set so that when the above recomposition happens, the new UI tree with the changed variant still finds a supported interaction and adds itself to the root node's composable child list.