### PR TITLE
Update VCS mapping for protobuf submodule

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,22 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2024 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/crates/dc_bundle/src/proto" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
This change adds a new VCS mapping for the `crates/dc_bundle/src/proto` directory. This directory is a Git submodule containing protobuf definitions.

The copyright header was also removed from `.idea/vcs.xml`. Since this is a generated file (and just a workspace configuration file) I don't think it's necessary.