### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:
           # This will cause the dependency graph workflow to re-run if new dependencies are uploaded
           # by a job that finishes after this one. Specifically needed for the Gradle dependency snapshot upload


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/dependency-review-action` | [`3c4e3dc`](https://github.com/actions/dependency-review-action/commit/3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261) | [`2031cfc`](https://github.com/actions/dependency-review-action/commit/2031cfc080254a8a887f58cffee85186f0e49e48) | [Release](https://github.com/actions/dependency-review-action/releases/tag/v4) | dependency-review.yml |

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
