### PR TITLE
Fix #2305: Handle unknown Figma features in deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "dc_bundle"
-version = "0.38.3"
+version = "0.38.4"
 dependencies = [
  "log",
  "protobuf",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "dc_figma_import"
-version = "0.38.3"
+version = "0.38.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "dc_jni"
-version = "0.38.3"
+version = "0.38.4"
 dependencies = [
  "android_logger",
  "bytes",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "dc_layout"
-version = "0.38.3"
+version = "0.38.4"
 dependencies = [
  "android_logger",
  "dc_bundle",

--- a/crates/dc_figma_import/src/figma_schema.rs
+++ b/crates/dc_figma_import/src/figma_schema.rs
@@ -641,6 +641,8 @@ pub enum LayoutMode {
     None,
     Horizontal,
     Vertical,
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Default, Copy)]
@@ -654,7 +656,7 @@ pub enum LayoutWrap {
 impl LayoutMode {
     pub fn is_none(&self) -> bool {
         match self {
-            LayoutMode::None => true,
+            LayoutMode::None | LayoutMode::Unknown => true,
             _ => false,
         }
     }
@@ -1013,7 +1015,10 @@ pub enum NodeData {
         #[serde(rename = "componentId")]
         component_id: String,
     },
-    Section {},
+    Section {
+        #[serde(default, rename = "sectionContentsHidden")]
+        section_contents_hidden: bool,
+    },
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -1403,4 +1408,82 @@ pub struct VariablesResponse {
     pub error: bool,
     pub status: i32,
     pub meta: VariablesMeta,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_mode_deserializes_known_values() {
+        let h: LayoutMode = serde_json::from_str("\"HORIZONTAL\"").unwrap();
+        assert_eq!(h, LayoutMode::Horizontal);
+        let v: LayoutMode = serde_json::from_str("\"VERTICAL\"").unwrap();
+        assert_eq!(v, LayoutMode::Vertical);
+        let n: LayoutMode = serde_json::from_str("\"NONE\"").unwrap();
+        assert_eq!(n, LayoutMode::None);
+    }
+
+    #[test]
+    fn test_layout_mode_deserializes_grid_as_unknown() {
+        // Issue #2305: "Auto-layout set to Grid" causes serialization error.
+        // GRID is a valid Figma layout mode but was not in our enum.
+        let grid: LayoutMode = serde_json::from_str("\"GRID\"").unwrap();
+        assert_eq!(grid, LayoutMode::Unknown);
+        assert!(grid.is_none()); // Unknown is treated as no-layout
+    }
+
+    #[test]
+    fn test_layout_mode_deserializes_future_values_as_unknown() {
+        // Any future Figma layout mode should not crash deserialization
+        let future: LayoutMode = serde_json::from_str("\"SOME_FUTURE_MODE\"").unwrap();
+        assert_eq!(future, LayoutMode::Unknown);
+    }
+
+    #[test]
+    fn test_section_node_deserializes() {
+        // Issue #2305: Sections used anywhere cause serialization error.
+        // Verify that a minimal Section node can be deserialized.
+        let json = r#"{
+            "id": "1:1",
+            "name": "My Section",
+            "type": "SECTION",
+            "visible": true,
+            "opacity": 1.0,
+            "fills": [],
+            "strokes": [],
+            "effects": [],
+            "children": [],
+            "sectionContentsHidden": true
+        }"#;
+        let node: Node = serde_json::from_str(json).unwrap();
+        assert_eq!(node.id, "1:1");
+        assert_eq!(node.name, "My Section");
+        match &node.data {
+            NodeData::Section { section_contents_hidden } => {
+                assert!(*section_contents_hidden);
+            }
+            _ => panic!("Expected Section variant"),
+        }
+    }
+
+    #[test]
+    fn test_section_node_with_unknown_fields() {
+        // Future Figma fields should not cause deserialization failure
+        let json = r#"{
+            "id": "1:2",
+            "name": "Section With Extras",
+            "type": "SECTION",
+            "visible": true,
+            "opacity": 1.0,
+            "fills": [],
+            "strokes": [],
+            "effects": [],
+            "children": [],
+            "sectionContentsHidden": false,
+            "devStatus": {"type": "READY_FOR_DEV"}
+        }"#;
+        let node: Node = serde_json::from_str(json).unwrap();
+        assert_eq!(node.name, "Section With Extras");
+    }
 }

--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -182,7 +182,9 @@ fn compute_layout(
             style.layout_style_mut().flex_direction = match frame.layout_mode {
                 figma_schema::LayoutMode::Horizontal => FlexDirection::FLEX_DIRECTION_ROW.into(),
                 figma_schema::LayoutMode::Vertical => FlexDirection::FLEX_DIRECTION_COLUMN.into(),
-                figma_schema::LayoutMode::None => FlexDirection::FLEX_DIRECTION_NONE.into(),
+                figma_schema::LayoutMode::None | figma_schema::LayoutMode::Unknown => {
+                    FlexDirection::FLEX_DIRECTION_NONE.into()
+                }
             };
         }
         style.layout_style_mut().padding = Some(DimensionRect {
@@ -313,7 +315,7 @@ fn compute_layout(
                 }
             }
 
-            if frame.layout_mode != figma_schema::LayoutMode::None {
+            if !frame.layout_mode.is_none() {
                 let width_points = bounds.width().ceil();
                 let height_points = bounds.height().ceil();
                 style.layout_style_mut().width = match frame.layout_sizing_horizontal {


### PR DESCRIPTION
## Summary
Prevents hard crashes when Figma introduces new features (like Grid auto-layout or Sections with new fields) that our schema doesn't yet support.

## Problem
When Figma adds new features (e.g., `GRID` layout mode, Section nodes with `sectionContentsHidden`), the strict deserialization crashes with `unknown variant` or `missing field` errors. This completely breaks document loading for files using any new Figma feature.

## Root Cause
- `LayoutMode` enum had no catch-all variant for unknown values
- `Section` node variant was missing the `sectionContentsHidden` field

## Changes
### `crates/dc_figma_import/src/figma_schema.rs`
- Added `#[serde(other)] Unknown` variant to `LayoutMode` enum — any unrecognized layout mode deserializes gracefully instead of crashing
- Added `sectionContentsHidden` field to `Section` variant with `#[serde(default)]`
- Added 5 unit tests verifying robust deserialization

### `crates/dc_figma_import/src/transform_flexbox.rs`
- Updated all `LayoutMode` match arms to handle the new `Unknown` variant
- `Unknown` layout mode is treated as non-auto-layout (safe default)

## Validation
- `cargo test -p dc_figma_import`: All tests pass ✅
- JSON with `"layoutMode": "GRID"` now deserializes without panic ✅
- JSON with unknown layout modes deserializes to `LayoutMode::Unknown` ✅

Fixes #2305