### PR TITLE
Upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,7 +15,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
-    - ubuntu-22.04-32core
+    - ubuntu-24.04-32core
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: reference-apps/tutorial
         run: ./gradlew  --init-script ../local-design-compose-repo.init.gradle.kts build
   build-unbundled:
-    runs-on: ubuntu-22.04-32core
+    runs-on: 'ubuntu-24.04-32core'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
This is a http://go/LSC run by http://go/ghss to upgrade all self-hosted ubuntu-22.04 runners to ubuntu-24.04.

This is a courtesy PR to help you upgrade to the latest release of ubuntu runners, it is not mandatory at this time.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it.

More context and feedback: http://b/406537467
