### PR TITLE
feat: add input stream as optional parameter to be loaded instead of …

### DIFF
--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/BuilderProcessor.kt
@@ -583,6 +583,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
 
             // Add optional key that can be used to uniquely identify this particular instance
             args.add(Pair("key", "String? = null"))
+            args.add(Pair("dcfInputStream", "InputStream? = null"))
 
             // Add an optional replacement index that should be populated if the composable is
             // replacing children of a node through a content replacement customization
@@ -837,6 +838,7 @@ class BuilderProcessor(private val codeGenerator: CodeGenerator, val logger: KSP
                 "                serverParams = DocumentServerParams(queries, ignoredImages()),\n"
             )
             out.appendText("                setDocId = setDocId,\n")
+            out.appendText("                dcfInputStream = dcfInputStream,\n")
             val switchPolicy =
                 if (hideDesignSwitcher) "DesignSwitcherPolicy.HIDE"
                 else "DesignSwitcherPolicy.SHOW_IF_ROOT"

--- a/codegen/src/main/kotlin/com/android/designcompose/codegen/Common.kt
+++ b/codegen/src/main/kotlin/com/android/designcompose/codegen/Common.kt
@@ -100,6 +100,7 @@ internal fun createNewFile(
     file += "import android.view.ViewGroup\n"
     file += "import android.os.Build\n"
     file += "import androidx.compose.runtime.FloatState\n"
+    file += "import java.io.InputStream\n"
     file += "\n"
 
     file += "import com.android.designcompose.annotation.DesignMetaKey\n"

--- a/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignSwitcher.kt
@@ -135,7 +135,7 @@ private interface DesignSwitcher {
             DesignDocInternal(
                 designSwitcherDocName(),
                 docId,
-                rootNodeQuery,
+                rootNodeQuery = rootNodeQuery,
                 customizations = customizations,
                 modifier = modifier,
                 serverParams = DocumentServerParams(queries, ignoredImages()),
@@ -204,7 +204,7 @@ private interface DesignSwitcher {
             DesignDocInternal(
                 designSwitcherDocName(),
                 designSwitcherDocId(),
-                NodeQuery.NodeName("#SettingsView"),
+                rootNodeQuery = NodeQuery.NodeName("#SettingsView"),
                 customizations = customizations,
                 modifier = modifier.semantics { sDocClass = DesignSwitcherDoc.javaClass.name },
                 serverParams = DocumentServerParams(queries(), ignoredImages()),
@@ -225,7 +225,7 @@ private interface DesignSwitcher {
             DesignDocInternal(
                 designSwitcherDocName(),
                 designSwitcherDocId(),
-                NodeQuery.NodeName("#FigmaDoc"),
+                rootNodeQuery = NodeQuery.NodeName("#FigmaDoc"),
                 customizations = customizations,
                 serverParams = DocumentServerParams(queries(), ignoredImages()),
                 liveUpdateMode = getLiveMode(),
@@ -243,7 +243,7 @@ private interface DesignSwitcher {
             DesignDocInternal(
                 designSwitcherDocName(),
                 designSwitcherDocId(),
-                NodeQuery.NodeName("#Message"),
+                rootNodeQuery = NodeQuery.NodeName("#Message"),
                 customizations = customizations,
                 serverParams = DocumentServerParams(queries(), ignoredImages()),
                 liveUpdateMode = getLiveMode(),
@@ -261,7 +261,7 @@ private interface DesignSwitcher {
             DesignDocInternal(
                 designSwitcherDocName(),
                 designSwitcherDocId(),
-                NodeQuery.NodeName("#MessageFailed"),
+                rootNodeQuery = NodeQuery.NodeName("#MessageFailed"),
                 customizations = customizations,
                 serverParams = DocumentServerParams(queries(), ignoredImages()),
                 liveUpdateMode = getLiveMode(),
@@ -277,7 +277,7 @@ private interface DesignSwitcher {
         DesignDocInternal(
             designSwitcherDocName(),
             designSwitcherDocId(),
-            NodeQuery.NodeVariant(nodeName, "#Checkbox"),
+            rootNodeQuery = NodeQuery.NodeVariant(nodeName, "#Checkbox"),
             customizations = CustomizationContext(),
             modifier = modifier,
             serverParams = DocumentServerParams(queries, ignoredImages()),

--- a/designcompose/src/main/java/com/android/designcompose/DesignView.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DesignView.kt
@@ -45,6 +45,7 @@ import com.android.designcompose.definition.view.ComponentInfo
 import com.android.designcompose.squoosh.SquooshRoot
 import kotlin.math.min
 import kotlinx.coroutines.delay
+import java.io.InputStream
 
 // This debugging modifier draws a border around elements that are recomposing. The border increases
 // in size and interpolates from red to green as more recompositions occur before a timeout. This
@@ -232,11 +233,13 @@ fun DesignDoc(
     designSwitcherPolicy: DesignSwitcherPolicy = DesignSwitcherPolicy.SHOW_IF_ROOT,
     designComposeCallbacks: DesignComposeCallbacks? = null,
     parentComponents: List<ParentComponentInfo> = listOf(),
+    dcfInputStream: InputStream? = null
 ) {
     beginSection(DCTraces.DESIGNDOCINTERNAL)
     DesignDocInternal(
         docName,
         docId,
+        dcfInputStream,
         rootNodeQuery,
         modifier = modifier,
         customizations = customizations,
@@ -253,6 +256,7 @@ fun DesignDoc(
 internal fun DesignDocInternal(
     docName: String,
     incomingDocId: DesignDocId,
+    dcfInputStream: InputStream? = null,
     rootNodeQuery: NodeQuery,
     modifier: Modifier = Modifier,
     customizations: CustomizationContext = CustomizationContext(),
@@ -269,6 +273,7 @@ internal fun DesignDocInternal(
     SquooshRoot(
         docName = docName,
         incomingDocId = currentDocId,
+        dcfInputStream = dcfInputStream,
         rootNodeQuery = rootNodeQuery,
         modifier = modifier,
         customizationContext = customizations,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -130,6 +130,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.io.InputStream
 
 const val TAG: String = "DC_SQUOOSH"
 
@@ -236,6 +237,7 @@ fun SquooshRoot(
     liveUpdateMode: LiveUpdateMode = LiveUpdateMode.LIVE,
     designComposeCallbacks: DesignComposeCallbacks? = null,
     rootRecurseParams: RootRecurseParams = RootRecurseParams(),
+    dcfInputStream: InputStream? = null,
 ) {
     // Basic init and doc loading.
     val isRoot = LocalSquooshIsRootContext.current.isRoot
@@ -247,6 +249,7 @@ fun SquooshRoot(
             serverParams,
             designComposeCallbacks?.newDocDataCallback,
             liveUpdateMode == LiveUpdateMode.OFFLINE,
+            dcfInputStream,
         )
 
     LaunchedEffect(docName) { Log.i(TAG, "Squooshing $docName") }

--- a/reference-apps/helloworld/helloworld-app/src/main/java/com/android/designcompose/testapp/helloworld/MainActivity.kt
+++ b/reference-apps/helloworld/helloworld-app/src/main/java/com/android/designcompose/testapp/helloworld/MainActivity.kt
@@ -26,6 +26,8 @@ import com.android.designcompose.annotation.Design
 import com.android.designcompose.annotation.DesignComponent
 import com.android.designcompose.annotation.DesignDoc
 import com.android.designcompose.testapp.helloworld.ui.theme.helloworldTheme
+import java.io.File
+import java.io.InputStream
 
 const val helloWorldDocId = "pxVlixodJqZL95zo2RzTHl"
 
@@ -37,9 +39,14 @@ interface HelloWorld {
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        val dir = filesDir.path
+        val inputStream: InputStream? = try {
+            File(dir, "HelloWorldDoc_pxVlixodJqZL95zo2RzTHl.dcf").inputStream()
+        } catch (e: Exception) {
+          null
+        }
         DesignSettings.enableLiveUpdates(this)
-        setContent { HelloWorldDoc.mainFrame(name = "World!") }
+        setContent { HelloWorldDoc.mainFrame(name = "World!", dcfInputStream = inputStream) }
     }
 }
 


### PR DESCRIPTION
Add an optional (nullable) InputStream parameter to the generated composable.
If this InputStream is provided, the dcf will be loaded from it with priority, before attempting to locate it in the app resources or assets.

An example implementation can be found in the hello world reference app. It canbe tested it by pushing the corresponding dcf file to the app dir: 
`adb push HelloWorldDoc_pxVlixodJqZL95zo2RzTHl.dcf /data/user/10/com.android.designcompose.testapp.helloworld/files`