### PR TITLE
Speed up fetch of components in other files

### DIFF
--- a/crates/figma_import/src/figma_schema.rs
+++ b/crates/figma_import/src/figma_schema.rs
@@ -51,6 +51,7 @@ pub enum ExportFormat {
     Jpg,
     Png,
     Svg,
+    Pdf,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]


### PR DESCRIPTION
Fixes #2161. When retrieving component data from other files, keep track of the components retrieved so we don't download them again when encountering other component instances from the same component.