### PR TITLE
Support load shader code from node in the plugin ui

### DIFF
--- a/support-figma/extended-layout-plugin/src/shader.html
+++ b/support-figma/extended-layout-plugin/src/shader.html
@@ -61,7 +61,10 @@
 
     <div id="nodeSection" class="collapsible" style="margin-top: 8px;">
         <div id="cleared">No nodes selected. Select a node that can have a background to start.</div>
-        <div id="selected"></div>
+        <div id="selected" style="display: flex; gap:4px; align-items: center">
+            <div id="nodeId" style="width: 100%;"></div>
+            <button id="loadShaderButton" class="button--primary">Load Shader</button>
+        </div>
     </div>
     <div id="nodeActions" class="content">
         <div style="display: flex; align-items: center; gap:4px;">
@@ -165,6 +168,7 @@
     let nodeSection = document.getElementById("nodeSection");
     let nodeCleared = document.getElementById("cleared");
     let nodeSelected = document.getElementById("selected");
+    let loadShaderButton = document.getElementById("loadShaderButton");
     let nodeActions = document.getElementById("nodeActions");
     let setShaderButton = document.getElementById("setShaderButton");
     let useShaderFallbackColor = document.getElementById("useShaderFallbackColor");
@@ -209,8 +213,15 @@
     const floatUniformMax = document.getElementById("floatUniformMax");
 
     // "Create" button closes the dialog and creates the uniform
-    createFloatUniformButton.addEventListener("click", () => {
+    createFloatUniformButton.onclick = async () => {
         const uniformName = floatUniformNameInput.value;
+        createShaderFloatUniform(floatUniformNameInput.value, null, floatUniformMin.value, floatUniformMax.value);
+
+        createFloatUniformDialog.close();
+        await runShader();
+    };
+
+    function createShaderFloatUniform(uniformName, floatValue, uniformMin, uniformMax) {
         if (customUniforms.includes(uniformName)) {
             alert("This uniform already exists, please use a different name.");
             return;
@@ -238,13 +249,13 @@
         deleteIcon.classList.add("icon");
         deleteIcon.classList.add("icon--close");
         deleteButton.appendChild(deleteIcon);
-        deleteButton.onclick = e => {
+        deleteButton.onclick = async e => {
             const index = customUniforms.indexOf(uniformName);
             customUniforms.splice(index, 1);
             uniformTypeMap.delete(uniformName);
             uniforms.removeChild(newUniformEntry);
 
-            runShader();
+            await runShader();
         };
         shaderLine.appendChild(deleteButton);
         newUniformEntry.appendChild(shaderLine);
@@ -255,12 +266,12 @@
         uniformSlider.id = `slider_${uniformName}`;
         uniformSlider.classList.add("slider");
         uniformSlider.type = "range";
-        const minValue = floatUniformMin.value ? Number(floatUniformMin.value) : 0;
+        const minValue = uniformMin ? Number(uniformMin) : 0;
         uniformSlider.min = minValue;
-        const maxValue = Math.max(floatUniformMax.value ? Number(floatUniformMax.value) : 1, minValue + 1);
+        const maxValue = Math.max(uniformMax ? Number(uniformMax) : 1, minValue + 1);
         uniformSlider.max = maxValue;
         uniformSlider.step = "0.001";
-        uniformSlider.value = (minValue + maxValue) / 2;
+        uniformSlider.value = floatValue ? floatValue : (minValue + maxValue) / 2;
         sliderLine.appendChild(uniformSlider);
 
         const uniformValue = document.createElement("span");
@@ -271,14 +282,11 @@
         sliderLine.appendChild(uniformValue);
         newUniformEntry.appendChild(sliderLine);
         uniforms.appendChild(newUniformEntry);
+    }
 
+    closeFloatUniformButton.onclick = () => {
         createFloatUniformDialog.close();
-        runShader();
-    });
-
-    closeFloatUniformButton.addEventListener("click", () => {
-        createFloatUniformDialog.close();
-    });
+    };
 
     function createFloatUniform() {
         createFloatUniformDialog.showModal();
@@ -291,8 +299,16 @@
     const colorUniformAlphaOption = document.getElementById("colorUniformAlphaOption");
 
     // "Create" button closes the dialog and creates the uniform
-    createColorUniformButton.addEventListener("click", () => {
+    createColorUniformButton.onclick = async () => {
         const uniformName = colorUniformNameInput.value;
+        const type = colorUniformAlphaOption.checked ? "color4" : "color3";
+        createShaderColorUniform(uniformName, type, null);
+
+        createColorUniformDialog.close();
+        await runShader();
+    };
+
+    function createShaderColorUniform(uniformName, type, colorValue) {
         if (customUniforms.includes(uniformName)) {
             alert("This uniform already exists, please use a different name.");
             return;
@@ -303,7 +319,6 @@
             return;
         }
         customUniforms.push(uniformName);
-        const type = colorUniformAlphaOption.checked ? "color4" : "color3";
         uniformTypeMap.set(uniformName, type);
 
         const newUniformEntry = document.createElement("div");
@@ -319,6 +334,9 @@
         colorInput.type = "color";
         colorInput.id = `color_${uniformName}`;
         shaderLine.appendChild(colorInput);
+        if (colorValue) {
+            colorInput.value = rgbFloatToHex(colorValue);
+        }
 
         const deleteButton = document.createElement("span");
         deleteButton.classList.add("icon-button");
@@ -326,18 +344,18 @@
         deleteIcon.classList.add("icon");
         deleteIcon.classList.add("icon--close");
         deleteButton.appendChild(deleteIcon);
-        deleteButton.onclick = e => {
+        deleteButton.onclick = async e => {
             const index = customUniforms.indexOf(uniformName);
             customUniforms.splice(index, 1);
             uniformTypeMap.delete(uniformName);
             uniforms.removeChild(newUniformEntry);
 
-            runShader();
+            await runShader();
         };
         shaderLine.appendChild(deleteButton);
         newUniformEntry.appendChild(shaderLine);
 
-        if (colorUniformAlphaOption.checked) {
+        if (type == "color4") {
             const sliderLine = document.createElement("div");
             sliderLine.classList.add("center-vertically-container");
             const uniformSlider = document.createElement("input");
@@ -347,7 +365,7 @@
             uniformSlider.min = 0;
             uniformSlider.max = 1;
             uniformSlider.step = "0.001";
-            uniformSlider.value = 1;
+            uniformSlider.value = colorValue ? colorValue.a : 1.0;
             sliderLine.appendChild(uniformSlider);
 
             const uniformValue = document.createElement("span");
@@ -359,14 +377,11 @@
             newUniformEntry.appendChild(sliderLine);
         }
         uniforms.appendChild(newUniformEntry);
+    }
 
+    closeColorUniformButton.onclick = () => {
         createColorUniformDialog.close();
-        runShader();
-    });
-
-    closeColorUniformButton.addEventListener("click", () => {
-        createColorUniformDialog.close();
-    });
+    };
 
     function createColorUniform() {
         createColorUniformDialog.showModal();
@@ -384,13 +399,21 @@
         return { r, g, b };
     }
 
+    function rgbFloatToHex(rgbColor) {
+        function componentToHex(c) {
+            const hex = Math.round(c * 255).toString(16);
+            return hex.padStart(2, '0');
+        }
+        return "#" + componentToHex(rgbColor.r) + componentToHex(rgbColor.g) + componentToHex(rgbColor.b);
+    }
+
     function clearUniforms() {
         customUniforms.length = 0;
         uniformTypeMap.clear();
         uniforms.innerHTML = "";
     }
 
-    function uniformValue(uniform) {
+    function previewUniformValue(uniform) {
         const type = uniformTypeMap.get(uniform);
         const floatArray = [];
         switch (type) {
@@ -412,6 +435,39 @@
         }
     }
 
+    function uniformValue(uniform) {
+        const type = uniformTypeMap.get(uniform);
+        const floatArray = [];
+        switch (type) {
+            case "float":
+                const slider = document.getElementById(`slider_${uniform}`);
+                return parseFloat(slider.value);
+            case "color3":
+            case "color4":
+                const color3 = document.getElementById(`color_${uniform}`);
+                let rgb3 = hexToRgbFloat(color3.value);
+                const alpha = document.getElementById(`alpha_${uniform}`);
+                return {
+                    r: rgb3.r,
+                    g: rgb3.g,
+                    b: rgb3.b,
+                    a: alpha ? parseFloat(alpha.value) : 1.0
+                };
+        }
+    }
+
+    function uniformExtras(uniform) {
+        const type = uniformTypeMap.get(uniform);
+        if (type == "float") {
+            const slider = document.getElementById(`slider_${uniform}`);
+            return {
+                min: parseFloat(slider.min),
+                max: parseFloat(slider.max)
+            };
+        }
+        return null;
+    }
+
     function clearShaderFromFigmaNode() {
         parent.postMessage({
             pluginMessage: {
@@ -420,14 +476,14 @@
         }, '*');
     }
 
-    function clearShaderCode() {
+    async function clearShaderCode() {
         clearUniforms();
         shaderCodeInput.value = `
 vec4 main(float2 fragCoord) {
     return vec4(0, 0, 0, 1);
 }`;
         currentShader = null;
-        runShader();
+        await runShader();
     }
 
     function loadShaderCode(shader) {
@@ -494,7 +550,7 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
                     mouseDragX, mouseDragY, mouseClickX, mouseClickY, // iMouse(x, y, z, w)
                 ];
                 customUniforms.forEach(function (uniform) {
-                    const value = uniformValue(uniform);
+                    const value = previewUniformValue(uniform);
                     if (typeof value === "string" || typeof value === "number") {
                         uniforms.push(value);
                     } else {
@@ -543,8 +599,9 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
                     customUniforms.forEach(function (uniform) {
                         let shaderUniform = {
                             uniformName: uniform,
-                            uniformType: uniformTypeMap.get(uniform).replace("color", "float"),
+                            uniformType: uniformTypeMap.get(uniform),
                             uniformValue: uniformValue(uniform),
+                            extras: uniformExtras(uniform),
                         };
                         shaderUniforms.push(shaderUniform);
                     });
@@ -588,6 +645,7 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
     window.onmessage = async function (event) {
         let msg = event.data.pluginMessage;
         if (msg.msg == 'shaderCode') {
+            clearUniforms();
             shaderCodeInput.value = msg.code;
             await runShader();
             return;
@@ -607,10 +665,39 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
         }
         if (msg.msg == "shader-selection") {
             nodeCleared.style.display = "none";
-            nodeSelected.innerHTML = `Node selected: ${msg.nodeId}`;
-            nodeSelected.style.display = "block";
+            nodeSelected.style.display = "flex";
             nodeSection.classList.add("active");
             nodeActions.style.display = "block";
+            document.getElementById("nodeId").innerHTML = `Node selected: ${msg.nodeId}`;
+            if (msg.shader) {
+                loadShaderButton.onclick = async () => {
+                    clearUniforms();
+                    shaderCodeInput.value = msg.shader;
+                    for (const shaderUniform of msg.shaderUniforms) {
+                        switch (shaderUniform.uniformType) {
+                            case "float":
+                                if (shaderUniform.extras) {
+                                    createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformValue,
+                                        shaderUniform.extras.min, shaderUniform.extras.max);
+                                } else {
+                                    createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformValue,
+                                        Math.min(0, shaderUniform.uniformValue), Math.max(1, shaderUniform.uniformValue));
+                                }
+                                break;
+                            case "color3":
+                            case "color4":
+                                createShaderColorUniform(shaderUniform.uniformName, shaderUniform.uniformType, shaderUniform.uniformValue);
+                                break;
+                        }
+                        console.log(`${shaderUniform.uniformName} ${shaderUniform.uniformType} = ${shaderUniform.uniformValue}`);
+                    }
+                    await runShader();
+                };
+                loadShaderButton.style.display = "block";
+            } else {
+                loadShaderButton.style.display = "none";
+            }
+
             shaderWidth = msg.size.width;
             shaderHeight = msg.size.height;
             canvas.width = shaderWidth;

--- a/support-figma/extended-layout-plugin/src/style.css
+++ b/support-figma/extended-layout-plugin/src/style.css
@@ -443,6 +443,7 @@ a:active {
 }
 
 .content {
+  padding: 8px;
   display: none;
   background-color: #f1f1f1;
 }


### PR DESCRIPTION
Fixes: #1877 
Changed plugin ui to use type "color3" "color4" so when it loads the shader code from node, it knows it is a color.

Added a load shader button to the node id line:
<img width="582" alt="Screenshot 2025-01-17 at 13 35 35" src="https://github.com/user-attachments/assets/98101aec-b112-449c-8757-d33b5afb7e46" />
