### PR TITLE
Update version to 0.38.1, Update svgtypes to 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/dc_figma_import", "crates/dc_jni", "crates/dc_layout", "crate
 
 [workspace.package]
 # LINT.IfChange
-version = "0.38.0"
+version = "0.38.1"
 # LINT.ThenChange(gradle/libs.versions.toml)
 edition = "2021"
 authors = ["DesignCompose Team <aae-design-compose@google.com>"]
@@ -21,9 +21,9 @@ panic = 'abort'
 
 [workspace.dependencies]
 # dc_* crates specify a version because they are dependencies published on crates.io
-dc_bundle = { version = "0.38.0", path = "crates/dc_bundle" }
-dc_layout = { version = "0.38.0", path = "crates/dc_layout" }
-dc_figma_import = { version = "0.38.0", path = "crates/dc_figma_import" }
+dc_bundle = { version = "0.38.1", path = "crates/dc_bundle" }
+dc_layout = { version = "0.38.1", path = "crates/dc_layout" }
+dc_figma_import = { version = "0.38.1", path = "crates/dc_figma_import" }
 android_logger = "0.13.1"
 anyhow = "1.0"
 bytes = "1.6.0"
@@ -43,7 +43,7 @@ serde_bytes = "0.11"
 serde-generate = { version = "0.25.1" }
 serde_json = "1.0"
 serde-reflection = { version = "0.3" }
-svgtypes = "0.15.1"
+svgtypes = "0.16.1"
 taffy = { version = "0.6", default-features = false, features = ["std", "taffy_tree", "flexbox", "content_size"] }
 tempfile = "3.11.0"
 thiserror = "2.0.11"

--- a/crates/dc_figma_import/README.md
+++ b/crates/dc_figma_import/README.md
@@ -15,7 +15,7 @@ The Figma API provides access to documents, images, vectors, and interactions th
 
 ### Generating data for a UI toolkit
 
-Currently `dc_figma_import` uses the Rust `bincode` serialization format to encode processed documents for the client. In the future we plan to migrate to protobuf because protobuf is better supported within Google.
+`dc_figma_import` uses the `protobuf` serialization format to encode processed documents for the client.
 
 * `toolkit_schema` includes the core structures that make up a serialized document.
 * `toolkit_style` includes the structures relating to style.
@@ -32,7 +32,6 @@ Currently `dc_figma_import` uses the Rust `bincode` serialization format to enco
 
 ### Application binaries
 
-* `reflection` generates Java code to deserialize the `bincode` encoded `toolkit_schema` and `serialized_document` types.
 * `dcf_info` deserializes a serialized DesignCompose file (.dcf) and prints out some basic data about the file.
   * Usage: `cargo run --bin dcf_info --features=dcf_info <path>`
 * `fetch` queries Figma for a file with specified nodes, then processes and serializes the response, and saves it into a .dcf file.

--- a/crates/dc_figma_import/src/extended_layout_schema.rs
+++ b/crates/dc_figma_import/src/extended_layout_schema.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 // This module deserializes our "vsw Extended Layout" plugin output. The plugin writes one of two
 // values: "vsw-extended-text-layout" and "vsw-extended-auto-layout". We define a struct for each
-// so we don't have to deal with serde/bincode tagged enum issues.
+// so we don't have to deal with serde tagged enum issues.
 
 /// ExtendedTextLayout is an extra set of fields set by our plugin that help us to deal with
 /// dynamic text content. We need to know if it should wrap, or be truncated or ellipsized,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # DesignCompose
 # LINT.IfChange
-designcompose = "0.38.0-SNAPSHOT"
+designcompose = "0.38.1-SNAPSHOT"
 # LINT.ThenChange(Cargo.toml)
 
 


### PR DESCRIPTION
- Update DesignCompose version to `0.38.1`
- Set all `dc_*` dependencies to version `0.38.1`
- Update crate `svgtypes` to `0.16.1`
- Update docs to remove mentions of `bincode` since it is no longer used
