### PR TITLE
Update documentation for recent changes

### DIFF
--- a/docs/_docs/animations.md
+++ b/docs/_docs/animations.md
@@ -6,12 +6,7 @@ nav_order: 13
 
 # Animations
 
-Animations are supported in two different ways: animations from Figma interactions, and animations from programmatically changing variants. To enable animations, the squoosh rendering path must be enabled by turning it on and wrapping your `@Composable` content with it:
-```kotlin
-    CompositionLocalProvider(LocalDesignDocSettings provides DesignDocSettings(useSquoosh = true)) {
-        content()
-    }
-```
+Animations are supported in two different ways: animations from Figma interactions, and animations from programmatically changing variants.
 
 ## Figma interaction animations
 Animations set in Figma as a prototype interaction are supported. These animations run automatically whenever an interaction triggers the animation to begin. After making any changes to an interaction, make sure to run the `Sync Prototype changes` plugin so that the interaction is saved to the plugin data.
@@ -19,13 +14,12 @@ Animations set in Figma as a prototype interaction are supported. These animatio
 <img src="./animations/SyncPrototype.png">
 
 ## Variant change animations
-When variants change programmatically using the `@DesignVariant` customization, they will use a default spring animation for the transition. This can be customized using the custom animation API by specifying an easing type, duration, and delay in the `DesignDocSetting()` function that enables the squoosh animation code path. Populate the new `customVariantTransition` parameter with a function that takes a `VariantTransitionContext` and returns an `AnimationTransition` interface. The context provides some data on variant that is changing, and the `AnimationTransition` needs two functions: `animationSpec()` that returns `AnimationSpec<Float>`, and `delayMillis()` that returns an `Int` representing the number of milliseconds to wait before beginning the animation. The `SmartAnimateTransition` is the only supported transition at this time. The easiest way to use this is to use a compose function such as `androidx.compose.animation.core.tween`, and optionally, the delay time in milliseconds.
+When variants change programmatically using the `@DesignVariant` customization, they will use a default spring animation for the transition. This can be customized using the custom animation API by specifying an easing type, duration, and delay in the `DesignDocSetting()` function. Populate the new `customVariantTransition` parameter with a function that takes a `VariantTransitionContext` and returns an `AnimationTransition` interface. The context provides some data on variant that is changing, and the `AnimationTransition` needs two functions: `animationSpec()` that returns `AnimationSpec<Float>`, and `delayMillis()` that returns an `Int` representing the number of milliseconds to wait before beginning the animation. The `SmartAnimateTransition` is the only supported transition at this time. The easiest way to use this is to use a compose function such as `androidx.compose.animation.core.tween`, and optionally, the delay time in milliseconds.
 
 Here is an example:
 
 ```kotlin
 DesignDocSettings(
-    useSquoosh = true,
     customVariantTransition = { context ->
         if (context.fromComponentSet("MyComponentName")) {
             SmartAnimateTransition(

--- a/docs/_docs/working-with-source/writing-tests.md
+++ b/docs/_docs/working-with-source/writing-tests.md
@@ -71,6 +71,23 @@ to be run locally.
 The tests can be run with `./gradlew test`, and will be run as part of `./gradlew check`
 and `./gradlew build`
 
+## Text Validation
+
+Traditionally, testing that a composable has a particular string rendered in it would use the `onNodeWithText()` function like this:
+``` 
+onNodeWithText("Testers!").assertExists()
+```
+
+However, because DesignCompose does its own text rendering, this method is not able to validate text. Instead, use the `assertHasText()` function on the document that contains the root view:
+```
+onDCDoc(HelloWorldDoc).assertHasText("Testers!")
+```
+
+To test that a string does not exist, use the analagous `assertDoesNotHaveText()` function:
+```
+onDCDoc(HelloWorldDoc).assertDoesNotHaveText("This text should not be here")
+```
+
 ## Screenshot tests
 
 [Roborazzi](https://github.com/takahirom/roborazzi) is used to support screenshot testing. It uses
@@ -150,7 +167,7 @@ Touch input such as taps and drags can be simulated in tests using functions suc
 onNodeWithTag("MyTag").performClick()
 ```
 
-When working with the squoosh code branch, nodes are harder to find since the entire view tree is rendered together. To find a node using `onNodeWithTag`, a replacement component or replacement content customization must be used in order to tag the data with `Modifier.testTag()`. Here is an example where a node named `#replace-node` is replaced with a node `#BlueNode` and tagged with a test tag.
+Because DesignCompose does not render each node with a composable and instead renders the whole tree at once, nodes are harder to find with test code. To find a node using `onNodeWithTag`, a replacement component or replacement content customization must be used in order to tag the data with `Modifier.testTag()`. Here is an example where a node named `#replace-node` is replaced with a node `#BlueNode` and tagged with a test tag.
 ```kotlin
 interface ComponentReplace {
     @DesignComponent(node = "#stage")
@@ -164,11 +181,9 @@ interface ComponentReplace {
 
 @Composable
 fun ComponentReplaceTest() {
-    CompositionLocalProvider(LocalDesignDocSettings provides DesignDocSettings(useSquoosh = true)) {
-        ComponentReplaceDoc.Main(
-            replaceNode = { ComponentReplaceDoc.BlueNode(modifier = Modifier.testTag("Blue")) }
-        )
-    }
+    ComponentReplaceDoc.Main(
+        replaceNode = { ComponentReplaceDoc.BlueNode(modifier = Modifier.testTag("Blue")) }
+    )
 }
 ```
 Now the `#BlueNode` node is tagged and can be found with the test framework:


### PR DESCRIPTION
Fixes #1884: Update testing documentation for testing text existence. Remove documentation references to squoosh since it has been removed. Add documentation for the scroll callback customization.