### PR TITLE
Quick fix for the UnsupportedOperationException

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
@@ -374,7 +374,7 @@ private fun GetBranches(
 }
 
 private fun GetProjectFileCount(doc: DocContent?): String {
-    val count = doc?.c?.project_files?.size ?: 0
+    val count = doc?.c?.projectFiles?.size ?: 0
     return count.toString()
 }
 
@@ -384,12 +384,12 @@ private fun GetProjectList(
     interactionState: InteractionState,
 ): ReplacementContent {
     return ReplacementContent(
-        count = doc?.c?.project_files?.size ?: 0,
+        count = doc?.c?.projectFiles?.size ?: 0,
         content = { index ->
             {
-                val docId = doc?.c?.project_files?.get(index)?.id ?: ""
+                val docId = doc?.c?.projectFiles?.get(index)?.id ?: ""
                 DesignSwitcherDoc.FigmaDoc(
-                    doc?.c?.project_files?.get(index)?.name ?: "",
+                    doc?.c?.projectFiles?.get(index)?.name ?: "",
                     docId,
                     Modifier.clickable {
                         interactionState.close(null)

--- a/designcompose/src/main/java/com/android/designcompose/DocContent.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocContent.kt
@@ -49,12 +49,16 @@ class DocContent(var c: GenericDocContent, previousDoc: DocContent?) {
     private var images: HashMap<String, Bitmap> = HashMap()
 
     init {
-        for ((imageKey, bytes) in c.document.imagesMap) {
-            if (bytes.isEmpty()) {
-                if (previousDoc != null && previousDoc.images[imageKey] != null) {
+        for ((imageKey, bytes) in c.inMemoryImagesMap) {
+            if (bytes.isEmpty) {
+                if (
+                    previousDoc != null &&
+                        previousDoc.images[imageKey] != null &&
+                        previousDoc.c.inMemoryImagesMap[imageKey] != null
+                ) {
                     images[imageKey] = previousDoc.images[imageKey]!!
-                    // Replace this record in the decoded doc.
-                    c.document.imagesMap[imageKey] = previousDoc.c.document.imagesMap[imageKey]
+                    // Replace this record and write to disk as the images of the decoded doc.
+                    c.inMemoryImagesMap[imageKey] = previousDoc.c.inMemoryImagesMap[imageKey]!!
                 }
             } else {
                 val byteArray = ByteArray(bytes.size()) { i -> bytes[i] }


### PR DESCRIPTION
Create a mutable image map in memory and when write to disk, create a copy of the document and replace the images map with the in memory map.

Fixes: #1998