### PR TITLE
Fix dcf file decoding

### DIFF
--- a/crates/dc_bundle/src/definition_file.rs
+++ b/crates/dc_bundle/src/definition_file.rs
@@ -57,9 +57,11 @@ pub fn decode_dcd_with_header(
     }
 
     let dcd_length = cis.read_raw_varint32().map_err(|_| Error::DecodeError())?;
+    let dcd_limit = cis.push_limit(dcd_length as u64).map_err(|_| Error::DecodeError())?;
     println!("DCD length = {:?}", dcd_length);
     let dcd = DesignComposeDefinition::parse_from(&mut cis)
         .map_err(|e| Error::DCDLoadError(format!("Failed to parse DCD: {}", e)))?;
+    cis.pop_limit(dcd_limit);
 
     Ok((header, dcd))
 }


### PR DESCRIPTION
Fixes https://github.com/google/automotive-design-compose/issues/2131: When decoding DesignComposeDefinition, limit the number of bytes parsed since it was written with write_delimited() and there may be additional image session data after it.