### PR TITLE
Refactor progress width and media progress to use MutableFloatState f…

### DIFF
--- a/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MediaAdapter.kt
+++ b/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MediaAdapter.kt
@@ -638,7 +638,7 @@ class MediaAdapter(
     class MediaNowPlayingProgress {
         var currentTimeText: MutableState<String> = mutableStateOf("")
         var maxTimeText: MutableState<String> = mutableStateOf("")
-        var progressWidth: MutableState<Float?> = mutableStateOf<Float?>(0F)
+        var progressWidth: MutableFloatState = mutableFloatStateOf(0F)
     }
 
     @Composable
@@ -647,7 +647,7 @@ class MediaAdapter(
         // Observe the current track progress
         val progress: PlaybackProgress? by nowPlayingPlaybackViewModel.progress.observeAsState()
         val maxProgress = progress?.maxProgress?.toFloat() ?: 0F
-        nowPlaying.progressWidth.value =
+        nowPlaying.progressWidth.floatValue =
             if (maxProgress == 0F) 0F
             else (progress?.progress?.toFloat() ?: 0F) * 100F / maxProgress
         nowPlaying.currentTimeText.value = progress?.currentTimeText as String? ?: ""

--- a/reference-apps/cluster-demo/app/src/main/java/com/android/designcompose/testapp/clusterdemo/MainActivity.kt
+++ b/reference-apps/cluster-demo/app/src/main/java/com/android/designcompose/testapp/clusterdemo/MainActivity.kt
@@ -474,7 +474,7 @@ private fun MainFrame(cameraPreview: CameraPreview?) {
     val tempDegreesStringState = remember { derivedStateOf { "${tempDegrees.value.toInt()}F" } }
     val rpm = remember { mutableStateOf(5F) }
     val rpmState = remember { derivedStateOf { rpm.value.roundToInt().toString() } }
-    val mediaProgress = remember { mutableStateOf<Float?>(100F) }
+    val mediaProgress = remember { mutableFloatStateOf(100F) }
 
     // Demo animations
     var driveDemoState by remember { mutableStateOf(DriveDemoState.Parked) }

--- a/reference-apps/cluster-demo/app/src/main/java/com/android/designcompose/testapp/clusterdemo/MainActivity.kt
+++ b/reference-apps/cluster-demo/app/src/main/java/com/android/designcompose/testapp/clusterdemo/MainActivity.kt
@@ -474,7 +474,7 @@ private fun MainFrame(cameraPreview: CameraPreview?) {
     val tempDegreesStringState = remember { derivedStateOf { "${tempDegrees.value.toInt()}F" } }
     val rpm = remember { mutableStateOf(5F) }
     val rpmState = remember { derivedStateOf { rpm.value.roundToInt().toString() } }
-    val mediaProgress = remember { mutableFloatStateOf(100F) }
+    val mediaProgress = remember { mutableStateOf<Float?>(100F) }
 
     // Demo animations
     var driveDemoState by remember { mutableStateOf(DriveDemoState.Parked) }


### PR DESCRIPTION
causing issues while compiling reference application after progress bar changes merged 

e: file:///home/ubuntu/Desktop/Figma/automotive-design-compose/reference-apps/aaos-unbundled/mediacompose/src/main/java/com/android/designcompose/reference/mediacompose/MainActivity.kt:183:28 Type mismatch: inferred type is MutableState<Float> but MeterState /* = FloatState */ was expected


e: file:///home/ubuntu/Desktop/Figma/automotive-design-compose/reference-apps/cluster-demo/app/src/main/java/com/android/designcompose/testapp/clusterdemo/MainActivity.kt:662:45 Type mismatch: inferred type is MutableState<Float> but MeterState /* = FloatState */ was expected
