### PR TITLE
Switch Dependabot to run on main, better consolidate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,12 +21,16 @@ updates:
       - "/.github/actions/build-figma-resource"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "dependapool"
+    target-branch: "main"
     groups:
       non-breaking-github-workflow:
         update-types:
         - "minor"
-    open-pull-requests-limit: 5
+        - "patch"
+      major-github-workflow:
+        update-types:
+        - "major"
+    open-pull-requests-limit: 2
     schedule:
       interval: weekly
       day: friday
@@ -35,12 +39,16 @@ updates:
     directory: /docs
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "dependapool"
+    target-branch: "main"
     groups:
       non-breaking-bundler:
         update-types:
         - "minor"
-    open-pull-requests-limit: 5
+        - "patch"
+      major-bundler:
+        update-types:
+        - "major"
+    open-pull-requests-limit: 2
     schedule:
       interval: weekly
       day: friday
@@ -51,12 +59,16 @@ updates:
       - "/support-figma/extended-layout-plugin"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "dependapool"
+    target-branch: "main"
     groups:
       non-breaking-figma-widget:
         update-types:
         - "minor"
-    open-pull-requests-limit: 5
+        - "patch"
+      major-figma-widget:
+        update-types:
+        - "major"
+    open-pull-requests-limit: 2
     schedule:
       interval: weekly
       day: friday
@@ -65,12 +77,16 @@ updates:
     directory: "/"
     assignees: [timothyfroehlich]
     reviewers: [timothyfroehlich]
-    target-branch: "dependapool"
+    target-branch: "main"
     groups:
       non-breaking-gradle:
         update-types:
         - "minor"
-    open-pull-requests-limit: 5
+        - "patch"
+      major-gradle:
+        update-types:
+        - "major"
+    open-pull-requests-limit: 2
     schedule:
       interval: weekly
       day: friday


### PR DESCRIPTION
The current Dependabot scheme to run on a "dependapool"
branch which would be merged required some manual steps.
GitHub's configured to delete branches after a merge
which meant I had to manually recreate the "dependapool"
branch each week.

I'm switching this back to run on main to avoid the manual work.

I'm also changing the configuration to better group the updates.
I realized that setting it to "minor" version updates still
created individual updates for "patch" releases. I'm adding a second
group to each for "major" updates (which are more likely to be breaking)

With this there'll still be up to ten dependabot CL's a week, (being generated on Fridays)
but usually less, because not all package ecosystems will have updates.