### PR TITLE
Support medium precision float

### DIFF
--- a/crates/figma_import/src/shader_schema.rs
+++ b/crates/figma_import/src/shader_schema.rs
@@ -60,7 +60,7 @@ pub struct ShaderUniformJson {
 impl Into<(String, ShaderUniform)> for ShaderUniformJson {
     fn into(self) -> (String, ShaderUniform) {
         let uniform_value = match self.uniform_type.as_str() {
-            "float" | "iTime" => {
+            "float" | "half" | "iTime" => {
                 if let Some(float_val) = self.uniform_value.as_f64() {
                     Some(ShaderUniformValue { value_type: Some(FloatValue(float_val as f32)) })
                 } else {
@@ -68,16 +68,22 @@ impl Into<(String, ShaderUniform)> for ShaderUniformJson {
                     None
                 }
             }
-            "float2" | "float3" | "float4" => {
+            "float2" | "float3" | "float4" | "half2" | "half3" | "half4" => {
                 if let Some(uniform_array) = self.uniform_value.as_array() {
                     let float_array: Vec<f32> = uniform_array
                         .iter()
                         .filter_map(|value| value.as_f64().map(|v| v as f32))
                         .collect();
                     match float_array.len() {
-                        2 if self.uniform_type == "float2" => Some(float_array),
-                        3 if self.uniform_type == "float3" => Some(float_array),
-                        4 if self.uniform_type == "float4" => Some(float_array),
+                        2 if self.uniform_type == "float2" || self.uniform_type == "half2" => {
+                            Some(float_array)
+                        }
+                        3 if self.uniform_type == "float3" || self.uniform_type == "half3" => {
+                            Some(float_array)
+                        }
+                        4 if self.uniform_type == "float4" || self.uniform_type == "half4" => {
+                            Some(float_array)
+                        }
                         _ => None,
                     }
                     .map(|float_vec| ShaderUniformValue {

--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -686,7 +686,7 @@ fun ShaderUniform.applyToShader(
     val definedType = shaderUniformMap[name]?.type
     when (value.valueTypeCase) {
         ValueTypeCase.FLOAT_VALUE -> {
-            if (definedType == "float" || definedType == "iTime") {
+            if (definedType == "float" || definedType == "iTime" || definedType == "half") {
                 shader.setFloatUniform(name, value.floatValue)
             }
         }
@@ -694,12 +694,14 @@ fun ShaderUniform.applyToShader(
         ValueTypeCase.FLOAT_VEC_VALUE -> {
             val floatVecValue = value.floatVecValue.floatsList
             when (floatVecValue.size) {
-                1 -> if (definedType == "float") shader.setFloatUniform(name, floatVecValue[0])
+                1 ->
+                    if (definedType == "float" || definedType == "half")
+                        shader.setFloatUniform(name, floatVecValue[0])
                 2 ->
-                    if (definedType == "float2")
+                    if (definedType == "float2" || definedType == "half2")
                         shader.setFloatUniform(name, floatVecValue[0], floatVecValue[1])
                 3 ->
-                    if (definedType == "float3")
+                    if (definedType == "float3" || definedType == "half3")
                         shader.setFloatUniform(
                             name,
                             floatVecValue[0],
@@ -707,7 +709,7 @@ fun ShaderUniform.applyToShader(
                             floatVecValue[2],
                         )
                 4 ->
-                    if (definedType == "float4")
+                    if (definedType == "float4" || definedType == "half4")
                         shader.setFloatUniform(
                             name,
                             floatVecValue[0],

--- a/support-figma/extended-layout-plugin/src/shader.html
+++ b/support-figma/extended-layout-plugin/src/shader.html
@@ -152,6 +152,7 @@
             <label for="floatUniformMax" style="flex-grow: 1;">Max:</label>
             <input type="number" id="floatUniformMax" placeholder="1" step="0.1"></input>
         </div>
+        <input type="checkbox" id="isMediumP">Create a medium float</input>
         </p>
         <div style="display: flex; gap: 4px;">
             <button id="createFloatUniformButton" class="button--primary" style="flex-grow: 1;">Create</button>
@@ -186,6 +187,12 @@
         <label><input type="radio" name="floatArrayUniformType" value="float3">float3</label>
         <br>
         <label><input type="radio" name="floatArrayUniformType" value="float4">float4</label>
+        <br>
+        <label><input type="radio" name="floatArrayUniformType" value="half2">half2</label>
+        <br>
+        <label><input type="radio" name="floatArrayUniformType" value="half3">half3</label>
+        <br>
+        <label><input type="radio" name="floatArrayUniformType" value="half4">half4</label>
         </p>
         <div style="display: flex; gap: 4px;">
             <button id="createFloatArrayUniformButton" class="button--primary" style="flex-grow: 1;">Create</button>
@@ -288,16 +295,18 @@
     const floatUniformNameInput = document.getElementById("floatUniformName");
     const floatUniformMin = document.getElementById("floatUniformMin");
     const floatUniformMax = document.getElementById("floatUniformMax");
+    const isMediumP = document.getElementById("isMediumP");
 
     // "Create" button closes the dialog and creates the uniform
     createFloatUniformButton.onclick = async () => {
         const uniformName = floatUniformNameInput.value;
-        createShaderFloatUniform(floatUniformNameInput.value, null, floatUniformMin.value, floatUniformMax.value);
+        const uniformType = isMediumP.checked ? "half" : "float";
+        createShaderFloatUniform(floatUniformNameInput.value, uniformType, null, floatUniformMin.value, floatUniformMax.value);
         await runShader();
     };
 
-    function createShaderFloatUniform(uniformName, floatValue, uniformMin, uniformMax) {
-        let newUniformEntry = createShaderUniform(uniformName, "float");
+    function createShaderFloatUniform(uniformName, uniformType, floatValue, uniformMin, uniformMax) {
+        let newUniformEntry = createShaderUniform(uniformName, uniformType ? uniformType : "float");
         if (!newUniformEntry) {
             return;
         }
@@ -355,7 +364,7 @@
 
         // Create inputs fields
         const inputsLine = document.createElement("div");
-        let sizeMap = { "float2": 2, "float3": 3, "float4": 4 };
+        let sizeMap = { "float2": 2, "float3": 3, "float4": 4, "half2": 2, "half3": 3, "half4": 4 };
         let arraySize = sizeMap[uniformType];
         for (let i = 0; i < arraySize; i++) {
             let input = document.createElement("input");
@@ -555,11 +564,15 @@
         // iTime is handled separately when the uniforms push the iTime value.
         switch (type) {
             case "float":
+            case "half":
                 const slider = document.getElementById(`slider_${uniform}`);
                 return parseFloat(slider.value);
             case "float2":
             case "float3":
             case "float4":
+            case "half2":
+            case "half3":
+            case "half4":
                 for (let i = 0; i < 4; i++) {
                     const input = document.getElementById(`input_${uniform}_${i}`);
                     if (input) {
@@ -590,9 +603,13 @@
         const type = uniformTypeMap.get(uniform);
         switch (type) {
             case "float":
+            case "half":
             case "float2":
             case "float3":
             case "float4":
+            case "half2":
+            case "half3":
+            case "half4":
             case "int":
                 return previewUniformValue(uniform);
             case "color3":
@@ -849,17 +866,21 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
                 for (const shaderUniform of shaderUniforms) {
                     switch (shaderUniform.uniformType) {
                         case "float":
+                        case "half":
                             if (shaderUniform.extras) {
-                                createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformValue,
+                                createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformType, shaderUniform.uniformValue,
                                     shaderUniform.extras.min, shaderUniform.extras.max);
                             } else {
-                                createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformValue,
+                                createShaderFloatUniform(shaderUniform.uniformName, shaderUniform.uniformType, shaderUniform.uniformValue,
                                     Math.min(0, shaderUniform.uniformValue), Math.max(1, shaderUniform.uniformValue));
                             }
                             break;
                         case "float2":
                         case "float3":
                         case "float4":
+                        case "half2":
+                        case "half3":
+                        case "half4":
                             createShaderFloatArrayUniform(shaderUniform.uniformName, shaderUniform.uniformType, shaderUniform.uniformValue);
                             break;
                         case "color3":

--- a/support-figma/extended-layout-plugin/src/shader.html
+++ b/support-figma/extended-layout-plugin/src/shader.html
@@ -23,9 +23,8 @@
 <!-- BEGIN OF SHADER PLUGIN UI -->
 <div class="page-padding-large">
     <div style="align-items: flex-start; gap: 16px; display: flex;">
-        <div class="container"
-            style="border: 1px black solid; width: auto; flex-shrink: 0; max-width: 256px; max-height: 256px; overflow: hidden;">
-            <canvas id="shaderPreview" width="256px" height="256px" />
+        <div class="container" style="border: 1px black solid; width: auto; flex-shrink: 0;">
+            <canvas id="shaderPreview" width="256" height="256" style="width: 256px; height: 256px;" />
         </div>
         <div style="width: auto; flex-grow: 1; max-height: 256px; overflow-y: scroll;">
             <div style="border: 2px black solid;">
@@ -835,6 +834,8 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
             shaderHeight = 256;
             canvas.width = shaderWidth;
             canvas.height = shaderHeight;
+            canvas.style.width = "256px";
+            canvas.style.height = "256px";
             await runShader();
             return;
         }
@@ -851,6 +852,9 @@ uniform float4 iMouse;           // Mouse drag pos=.xy Click pos=.zw (pixels)
             shaderHeight = msg.size.height;
             canvas.width = shaderWidth;
             canvas.height = shaderHeight;
+            let scaleFactor = (shaderWidth > 256 || shaderHeight > 256) ? Math.min(256 / shaderWidth, 256 / shaderHeight) : 1;
+            canvas.style.width = `${shaderWidth * scaleFactor}px`;
+            canvas.style.height = `${shaderHeight * scaleFactor}px`;
             await runShader();
             return;
         }


### PR DESCRIPTION
Add support for half, half2, half3 and half4 which has medium precision but consumes less memory.

On DesignCompose side, it uses the same API `setFloatUniform`to set the uniform value.

Fixes: #2035 