### PR TITLE
Fix #1514: Avoid double key events during animated transitions

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -329,18 +329,22 @@ internal fun resolveVariantsRecursively(
     view.reactionsList.forEach { r ->
         hasSupportedInteraction = hasSupportedInteraction || r.trigger.isSupportedInteraction()
         if (r.trigger.hasKeyDown()) {
-            // Register to be a listener for key reactions on this node
-            val keyTrigger = r.trigger.keyDown
-            val keyEvent = DesignKeyEvent.fromJsKeyCodes(keyTrigger.keyCodes.toList())
-            val keyAction =
-                KeyAction(
-                    interactionState,
-                    r.action,
-                    findTargetInstanceId(document, parentComps, r.action),
-                    customizations.getKey(),
-                    null,
-                )
-            keyTracker.addListener(keyEvent, keyAction)
+            // Only register key event listeners during the base phase to avoid
+            // processing key events twice during animated transitions (Issue #1514).
+            if (variantTransition.treeBuildPhase == TreeBuildPhase.BasePhase) {
+                // Register to be a listener for key reactions on this node
+                val keyTrigger = r.trigger.keyDown
+                val keyEvent = DesignKeyEvent.fromJsKeyCodes(keyTrigger.keyCodes.toList())
+                val keyAction =
+                    KeyAction(
+                        interactionState,
+                        r.action,
+                        findTargetInstanceId(document, parentComps, r.action),
+                        customizations.getKey(),
+                        null,
+                    )
+                keyTracker.addListener(keyEvent, keyAction)
+            }
         }
     }
     val tapCallback = customizations.getTapCallback(view)


### PR DESCRIPTION
## Summary
Prevents key events from being processed twice during animated variant transitions.

## Problem
During animated transitions, `resolveVariantsRecursively()` is called twice — once for the source tree (`BasePhase`) and once for the destination tree (`TransitionTargetPhase`). Both calls registered key event listeners via `keyTracker.addListener()`, causing every key event to fire its action twice.

## Root Cause
In `SquooshTreeBuilder.kt`, the key event listener registration at line 331-343 ran unconditionally for both tree build phases:
```kotlin
// Before fix: runs on BOTH phases
if (r.trigger.hasKeyDown()) {
    keyTracker.addListener(keyEvent, keyAction) // registered twice!
}
```

## Fix
Wrapped the key listener registration in a `TreeBuildPhase.BasePhase` check:
```kotlin
if (r.trigger.hasKeyDown()) {
    if (variantTransition.treeBuildPhase == TreeBuildPhase.BasePhase) {
        keyTracker.addListener(keyEvent, keyAction) // registered once
    }
}
```

## Changes
- **`designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt`**: Scope key listener registration to BasePhase only

## Validation
- `./gradlew designcompose:compileDebugKotlin`: Passes ✅
- Key listeners are only registered during source tree build, not transition target

Fixes #1514