### PR TITLE
Create Scalable UI plugin

### DIFF
--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -29,4 +29,6 @@ lint:
     field_names_exclude_prepositions:
       excludes:
         - by
+        - from
+        - to
 

--- a/crates/dc_bundle/src/definition/view.rs
+++ b/crates/dc_bundle/src/definition/view.rs
@@ -90,6 +90,7 @@ impl NodeStyle {
             meter_data: None.into(),
             hyperlink: None.into(),
             shader_data: None.into(),
+            scalable_data: None.into(),
             ..Default::default()
         }
     }

--- a/crates/dc_bundle/src/proto/definition/element/scalable.proto
+++ b/crates/dc_bundle/src/proto/definition/element/scalable.proto
@@ -1,0 +1,92 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package designcompose.definition.element;
+
+option java_multiple_files = true;
+option java_package = "com.android.designcompose.definition.element";
+option optimize_for = LITE_RUNTIME;
+
+// An event that causes one or more variants to change
+message Event {
+  string event_name = 1;
+  string event_tokens = 2;
+  string from_variant_id = 3;
+  string from_variant_name = 4;
+  string to_variant_id = 5;
+  string to_variant_name = 6;
+}
+
+// A key frame that shows the given variant at the given frame
+message Keyframe {
+  int32 frame = 1;
+  string variant_name = 2;
+}
+
+// A key frame variant that blends two or more variants
+message KeyframeVariant {
+  string name = 1;
+  repeated Keyframe keyframes = 2;
+}
+
+// Data for the parent of a set of variants
+message ScalableUIComponentSet {
+  string id = 1;
+  string name = 2;
+  string role = 3;
+  string default_variant_id = 4;
+  string default_variant_name = 5;
+  repeated Event events = 6;
+  repeated KeyframeVariant keyframe_variants = 7;
+  repeated string variant_ids = 8;
+}
+
+// Represents a dimension in pixels or percentage
+message ScalableDimension {
+  oneof Dimension {
+    float points = 1;
+    float percent = 2;
+  }
+}
+
+// Bounds of a rectangle
+message Bounds {
+  ScalableDimension left = 1;
+  ScalableDimension top = 2;
+  ScalableDimension right = 3;
+  ScalableDimension bottom = 4;
+  ScalableDimension width = 5;
+  ScalableDimension height = 6;
+}
+
+// Data for a single variant of a component set
+message ScalableUiVariant {
+  string id = 1;
+  string name = 2;
+  bool is_default = 3;
+  bool is_visible = 4;
+  Bounds bounds = 5;
+  float alpha = 6;
+  int32 layer = 7;
+}
+
+// A generic data structure for scalable ui to represent a component set or variant
+message ScalableUIData {
+  oneof data {
+    ScalableUIComponentSet set = 1;
+    ScalableUiVariant variant = 2;
+  }
+}

--- a/crates/dc_bundle/src/proto/definition/view/node_style.proto
+++ b/crates/dc_bundle/src/proto/definition/view/node_style.proto
@@ -20,6 +20,7 @@ import "definition/element/background.proto";
 import "definition/element/font.proto";
 import "definition/element/geometry.proto";
 import "definition/element/path.proto";
+import "definition/element/scalable.proto";
 import "definition/element/shader.proto";
 import "definition/element/variable.proto";
 import "definition/interaction/pointer.proto";
@@ -45,7 +46,7 @@ enum Display {
 
 // Contains all of the styleable parameters accepted by the Rect and Text
 // components.
-// Next id = 44
+// Next id = 45
 message NodeStyle {
   // Text properties
   element.Background text_color = 1;
@@ -80,7 +81,7 @@ message NodeStyle {
   repeated modifier.FilterOp filters = 21;
   repeated modifier.FilterOp backdrop_filters = 22;
   modifier.BlendMode blend_mode = 23;
-  
+
   // Layout properties
   Display display_type = 24;
   layout.FlexWrap flex_wrap = 25;
@@ -103,4 +104,6 @@ message NodeStyle {
   // Runtime shader from the shader plugin as background.
   // When shader is present, background will not be drawn.
   optional element.ShaderData shader_data = 43;
+
+  optional element.ScalableUIData scalable_data = 44;
 }

--- a/crates/dc_bundle/src/proto/definition/view/view.proto
+++ b/crates/dc_bundle/src/proto/definition/view/view.proto
@@ -46,8 +46,8 @@ message View {
   // unique numeric id (not replicated within one DesignCompose file), which is
   // used by the renderer when building a layout tree, or when mapping from an
   // integer to a View.
-  // IMPORTANT: This is a u16, but proto doesn't do short types. Convert back to 
-  // u16 after deserializing 
+  // IMPORTANT: This is a u16, but proto doesn't do short types. Convert back to
+  // u16 after deserializing
   uint32 unique_id = 1;
   // id doesn't exist in vsw toolkit, but is useful for tracing from Figma node
   // to output

--- a/crates/dc_jni/src/android_interface/convert_request.rs
+++ b/crates/dc_jni/src/android_interface/convert_request.rs
@@ -19,6 +19,7 @@ use dc_bundle::design_compose_definition::{
     DesignComposeDefinition, DesignComposeDefinitionHeader,
 };
 use dc_bundle::figma_doc::ServerFigmaDoc;
+use figma_import::HiddenNodePolicy;
 use figma_import::ImageContextSession;
 use figma_import::ProxyConfig;
 
@@ -57,6 +58,7 @@ pub fn fetch_doc(
                 .map(|imgref| (NodeQuery::name(imgref.node.clone()), imgref.images.clone()))
                 .collect(),
             &mut error_list,
+            HiddenNodePolicy::Skip, // skip hidden nodes
         )?;
 
         let variable_map = doc.build_variable_map();

--- a/crates/figma_import/src/lib.rs
+++ b/crates/figma_import/src/lib.rs
@@ -28,6 +28,7 @@ mod image_context;
 pub mod meter_schema;
 mod proxy_config;
 pub mod reaction_schema;
+pub mod scalableui_schema;
 pub mod shader_schema;
 
 pub mod tools;
@@ -39,6 +40,7 @@ pub use dc_bundle::design_compose_definition::DesignComposeDefinition;
 pub use dc_bundle::design_compose_definition::DesignComposeDefinitionHeader;
 pub use dc_bundle::geometry::Rectangle;
 pub use document::Document;
+pub use document::HiddenNodePolicy;
 pub use error::Error;
 pub use image_context::ImageContextSession;
 pub use proxy_config::ProxyConfig;

--- a/crates/figma_import/src/scalableui_schema.rs
+++ b/crates/figma_import/src/scalableui_schema.rs
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use dc_bundle::scalable;
+use dc_bundle::scalable::ScalableUIComponentSet;
+use serde::{Deserialize, Serialize};
+
+//
+// Schema data for component sets
+//
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct Event {
+    event_name: String,
+    event_tokens: String,
+    from_variant_id: String,
+    from_variant_name: String,
+    to_variant_id: String,
+    to_variant_name: String,
+}
+
+impl Into<scalable::Event> for &Event {
+    fn into(self) -> scalable::Event {
+        scalable::Event {
+            event_name: self.event_name.clone(),
+            event_tokens: self.event_tokens.clone(),
+            from_variant_id: self.from_variant_id.clone(),
+            from_variant_name: self.from_variant_name.clone(),
+            to_variant_id: self.to_variant_id.clone(),
+            to_variant_name: self.to_variant_name.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct Keyframe {
+    frame: i32,
+    variant_name: String,
+}
+
+impl Into<scalable::Keyframe> for &Keyframe {
+    fn into(self) -> scalable::Keyframe {
+        scalable::Keyframe {
+            frame: self.frame,
+            variant_name: self.variant_name.clone(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct KeyframeVariant {
+    name: String,
+    keyframes: Vec<Keyframe>,
+}
+
+impl Into<scalable::KeyframeVariant> for &KeyframeVariant {
+    fn into(self) -> scalable::KeyframeVariant {
+        scalable::KeyframeVariant {
+            name: self.name.clone(),
+            keyframes: self.keyframes.iter().map(|kf| kf.into()).collect(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ComponentSetDataJson {
+    id: String,
+    name: String,
+    role: String,
+    default_variant_id: String,
+    default_variant_name: String,
+    event_list: Vec<Event>,
+    keyframe_variants: Vec<KeyframeVariant>,
+}
+
+impl Into<ScalableUIComponentSet> for ComponentSetDataJson {
+    fn into(self) -> ScalableUIComponentSet {
+        ScalableUIComponentSet {
+            id: self.id,
+            name: self.name,
+            role: self.role,
+            default_variant_id: self.default_variant_id,
+            default_variant_name: self.default_variant_name,
+            events: self.event_list.iter().map(|e| e.into()).collect(),
+            keyframe_variants: self.keyframe_variants.iter().map(|kfv| kfv.into()).collect(),
+            variant_ids: vec![],
+            ..Default::default()
+        }
+    }
+}
+
+//
+// Schema data for variants
+//
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VariantDataJson {
+    id: String,
+    name: String,
+    is_default: bool,
+    layer: i32,
+}
+
+impl Into<scalable::ScalableUiVariant> for VariantDataJson {
+    fn into(self) -> scalable::ScalableUiVariant {
+        scalable::ScalableUiVariant {
+            id: self.id,
+            name: self.name,
+            is_default: self.is_default,
+            is_visible: true,
+            bounds: None.into(),
+            alpha: 1.0,
+            layer: self.layer,
+            ..Default::default()
+        }
+    }
+}
+
+//
+// ScalableUiDataJson represents the schema for any node that has scalable ui data
+//
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(untagged)]
+pub(crate) enum ScalableUiDataJson {
+    Set(ComponentSetDataJson),
+    Variant(VariantDataJson),
+}
+
+impl Into<scalable::ScalableUIData> for ScalableUiDataJson {
+    fn into(self) -> scalable::ScalableUIData {
+        scalable::ScalableUIData {
+            data: Some(match self {
+                ScalableUiDataJson::Set(set) => scalable::scalable_uidata::Data::Set(set.into()),
+                ScalableUiDataJson::Variant(var) => {
+                    scalable::scalable_uidata::Data::Variant(var.into())
+                }
+            }),
+            ..Default::default()
+        }
+    }
+}

--- a/crates/figma_import/src/tools/fetch_layout.rs
+++ b/crates/figma_import/src/tools/fetch_layout.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::HiddenNodePolicy;
 use crate::{proxy_config::ProxyConfig, Document};
 /// Utility program to fetch a doc and serialize it to file
 use clap::Parser;
@@ -247,6 +248,7 @@ pub fn fetch_layout(args: Args) -> Result<(), ConvertError> {
         &args.nodes.iter().map(|name| NodeQuery::name(name)).collect(),
         &Vec::new(),
         &mut error_list,
+        HiddenNodePolicy::Skip, // skip hidden nodes
     )?;
     for error in error_list {
         eprintln!("Warning: {error}");

--- a/crates/figma_import/tests/test_fetches.rs
+++ b/crates/figma_import/tests/test_fetches.rs
@@ -36,7 +36,7 @@ fn run_test(doc_id: &str, queries: &[&str]) {
     )
     .unwrap();
 
-    let dc_definition = build_definition(&mut doc, &queries).unwrap();
+    let dc_definition = build_definition(&mut doc, &queries, true).unwrap();
     let header = DesignComposeDefinitionHeader::current(
         "".to_string(),
         "testFetch".to_string(),

--- a/support-figma/extended-layout-plugin/manifest.json
+++ b/support-figma/extended-layout-plugin/manifest.json
@@ -6,6 +6,7 @@
   "ui": {
     "main": "dist/ui.html",
     "shader": "dist/shader.html",
+    "scalable": "dist/scalable.html",
     "cloudy_sky": "dist/data/shader/cloudy_sky.txt",
     "discrete_ocean": "dist/data/shader/discrete_ocean.txt",
     "fibonacci_sphere": "dist/data/shader/fibonacci_sphere.txt",
@@ -39,8 +40,9 @@
     {
       "name": "Clear All Shaders",
       "command": "shader-clear-all"
-    }
-
+    },
+    { "separator": true },
+    { "name": "ScalableUI", "command": "scalable" }
   ],
   "networkAccess": {
     "allowedDomains": [

--- a/support-figma/extended-layout-plugin/src/code.ts
+++ b/support-figma/extended-layout-plugin/src/code.ts
@@ -19,6 +19,7 @@ import * as Localization from "./localization-module";
 import * as DesignSpecs from "./design-spec-module";
 import * as ImageRes from "./image-res-module";
 import * as Shader from "./shader";
+import * as Scalable from "./scalable";
 
 // Warning component.
 interface ClippyWarningRun {
@@ -584,6 +585,33 @@ if (figma.command === "sync") {
   figma.on("selectionchange", Shader.onSelectionChanged);
 } else if (figma.command === "shader-clear-all") {
   Shader.clearAll();
+} else if (figma.command === "scalable") {
+  figma.showUI(__uiFiles__.scalable, { width: 600, height: 600 });
+  Scalable.onSelectionChanged();
+  figma.ui.onmessage = (msg) => {
+    if (msg.msg == "createEvent")
+      Scalable.createNewEvent(msg);
+    else if (msg.msg == "removeEvent")
+      Scalable.removeEvent(msg);
+    else if (msg.msg == "sendEvent")
+      Scalable.sendEvent(msg);
+    else if (msg.msg == "resetState")
+      Scalable.resetState(msg);
+    else if (msg.msg == "createKeyframeVariant")
+      Scalable.createKeyframeVariant(msg);
+    else if (msg.msg == "removeKeyframeVariant")
+      Scalable.removeKeyframeVariant(msg);
+    else if (msg.msg == "roleChanged")
+      Scalable.roleChanged(msg);
+    else if (msg.msg == "nodeChanged")
+      Scalable.nodeChanged(msg);
+    else if (msg.msg == "addNode")
+      Scalable.addNode();
+    else if (msg.msg == "removeNode")
+      Scalable.removeNode();
+  };
+  figma.on("selectionchange", Scalable.onSelectionChanged);
+  Scalable.onSelectionChanged();
 } else if (figma.command === "move-plugin-data") {
   function movePluginDataWithKey(node: BaseNode, key: string) {
     // Read the private plugin data, write to shared

--- a/support-figma/extended-layout-plugin/src/scalable.html
+++ b/support-figma/extended-layout-plugin/src/scalable.html
@@ -1,0 +1,664 @@
+<!--
+ Copyright 2025 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/thomas-lowry/figma-plugin-ds/dist/figma-plugin-ds.css" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+
+<div>
+    <div id="componentSetAddButton" class="page-padding-small">
+      <button id="addSetButton" class="button--primary" style="flex-grow: 1;" onclick="addSet();">Add ScalableUI Data</button>
+    </div>
+    <div id="componentSetRemoveButton" class="page-padding-small">
+      <button id="removeSetButton" class="button--primary" style="flex-grow: 1;" onclick="removeSet();">Remove ScalableUI Data</button>
+    </div>
+</div>
+
+<div id="componentSetSection" style="display: none">
+    <div class="page-padding-small">
+        <label class="boldlabel">COMPONENT SET:</label>
+        <label id="componentSetName" class="normallabel"></label>
+    </div>
+
+    <div id="roleSection" style="display: flex; align-items: center;">
+        <div class="page-padding-small">
+            <label class="boldlabel">ROLE:</label>
+        </div>
+        <input id="roleInput" type="text" style="height: 24" value="@my/role" onchange="onRoleChanged();"></input>
+    </div>
+
+    <div id="eventSection">
+        <div class="page-padding-small">
+            <label class="boldlabel">EVENTS:</label>
+        </div>
+        <div id="componentSetEventsSection" style="margin-left: 16"></div>
+        <div id="addEventSection" class="page-padding-small">
+            <button id="addEventButton" class="button--primary" style="flex-grow: 1;" onclick="addEventDialog();">Add event</button>
+        </div>
+    </div>
+
+    <div id="componentSetVariantsSection">
+        <div class="page-padding-small">
+            <label class="boldlabel">VARIANTS:</label>
+        </div>
+        <div id="componentSetVariantsList" class="page-padding-small" style="margin-top: -10">
+        </div>
+    </div>
+
+    <div id="componentSetKeyframeVariantsSection">
+        <div class="page-padding-small">
+            <label class="boldlabel">KEYFRAME VARIANTS:</label>
+        </div>
+        <div id="keyframeVariantsList" class="page-padding-small" style="margin-top: -10">
+        </div>
+    </div>
+
+    <div id="addKeyframeVariantSection" class="page-padding-small">
+        <button id="addKeyframeButton" class="button--primary" style="flex-grow: 1;" onclick="addKeyframeDialog();">Add Keyframe Variant</button>
+    </div>
+</div>
+
+<div id="invalidNodeSection" style="display: block; justify-content: center; align-items: center; text-align: center; width: 100%; height: 100%">
+    Invalid Node Selected.<br>
+    Please select a COMPONENT SET
+</div>
+
+<div id="stageSection">
+    <div class="page-padding-small">
+        <label class="boldlabel">Simulate an event:</label><br>
+        <select id="sendEventSelect" style="margin-top: 8"></select><br>
+        <select id="sendTokensSelect" style="margin-top: 8"></select><br>
+        <button id="sendEventButton" class="button--primary" style="flex-grow: 1; margin-top: 8" onclick="sendEvent();">Send Event</button>
+    </div>
+    <div class="page-padding-large" style="display: flex; justify-content: center; width: 100%">
+        <button id="resetStateButton" class="button--primary" onclick="resetState();">Reset State</button>
+    </div>
+</div>
+
+<dialog id="createEventDialog">
+    <p>
+        <div style="display: flex; gap: 8px;">
+            <label for="createEventNameInput" style="flex-grow: 1;">On Event:</label>
+            <input id="createEventNameInput" type="text" autofocus></input>
+        </div>
+        <div style="display: flex; gap: 8px; margin-top: 10">
+            <label for="createEventTokenInput" style="flex-grow: 1;">Event Tokens:</label>
+            <input id="createEventTokenInput" type="text"></input>
+        </div>
+        <div style="display: flex; gap: 8px; margin-top: 10">
+            <label for="createEventFromVariant" style="flex-grow: 1;">From Variant:</label>
+            <select id="createEventFromVariant"></select>
+        </div>
+        <div style="display: flex; gap: 8px; margin-top: 10">
+            <label for="createEventToVariant" style="flex-grow: 1;">To Variant:</label>
+            <select id="createEventToVariant"></select>
+        </div>
+    </p>
+    <div style="display: flex; gap: 4px;">
+        <button class="button--primary" onclick="createNewEvent();">Create</button>
+        <button class="button--primary" onclick="createEventDialog.close()">Cancel</button>
+    </div>
+</dialog>
+
+<dialog id="createKeyframeDialog">
+    <p>
+        <div style="display: flex; gap: 8px;">
+            <label for="keyframeName" style="flex-grow: 1;">Name:</label>
+            <input id="keyframeName" type="text" autofocus></input>
+        </div>
+        <div id="keyframeList"></div>
+    </p>
+    <div style="display: flex; gap: 8px; align-items: center; margin-top: 6">
+        <span class="icon-button" onclick="createKeyframe()">
+            <span class="icon icon--plus"></span>
+        </span>
+        <span>Add Keyframe</span>
+    </div>
+    <div style="display: flex; gap: 4px; margin-top: 10">
+        <button class="button--primary" onclick="createNewKeyframe();">Create</button>
+        <button class="button--primary" onclick="createKeyframeDialog.close()">Cancel</button>
+    </div>
+</dialog>
+
+<script>
+    function addEventDialog() {
+        createEventDialog.showModal();
+    }
+
+    function createNewEvent() {
+        const eventName = createEventNameInput.value;
+        const eventTokens = createEventTokenInput.value;
+        const fromVariantId = createEventFromVariant.value;
+        const fromVariantName = createEventFromVariant.options[createEventFromVariant.selectedIndex].text;
+        const toVariantId = createEventToVariant.value;
+        const toVariantName = createEventToVariant.options[createEventToVariant.selectedIndex].text;
+        createEventDialog.close();
+
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'createEvent',
+                event: eventName,
+                eventTokens: eventTokens,
+                fromVariantId: fromVariantId,
+                fromVariantName: fromVariantName,
+                toVariantId: toVariantId,
+                toVariantName: toVariantName,
+            }
+        }, '*');
+    }
+
+    function addKeyframeDialog() {
+        while (keyframeList.firstChild) {
+            keyframeList.removeChild(keyframeList.lastChild);
+        }
+
+        createKeyframeDialog.showModal();
+    }
+
+    function createKeyframe() {
+        const keyframeSection = document.createElement("div");
+        keyframeSection.style.border = "1px solid black";
+        keyframeSection.style.marginTop = 6;
+        keyframeSection.style.padding = 6;
+
+        const frameNumSection = document.createElement("div");
+        frameNumSection.style.display = "flex";
+        frameNumSection.style.gap = "8px";
+        frameNumSection.marginTop = 6;
+        
+        const frameLabel = document.createElement("label");
+        frameLabel.classList.add("normallabel");
+        frameLabel.style.flexGrow = 1;
+        frameLabel.textContent = "Frame:";
+        frameNumSection.appendChild(frameLabel);
+
+        const textInput = document.createElement("input");
+        textInput.id = "keyframeFrameInput" + keyframeList.childElementCount;
+        textInput.type = "number";
+        textInput.placeholder = "0";
+        textInput.min = "0";
+        textInput.max = "100";
+        frameNumSection.appendChild(textInput);
+        keyframeSection.appendChild(frameNumSection);
+
+        const variantSection = document.createElement("div");
+        variantSection.style.display = "flex";
+        variantSection.style.gap = "8px";
+        variantSection.style.marginTop = 6;
+        variantSection.marginTop = 6;
+
+        const varLabel = document.createElement("label");
+        varLabel.classList.add("normallabel");
+        varLabel.style.flexGrow = 1;
+        varLabel.textContent = "Variant:";
+        variantSection.appendChild(varLabel);
+
+        const varSelect = document.createElement("select");
+        varSelect.id = "keyframeVariantSelect" + keyframeList.childElementCount;
+        addVariantsToSelect(varSelect);
+        variantSection.appendChild(varSelect);
+        keyframeSection.appendChild(variantSection);
+        keyframeList.appendChild(keyframeSection);
+    }
+
+    function sendEvent() {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'sendEvent',
+                event: sendEventSelect.value,
+            }
+        }, '*');
+    }
+
+    function resetState() {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'resetState',
+            }
+        }, '*');
+    }
+
+    function addVariantsToSelect(select) {
+        const allLabels = document.querySelectorAll('label');
+        const variantLabels = Array.from(allLabels).filter(label => {
+            return label.textContent == "VARIANT: "
+        });
+
+        for (const vl of variantLabels) {
+            const id = vl.id;
+            const name = document.getElementById(id + "-name").textContent;
+
+            const variantOption = document.createElement("option");
+            variantOption.text = name;
+            variantOption.value = id;
+            select.appendChild(variantOption);
+        }
+    }
+
+    function createNewKeyframe() {
+        const name = keyframeName.value;
+        let keyframes = [];
+        for (let i = 0; i < keyframeList.childElementCount; ++i) {
+            const keyframeInputId = "keyframeFrameInput" + i;
+            const keyframeInput = document.getElementById(keyframeInputId);
+            const frameValue = toNumber(keyframeInput.value, 0);
+
+            const keyframeSelectId = "keyframeVariantSelect" + i;
+            const keyframeSelect = document.getElementById(keyframeSelectId);
+            const selectValue = keyframeSelect.options[keyframeSelect.selectedIndex].text;
+
+            keyframes.push({
+                frame: frameValue,
+                variant: selectValue,
+            });
+        }
+
+        createKeyframeDialog.close();
+
+        if (keyframes.length > 0) {
+            parent.postMessage({
+                pluginMessage: {
+                    msg: 'createKeyframeVariant',
+                    name: name,
+                    keyframes: keyframes,
+                }
+            }, '*');
+        }
+    }
+
+    function onRoleChanged() {
+        const roleName = roleInput.value;
+
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'roleChanged',
+                role: roleName,
+            }
+        }, '*');
+    }
+
+    function toNumber(str, def) {
+        let num = parseInt(str, 10);
+        if (isNaN(num)) {
+            return def;
+        }
+        return num;
+    }
+
+    function addSet() {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'addNode',
+            }
+        }, '*');
+    }
+
+    function removeSet() {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'removeNode',
+            }
+        }, '*');
+    }
+    
+    function onRemoveEvent(name) {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'removeEvent',
+                event: name,
+            }
+        }, '*');
+    }
+
+    function onRemoveKeyframeVariant(name) {
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'removeKeyframeVariant',
+                keyframeVariant: name,
+            }
+        }, '*');
+    }
+
+    function onDefaultChecked(checkbox) {
+        const checkedDefaults = document.querySelectorAll('input[type="checkbox"][class="defaultCheckbox"]:checked');
+        for (const cb of checkedDefaults) {
+            if (cb != checkbox)
+                cb.checked = false;
+        }
+        onVariantChanged();
+    }
+
+    function onVariantChanged() {
+        const allLabels = document.querySelectorAll('label');
+        const variantLabels = Array.from(allLabels).filter(label => {
+            return label.textContent == "VARIANT: "
+        });
+
+        const variantList = [];
+        for (const vl of variantLabels) {
+            const id = vl.id;
+            const name = document.getElementById(id + "-name").textContent;
+            const isDefault = document.getElementById(id + "-default").checked;
+            const layer = document.getElementById(id + "-layer").value;
+            variantList.push({
+                isDefault,
+                id,
+                name,
+                layer: toNumber(layer),
+            });
+        }
+
+        parent.postMessage({
+            pluginMessage: {
+                msg: 'nodeChanged',
+                variantList: variantList,
+            }
+        }, '*');
+    }
+
+    function selectComponentSet(name, type, setData, variantList) {
+        invalidNodeSection.style.display = "none";
+        stageSection.style.display = "none";
+
+        const hasData = setData != null;
+        componentSetAddButton.style.display = hasData ? "none" : "block";
+        componentSetRemoveButton.style.display = hasData ? "block" : "none";
+        componentSetSection.style.display = hasData ? "block" : "none";
+
+        if (!hasData)
+            return;
+
+        if (setData.role)
+            roleInput.value = setData.role;
+        else
+            roleInput.value = "";
+
+        while (componentSetEventsSection.firstChild) {
+            componentSetEventsSection.removeChild(componentSetEventsSection.lastChild);
+        }
+        if (setData.eventList) {
+            for (const event of setData.eventList)
+                addEvent(event);
+        }
+
+        while (componentSetVariantsList.firstChild) {
+          componentSetVariantsList.removeChild(componentSetVariantsList.lastChild);
+        }
+        while (createEventFromVariant.firstChild) {
+            createEventFromVariant.removeChild(createEventFromVariant.lastChild);
+        }
+        while (createEventToVariant.firstChild) {
+            createEventToVariant.removeChild(createEventToVariant.lastChild);
+        }
+
+        // Add empty default option for FROM variant
+        const variantOptionFromEmpty = document.createElement("option");
+        variantOptionFromEmpty.text = "";
+        variantOptionFromEmpty.value = "";
+        createEventFromVariant.appendChild(variantOptionFromEmpty);
+
+        // Add variants to select dropdown for event dialog and to main UI
+        componentSetName.textContent = name;
+        for (let child of variantList) {
+            addVariantToEventSelect(child.name, child.id);
+            addVariantSection(child.name, child);
+        }
+
+        // Add keyframe variants to select dropdown for event dialog
+        for (const kfv of setData.keyframeVariants) {
+            addVariantToEventSelect(kfv.name, kfv.name);
+        }
+
+        addKeyframeVariants(setData.keyframeVariants);
+    }
+
+    function addEvent(event) {
+        const name = event.eventName;
+        const eventTokens = event.eventTokens;
+        const fromVariantName = event.fromVariantName;
+        const toVariantName = event.toVariantName;
+        const hasFromVariant = fromVariantName != null && fromVariantName.length > 0;
+        const eventDiv = document.createElement("div");
+
+        const eventLabel = document.createElement("label");
+        eventLabel.classList.add("normallabel");
+        eventLabel.textContent = name;
+        eventDiv.appendChild(eventLabel);
+
+        if (eventTokens != null && eventTokens.length > 0) {
+            const tokensLabel = document.createElement("label");
+            tokensLabel.classList.add("normallabel");
+            tokensLabel.textContent = ", " + eventTokens;
+            eventDiv.appendChild(tokensLabel);
+        }
+
+        const arrowLabel = document.createElement("label");
+        arrowLabel.classList.add("boldlabel");
+        arrowLabel.textContent = "  ->  ";
+        eventDiv.appendChild(arrowLabel);
+
+        const variantLabel = document.createElement("label");
+        variantLabel.classList.add("normallabel");
+        if (hasFromVariant) {
+            variantLabel.textContent = "(" + fromVariantName + " -> " + toVariantName + ")";
+        } else {
+            variantLabel.textContent = toVariantName;
+        }
+        eventDiv.appendChild(variantLabel);
+
+        const removeButton = document.createElement("button");
+        removeButton.classList.add("button--secondary");
+        removeButton.style.flexGrow = 1;
+        removeButton.style.marginLeft = 10;
+        removeButton.onclick = () => { onRemoveEvent(name); }
+        removeButton.textContent = "Remove Event";
+        eventDiv.appendChild(removeButton);
+
+        componentSetEventsSection.appendChild(eventDiv);
+    }
+
+    function addVariantToEventSelect(name, id) {
+        const variantOptionFrom = document.createElement("option");
+        variantOptionFrom.text = name;
+        variantOptionFrom.value = id;
+        createEventFromVariant.appendChild(variantOptionFrom);
+        const variantOptionTo = document.createElement("option");
+        variantOptionTo.text = name;
+        variantOptionTo.value = id;
+        createEventToVariant.appendChild(variantOptionTo);
+    }
+
+    function addVariantSection(name, variantData) {
+        const id = variantData.id;
+        const sectionDiv = document.createElement("div");
+        sectionDiv.classList.add("page-padding-small");
+
+        // Variant name section
+        const nameSection = document.createElement("div");
+        const nodeTypeLabel = document.createElement("label");
+        nodeTypeLabel.classList.add("boldlabel");
+        nodeTypeLabel.textContent = "VARIANT: ";
+        nodeTypeLabel.id = id;
+        const nodeTypeName = document.createElement("label");
+        nodeTypeName.classList.add("normallabel");
+        nodeTypeName.textContent = name;
+        nodeTypeName.id = id + "-name";
+        nameSection.appendChild(nodeTypeLabel);
+        nameSection.appendChild(nodeTypeName);
+        sectionDiv.appendChild(nameSection);
+
+        // Default option
+        const defaultSection = document.createElement("div");
+        defaultSection.style.display = "flex";
+        defaultSection.style.alignItems = "center";
+        const defaultLabel = document.createElement("label");
+        defaultLabel.classList.add("boldlabel");
+        defaultLabel.textContent = "Default:";
+        defaultSection.appendChild(defaultLabel);
+        const defaultCheckbox = document.createElement("input");
+        defaultCheckbox.id = id + "-default";
+        defaultCheckbox.classList.add("defaultCheckbox");
+        defaultCheckbox.type = "checkbox";
+        defaultCheckbox.onclick = () => { onDefaultChecked(defaultCheckbox); }
+        defaultCheckbox.checked = variantData?.isDefault;
+        defaultSection.appendChild(defaultCheckbox);
+        sectionDiv.appendChild(defaultSection);
+        
+        // Layer override option
+        const layerSection = document.createElement("layer");
+        layerSection.style.display = "flex";
+        layerSection.style.alignItems = "center";
+        const layerLabel = document.createElement("label");
+        layerLabel.classList.add("boldlabel");
+        layerLabel.textContent = "Layer:";
+        layerSection.appendChild(layerLabel);
+        const layerInput = document.createElement("input");
+        layerInput.id = id + "-layer";
+        layerInput.style.marginLeft = "10";
+        layerInput.style.width = "50";
+        layerInput.type = "number";
+        layerInput.defaultValue = 0;
+        layerInput.placeholder = 0;
+        if (variantData?.layer != null)
+            layerInput.value = variantData.layer;
+        layerInput.oninput = () => { onVariantChanged(); }
+        layerSection.appendChild(layerInput);
+        sectionDiv.appendChild(layerSection);
+
+
+        componentSetVariantsList.appendChild(sectionDiv);
+    }
+
+    function addKeyframeVariants(keyframeVariantList) {
+        while (keyframeVariantsList.firstChild) {
+            keyframeVariantsList.removeChild(keyframeVariantsList.lastChild);
+        }
+
+        for (const kfv of keyframeVariantList) {
+            addKeyframeVariant(kfv);
+        }
+    }
+
+    function addKeyframeVariant(kfv) {
+        const sectionDiv = document.createElement("div");
+        sectionDiv.classList.add("page-padding-small");
+
+        // Keyframe name section
+        const nameSection = document.createElement("div");
+        const nodeTypeLabel = document.createElement("label");
+        nodeTypeLabel.classList.add("boldlabel");
+        nodeTypeLabel.textContent = "Keyframe Variant: ";
+        const nodeTypeName = document.createElement("label");
+        nodeTypeName.classList.add("normallabel");
+        nodeTypeName.textContent = kfv.name;
+        nameSection.appendChild(nodeTypeLabel);
+        nameSection.appendChild(nodeTypeName);
+
+        const removeButton = document.createElement("button");
+        removeButton.classList.add("button--secondary");
+        removeButton.style.flexGrow = 1;
+        removeButton.style.marginLeft = 10;
+        removeButton.onclick = () => { onRemoveKeyframeVariant(kfv.name); }
+        removeButton.textContent = "Remove Keyframe Variant";
+        nameSection.appendChild(removeButton);
+
+        sectionDiv.appendChild(nameSection);
+        keyframeVariantsList.appendChild(sectionDiv);
+
+        for (const kf of kfv.keyframes) {
+            addKeyframe(kf, sectionDiv);
+        }
+    }
+
+    function addKeyframe(kf, parentSection) {
+        const sectionDiv = document.createElement("div");
+        sectionDiv.style.marginLeft = 10;
+        const keyframeSection = document.createElement("div");
+
+        const keyframeLabel = document.createElement("label");
+        keyframeLabel.classList.add("normallabel");
+        keyframeLabel.textContent = "Keyframe ";
+        keyframeSection.appendChild(keyframeLabel);
+
+        const frameNumber = document.createElement("label");
+        frameNumber.classList.add("normallabel");
+        frameNumber.textContent = kf.frame;
+        keyframeSection.appendChild(frameNumber);
+
+        const arrowLabel = document.createElement("label");
+        arrowLabel.classList.add("boldlabel");
+        arrowLabel.textContent = "  ->  ";
+        keyframeSection.appendChild(arrowLabel);
+
+        const variantName = document.createElement("label");
+        variantName.classList.add("normallabel");
+        variantName.textContent = kf.variantName;
+        keyframeSection.appendChild(variantName);
+
+        sectionDiv.appendChild(keyframeSection);
+        parentSection.appendChild(sectionDiv);
+    }
+
+    function selectStage(eventList, tokenList) {
+        invalidNodeSection.style.display = "none";
+        componentSetAddButton.style.display = "none";
+        componentSetRemoveButton.style.display = "none";
+        componentSetSection.style.display = "none";
+        stageSection.style.display = "block";
+
+        while (sendEventSelect.firstChild) {
+            sendEventSelect.removeChild(sendEventSelect.lastChild);
+        }
+        for (const event of eventList) {
+            const eventOption = document.createElement("option");
+            eventOption.text = event;
+            eventOption.value = event;
+            sendEventSelect.appendChild(eventOption);
+        }
+
+        while (sendTokensSelect.firstChild) {
+            sendTokensSelect.removeChild(sendTokensSelect.lastChild);
+        }
+        for (const token of tokenList) {
+            const tokenOption = document.createElement("option");
+            tokenOption.text = token;
+            tokenOption.value = token;
+            sendTokensSelect.appendChild(tokenOption);
+        }
+    }
+
+    function deselectComponent() {
+        componentSetSection.style.display = "none";
+        componentSetAddButton.style.display = "none";
+        componentSetRemoveButton.style.display = "none";
+        invalidNodeSection.style.display = "flex";
+        stageSection.style.display = "none";
+    }
+
+    window.onmessage = async function (event) {
+        let msg = event.data.pluginMessage;
+        if (msg.msg == "scalable-select-component-set") {
+            selectComponentSet(msg.nodeName, msg.nodeType, msg.setData, msg.variantList);
+        } else if (msg.msg == "scalable-select-stage") {
+            selectStage(msg.eventList, msg.tokenList);
+        } else if (msg.msg == "scalable-deselect") {
+            deselectComponent();
+        } else {
+            console.log("Unknown message: " + msg.msg);
+        }
+    }
+</script>

--- a/support-figma/extended-layout-plugin/src/scalable.ts
+++ b/support-figma/extended-layout-plugin/src/scalable.ts
@@ -1,0 +1,565 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Utils from "./utils";
+
+/*
+const SHADER_PLUGIN_DATA_KEY = "shader";
+const SHADER_FALLBACK_COLOR_PLUGIN_DATA_KEY = "shaderFallbackColor";
+const SHADER_UNIFORMS_PLUGIN_DATA_KEY = "shaderUniforms";
+// Private plugin data, used for clearing shader functionalities
+const SHADER_IMAGE_HASH = "shaderImageHash";
+*/
+
+const SCALABLE_PLUGIN_DATA_KEY = "scalableui";
+
+interface VariantData {
+  id: string,
+  name: string,
+  isDefault: boolean,
+  layer: number,
+}
+
+interface Event {
+  eventName: string,
+  eventTokens: string,
+  fromVariantId: string,
+  fromVariantName: string,
+  toVariantId: string,
+  toVariantName: string,
+}
+
+interface Keyframe {
+  frame: number,
+  variantName: string,
+}
+
+interface KeyframeVariant {
+  name: string,
+  keyframes: Keyframe[],
+}
+
+interface ComponentSetData {
+  id: string,
+  name: string,
+  role: string,
+  defaultVariantId: string,
+  defaultVariantName: string,
+  eventList: Event[],
+  keyframeVariants: KeyframeVariant[],
+}
+
+function newComponentSetData(id: string, name: string) {
+  return {
+    id: id,
+    name: name,
+    role: "",
+    defaultVariantId: "",
+    defaultVariantName: "",
+    eventList: [],
+    keyframeVariants: [],
+  } as ComponentSetData;
+}
+
+export async function onSelectionChanged() {
+  let selection = figma.currentPage.selection;
+
+  if (!selection || selection.length != 1 || !selection[0]) {
+    deselectNode();
+    return;
+  }
+
+  let node = selection[0];
+  if (node.type == "COMPONENT_SET") {
+    sendComponentSetData(node);
+  } else {
+    let eventSet: Set<string> = new Set();
+    let tokenSet: Set<string> = new Set();
+    await getAllEvents(node, eventSet, tokenSet);
+    if (eventSet.size > 0) {
+      sendStageData(eventSet, tokenSet);
+    } else {
+      deselectNode();
+    }
+  }
+}
+
+async function sendStageData(eventSet: Set<string>, tokenSet: Set<string>) {
+  const eventList = Array.from(eventSet);
+  const tokenList = Array.from(tokenSet).sort();
+  figma.ui.postMessage({
+    msg: "scalable-select-stage",
+    eventList: eventList,
+    tokenList: tokenList,
+  });
+}
+
+async function getAllEvents(node: SceneNode, eventSet: Set<string>, tokenSet: Set<String>) {
+  if (node.type == "INSTANCE") {
+    const instanceNode = node as InstanceNode;
+    const setData = await getComponentSetDataFromInstance(instanceNode);
+    if (setData != null && setData.eventList != null) {
+      for (const event of setData.eventList) {
+        eventSet.add(event.eventName);
+        tokenSet.add(event.eventTokens);
+      }
+    }
+  }
+
+  const parentNode = node as ChildrenMixin;
+  if (parentNode != null && parentNode.children != null) {
+    for (const child of parentNode.children)
+      await getAllEvents(child, eventSet, tokenSet);
+  }
+}
+
+async function getComponentSetDataFromInstance(node: InstanceNode) {
+  const mainComponent = await node.getMainComponentAsync();
+  const componentSet = mainComponent?.parent;
+
+  if (componentSet != null) {
+    const scalableData = componentSet.getSharedPluginData(
+      Utils.SHARED_PLUGIN_NAMESPACE,
+      SCALABLE_PLUGIN_DATA_KEY
+    );
+    let setData: ComponentSetData | null = null;
+    if (scalableData) {
+      setData = JSON.parse(scalableData) as ComponentSetData;
+      return setData;
+    }
+  }
+  return null;
+}
+
+function sendComponentSetData(node: ComponentSetNode) {
+  const setData = loadComponentSetData(node);
+  const variantList = [];
+  for (let child of node.children) {
+    const variantData = loadVariantData(child);
+    variantList.push(variantData);
+  }
+
+  figma.ui.postMessage({
+    msg: "scalable-select-component-set",
+    nodeName: node.name,
+    nodeType: node.type,
+    nodeId: node.id,
+    variantList: variantList,
+    setData: setData,
+  });
+}
+
+export async function createNewEvent(msg: any) {
+  const node = figma.currentPage.selection[0] as ComponentSetNode;
+  let setData = loadComponentSetData(node);
+  if (!setData)
+    setData = newComponentSetData(node.id, node.name);
+  const event = {
+    eventName: msg.event,
+    eventTokens: msg.eventTokens,
+    fromVariantId: msg.fromVariantId,
+    fromVariantName: msg.fromVariantName,
+    toVariantId: msg.toVariantId,
+    toVariantName: msg.toVariantName,
+  } as Event;
+  setData.eventList.push(event);
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+export function removeEvent(msg: any) {
+  const node = figma.currentPage.selection[0] as ComponentSetNode;
+  let setData = loadComponentSetData(node);
+  if (setData != null)
+    setData.eventList = setData.eventList.filter(event => event.eventName !== msg.event);
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+export function sendEvent(msg: any) {
+  simulateEvent(figma.currentPage.selection[0], msg.event);
+  //testAnim();
+}
+
+interface Bounds {
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+}
+
+interface AnimData {
+  bounds: Bounds,
+  visible: boolean,
+  alpha: number,
+}
+
+async function testAnim() {
+  const mapFromInstance = await figma.getNodeByIdAsync("223:42");
+  const mapToComponent = await figma.getNodeByIdAsync("218:71");
+
+  if (mapFromInstance != null && mapToComponent != null) {
+    const fromInstance = mapFromInstance as InstanceNode;
+    const fromComponent = await fromInstance.getMainComponentAsync() as ComponentNode;
+    const toComponent = mapToComponent as ComponentNode;
+    const fromChild = fromComponent.findChild((child: SceneNode) => child.name == "main") as FrameNode;
+    const toChild = toComponent.findChild((child: SceneNode) => child.name == "main") as FrameNode;
+    if (fromChild != null && toChild != null) {
+      startAnim(fromChild, toChild, fromInstance, toComponent);
+    }
+  }
+}
+
+function startAnim(fromChild: FrameNode, toChild: FrameNode, fromInstance: InstanceNode, toComponent: ComponentNode) {
+  const fromBounds = {
+    left: fromChild.x,
+    top: fromChild.y,
+    width: Math.max(fromChild.width, 0.01), // Figma width/height must be at least 0.01
+    height: Math.max(fromChild.height, 0.01),
+  } as Bounds;
+  const fromAnimData = {
+    bounds: fromBounds,
+    visible: fromChild.visible,
+    alpha: fromChild.opacity,
+  }
+  const toBounds = {
+    left: toChild.x,
+    top: toChild.y,
+    width: Math.max(toChild.width, 0.01),
+    height: Math.max(toChild.height, 0.01),
+  } as Bounds;
+  const toAnimData = {
+    bounds: toBounds,
+    visible: toChild.visible,
+    alpha: toChild.opacity,
+  }
+
+  const duration = 500;
+  let startTime = Date.now();
+  let index = 0;
+  let intervalId = setInterval(() => {
+    const timeNow = Date.now();
+    ++index;
+    const linearProgress = (timeNow - startTime) / duration;
+    const value = easeOutCubic(linearProgress);
+    animateFrame(fromChild, fromAnimData, toAnimData, value);
+    if (timeNow > startTime + duration) {
+      clearInterval(intervalId);
+      endAnim(fromChild, fromAnimData, fromInstance, toComponent)
+    }
+  });
+  //endAnim(fromChild, fromAnimData, fromInstance, toComponent);
+}
+
+function endAnim(node: FrameNode, fromAnimData: AnimData, fromInstance: InstanceNode, toComponent: ComponentNode) {
+  // Set the instance to the new component
+  fromInstance.mainComponent = toComponent;
+
+  // Undo changes to the component
+  const width = Math.max(fromAnimData.bounds.width, 0.01);
+  const height = Math.max(fromAnimData.bounds.height, 0.01);
+  node.resize(width, height);
+  node.x = fromAnimData.bounds.left;
+  node.y = fromAnimData.bounds.top;
+
+  node.visible = fromAnimData.visible;
+  node.opacity = fromAnimData.alpha;
+}
+
+function easeOutCubic(x: number): number {
+  return 1 - Math.pow(1 - x, 3);
+}
+
+function animateFrame(node: FrameNode, from: AnimData, to: AnimData, value: number) {
+  const left = to.bounds.left * value + from.bounds.left * (1 - value);
+  const top = to.bounds.top * value + from.bounds.top * (1 - value);
+  const width = Math.max(to.bounds.width * value + from.bounds.width * (1 - value), 0.01);
+  const height = Math.max(to.bounds.height * value + from.bounds.height * (1 - value), 0.01);
+  node.resize(width, height);
+  node.x = left;
+  node.y = top;
+
+  const visible = to.visible;
+  const alpha = Math.max(Math.min(to.alpha * value + from.alpha * (1 - value), 0), 1);
+  node.visible = visible;
+  node.opacity = alpha;
+}
+
+async function simulateEvent(node: SceneNode, eventName: string) {
+  if (node.type == "INSTANCE") {
+    const instanceNode = node as InstanceNode;
+    const setData = await getComponentSetDataFromInstance(instanceNode);
+    if (setData != null && setData.eventList != null) {
+      for (const event of setData.eventList) {
+        if (event.eventName == eventName) {
+          const toNode = await figma.getNodeByIdAsync(event.toVariantId);
+
+          if (instanceNode != null && toNode != null) {
+            const fromComponent = await instanceNode.getMainComponentAsync() as ComponentNode;
+            const toComponent = toNode as ComponentNode;
+            const fromChild = fromComponent.findChild((child: SceneNode) => child.name == "main") as FrameNode;
+            const toChild = toComponent.findChild((child: SceneNode) => child.name == "main") as FrameNode;
+            if (fromChild != null && toChild != null) {
+              startAnim(fromChild, toChild, instanceNode, toComponent);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const parentNode = node as ChildrenMixin;
+  if (parentNode != null && parentNode.children != null) {
+    for (const child of parentNode.children)
+      await simulateEvent(child, eventName);
+  }
+}
+
+export function resetState(msg: any) {
+  resetInstance(figma.currentPage.selection[0]);
+}
+
+async function resetInstance(node: SceneNode) {
+  if (node.type == "INSTANCE") {
+    const instanceNode = node as InstanceNode;
+    const setData = await getComponentSetDataFromInstance(instanceNode);
+    if (setData != null && setData.defaultVariantId != null) {
+      const toNode = await figma.getNodeByIdAsync(setData.defaultVariantId);
+      if (toNode?.type == "COMPONENT") {
+        instanceNode.mainComponent = toNode;
+      }
+    }
+  }
+
+  const parentNode = node as ChildrenMixin;
+  if (parentNode != null && parentNode.children != null) {
+    for (const child of parentNode.children)
+      await resetInstance(child);
+  }
+}
+
+export function createKeyframeVariant(msg: any) {
+  const node = figma.currentPage.selection[0] as ComponentSetNode;
+  let setData = loadComponentSetData(node);
+  if (!setData)
+    setData = newComponentSetData(node.id, node.name);
+
+  const keyframes = [];
+  for (let i = 0; i < msg.keyframes.length; ++i) {
+    const kf = msg.keyframes[i];
+    keyframes.push({
+        frame: kf.frame,
+        variantName: kf.variant
+      } as Keyframe
+    );
+  }
+
+  const keyframeVariant = {
+    name: msg.name,
+    keyframes: keyframes
+  } as KeyframeVariant;
+
+  setData.keyframeVariants.push(keyframeVariant);
+
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+export function removeKeyframeVariant(msg: any) {
+  const node = figma.currentPage.selection[0] as ComponentSetNode;
+  let setData = loadComponentSetData(node);
+  if (setData != null)
+    setData.keyframeVariants = setData.keyframeVariants.filter(kfv => kfv.name != msg.keyframeVariant);
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+export function roleChanged(msg: any) {
+  const node = figma.currentPage.selection[0] as ComponentSetNode;
+  let setData = loadComponentSetData(node);
+  if (setData != null)
+    setData.role = msg.role;
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+export function addNode() {
+  let node = figma.currentPage.selection[0] as ComponentSetNode;
+  const setData = newComponentSetData(node.id, node.name);
+
+  let first = true;
+  for (const child of node.children) {
+    const variantData = newVariantData(child.id, child.name, first);
+    if (first) {
+      setData.defaultVariantId = child.id;
+      setData.defaultVariantName = child.name;
+    }
+    first = false;
+    child.setSharedPluginData(
+      Utils.SHARED_PLUGIN_NAMESPACE,
+      SCALABLE_PLUGIN_DATA_KEY,
+      JSON.stringify(variantData)
+    );
+  }
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY,
+    JSON.stringify(setData)
+  );
+  sendComponentSetData(node);
+}
+
+function newVariantData(id: string, name: string, isDefault: boolean) {
+  return {
+    id: id,
+    name: name,
+    isDefault: isDefault,
+    layer: 0,
+  } as VariantData;
+}
+
+export function removeNode() {
+  const node = figma.currentPage.selection[0];
+  node.setSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY, ""
+  );
+
+  const setNode = node as ComponentSetNode;
+  if (setNode != null) {
+    for (const child of setNode.children) {
+      child.setSharedPluginData(
+        Utils.SHARED_PLUGIN_NAMESPACE,
+        SCALABLE_PLUGIN_DATA_KEY, ""
+      );
+    }
+  }
+
+  sendComponentSetData(node as ComponentSetNode);
+}
+
+function replaceNum(key: string, value: any) {
+  if (key == "value") {
+    return parseFloat(value);
+  }
+  return value;
+}
+
+export async function nodeChanged(msg: any) {
+  const variantMap = hashToVariantMap(msg.variantList);
+  for (let [id, variant] of variantMap) {
+    if (variant.isDefault) {
+      const setNode = figma.currentPage.selection[0] as ComponentSetNode;
+      let setData = loadComponentSetData(setNode);
+      if (setData != null) {
+        setData.defaultVariantId = id;
+        setData.defaultVariantName = variant.name;
+      }
+      setNode.setSharedPluginData(
+        Utils.SHARED_PLUGIN_NAMESPACE,
+        SCALABLE_PLUGIN_DATA_KEY,
+        JSON.stringify(setData)
+      );
+    }
+    Utils.dcLog("Saving to " + id + ": " + JSON.stringify(variant, replaceNum));
+    let node = await figma.getNodeByIdAsync(id) as BaseNode;
+    node.setSharedPluginData(
+      Utils.SHARED_PLUGIN_NAMESPACE,
+      SCALABLE_PLUGIN_DATA_KEY,
+      JSON.stringify(variant, replaceNum)
+    );
+  }
+}
+
+function loadComponentSetData(node: ComponentSetNode) {
+  let componentSetDataStr = node.getSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY
+  );
+  let setData: ComponentSetData | null = null;
+  if (componentSetDataStr)
+    setData = JSON.parse(componentSetDataStr) as ComponentSetData;
+  Utils.dcLog("Loaded set: " + componentSetDataStr);
+  if (setData != null) {
+    setData.id = node.id;
+    setData.name = node.name;
+    if (setData.eventList == null)
+      setData.eventList = [];
+    if (setData.keyframeVariants == null)
+      setData.keyframeVariants = [];
+  }
+  return setData;
+}
+
+function loadVariantData(node: SceneNode) {
+  // Try to load existing data on this node
+  let variantDataStr = node.getSharedPluginData(
+    Utils.SHARED_PLUGIN_NAMESPACE,
+    SCALABLE_PLUGIN_DATA_KEY
+  );
+  let variantData: VariantData | null = null;
+  if (variantDataStr) {
+    variantData = JSON.parse(variantDataStr) as VariantData;
+    variantData.id = node.id;
+    variantData.name = node.name;
+  } else {
+    variantData = {
+      id: node.id,
+      name: node.name,
+    } as VariantData;
+  }
+  return variantData;
+}
+
+function hashToVariantMap(variantList: any) {
+  const variantMap: Map<string, VariantData> = new Map();
+  for (const v of variantList) {
+    const variantData = {
+      id: v.id,
+      name: v.name,
+      isDefault: v.isDefault,
+      layer: v.layer,
+    } as VariantData;
+    variantMap.set(v.id, variantData);
+  }
+  return variantMap;
+}
+
+function deselectNode() {
+  figma.ui.postMessage({
+    msg: "scalable-deselect",
+  });
+}

--- a/support-figma/extended-layout-plugin/webpack.config.js
+++ b/support-figma/extended-layout-plugin/webpack.config.js
@@ -82,6 +82,11 @@ module.exports = (env, argv) => ({
       filename: "shader.html",
       inject: false,
     }),
+    new HtmlWebpackPlugin({
+      template: "src/scalable.html",
+      filename: "scalable.html",
+      inject: false,
+    }),
     new CopyPlugin({
       patterns: [
         { from: "src/data/shader/", to: "data/shader/" }, // Copy to the dist folder


### PR DESCRIPTION
Fixes #2180.

- Create a plugin to add scalable UI data
- Proto and Figma schema changes to parse and store the data

To fetch a file to be used to load scalable ui panel states, run the fetch tool with the --scalableui option and the root node that contains all the panel component instances. For example:

cargo run --bin fetch --features fetch -- --doc-id <doc_id> --nodes "#stage" --output ScalableSystemUi_<doc_id>.dcf --scalableui
