### PR TITLE
Adjust shader preview canvas size and shader size on node size change

### DIFF
--- a/support-figma/extended-layout-plugin/src/shader.html
+++ b/support-figma/extended-layout-plugin/src/shader.html
@@ -23,10 +23,10 @@
 <!-- BEGIN OF SHADER PLUGIN UI -->
 <div class="page-padding-large">
     <div style="align-items: flex-start; gap: 16px; display: flex;">
-        <div>
-            <canvas id="shaderPreview" width="256px" height="256px" style="border: 1px black solid" />
+        <div class="container" style="border: 1px black solid; max-width: 256px; max-height: 256px; overflow: hidden;">
+            <canvas id="shaderPreview" width="256px" height="256px" />
         </div>
-        <div style="width: 100%; max-height: 256px; overflow-y: scroll;">
+        <div style="width: auto; flex-grow: 1; max-height: 256px; overflow-y: scroll;">
             <div style="border: 2px black solid;">
                 <div>
                     <div style="height: 32px;" class="center-vertically-container">uniform float3 iResolution;</div>
@@ -158,6 +158,8 @@
 
 <script>
     let canvas = document.getElementById("shaderPreview");
+    let shaderWidth = 256;
+    let shaderHeight = 256;
     let shaderCodeInput = document.getElementById("shaderCodeInput");
 
     let nodeSection = document.getElementById("nodeSection");
@@ -443,8 +445,6 @@ vec4 main(float2 fragCoord) {
             locateFile: (file) =>
                 "https://unpkg.com/canvaskit-wasm@latest/bin/" + file,
         }).then((CanvasKit) => {
-            const shaderWidth = 256;
-            const shaderHeight = 256;
 
             const paint = new CanvasKit.Paint();
             const startTimeMs = Date.now();
@@ -598,6 +598,11 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
             nodeCleared.style.display = "block";
             nodeSelected.style.display = "none";
             nodeActions.style.display = "none";
+            shaderWidth = 256;
+            shaderHeight = 256;
+            canvas.width = shaderWidth;
+            canvas.height = shaderHeight;
+            await runShader();
             return;
         }
         if (msg.msg == "shader-selection") {
@@ -606,6 +611,11 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
             nodeSelected.style.display = "block";
             nodeSection.classList.add("active");
             nodeActions.style.display = "block";
+            shaderWidth = msg.size.width;
+            shaderHeight = msg.size.height;
+            canvas.width = shaderWidth;
+            canvas.height = shaderHeight;
+            await runShader();
             return;
         }
     }


### PR DESCRIPTION
Fixes: #1831

Before the change, the shader always generates preview image with resolution 256x256. After the change, it generates the shader preview image  with the same size of the selected node.