### PR TITLE
Refactor to help importing the crate to AOSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "protobuf-codegen",
  "serde",
  "serde_bytes",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -329,7 +329,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "ureq",
 ]
 
@@ -343,7 +343,7 @@ dependencies = [
  "protobuf",
  "serde",
  "taffy",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ dependencies = [
  "taffy",
  "tempfile",
  "testdir",
- "thiserror",
+ "thiserror 2.0.12",
  "unicode-segmentation",
  "ureq",
  "vergen",
@@ -699,7 +699,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.63",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -857,9 +857,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -872,7 +872,7 @@ checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -902,7 +902,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "which",
 ]
 
@@ -912,7 +912,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1241,7 +1241,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1249,6 +1258,17 @@ name = "thiserror-impl"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ jni = "0.21.1"
 lazy_static = "1.5.0"
 log = "0.4"
 phf = { version = "0.11", features = ["macros"] }
-protobuf = "3.7.1"
-protobuf-codegen = "3.7.1"
+protobuf = "3.2.0"
+protobuf-codegen = "3.2.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde-generate = { version = "0.25.1" }
@@ -49,7 +49,7 @@ svgtypes = "0.15.1"
 taffy = { version = "0.6", default-features = false, features = ["std", "taffy_tree", "flexbox", "content_size"] }
 testdir = "0.9.1"
 tempfile = "3.11.0"
-thiserror = "1.0"
+thiserror = "2.0.11"
 unicode-segmentation = "1"
 ureq = "2"
 vergen = { version = "8.3.2", default-features = false, features = [

--- a/crates/dc_bundle/build.rs
+++ b/crates/dc_bundle/build.rs
@@ -34,12 +34,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut codegen = protobuf_codegen::Codegen::new();
 
     codegen
+        .pure()
         .customize(config)
         .out_dir(&out_dir)
         .include(&proto_path)
         .inputs(&proto_files_str)
-        .cargo_out_dir("protos")
-        .run()?;
+        .run_from_script();
 
     println!("cargo:rerun-if-changed={}", proto_path.to_str().unwrap());
     Ok(())

--- a/crates/dc_bundle/src/lib.rs
+++ b/crates/dc_bundle/src/lib.rs
@@ -18,7 +18,7 @@ pub mod definition;
 pub mod definition_file;
 
 // Include the generated proto module.
-include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
+include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 
 #[derive(Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
Downgrade protobuf version to 3.2.0, the same version currently supported on Android to reduce the number of patches required.
Move to pure rust code generator to avoid requiring protoc installed on the host machine.
Drop using the "protos" subfolder, it is hard to work with in soong. The proto files are included in the root 'lib.rs' anyway.
Upgrade thiserror to 2.x.

Fixes https://github.com/google/automotive-design-compose/issues/2195