### PR TITLE
Fix #249: Add security check for Figma token file permissions

### DIFF
--- a/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
+++ b/plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt
@@ -17,6 +17,8 @@
 package com.android.designcompose.gradle
 
 import java.awt.SystemColor.text
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -73,9 +75,54 @@ fun Project.initializeExtension(extension: PluginExtension) {
             .environmentVariable("FIGMA_ACCESS_TOKEN")
             .orElse(providers.gradleProperty(tokenGradlePropertyName))
             .orElse(
-                providers.fileContents(extension.figmaTokenFile).asText.map { text -> text.trim() }
+                providers.fileContents(extension.figmaTokenFile).asText.map { text ->
+                    // Check file permissions when reading the token from a file (Issue #249).
+                    // Warn if the file is world-readable, as this could expose the Figma
+                    // access token to other users on shared systems.
+                    checkTokenFilePermissions(extension.figmaTokenFile)
+                    text.trim()
+                }
             )
     )
     // Avoid odd behavior by only allowing changes to be made to the token before it's read
     extension.figmaToken.finalizeValueOnRead()
 }
+
+/**
+ * Check that the Figma token file is not world-readable. On Unix/macOS systems, a world-readable
+ * token file could expose the Figma access token to other users. This function emits a warning
+ * if the file has overly permissive permissions.
+ *
+ * @param tokenFile The RegularFileProperty pointing to the token file
+ */
+private fun Project.checkTokenFilePermissions(tokenFile: RegularFileProperty) {
+    if (!Os.isFamily(Os.FAMILY_UNIX)) return
+
+    try {
+        val file = tokenFile.get().asFile
+        if (!file.exists()) return
+
+        val permissions = Files.getPosixFilePermissions(file.toPath())
+        val worldReadable = PosixFilePermission.OTHERS_READ in permissions
+        val worldWritable = PosixFilePermission.OTHERS_WRITE in permissions
+        val groupReadable = PosixFilePermission.GROUP_READ in permissions
+
+        if (worldReadable || worldWritable) {
+            logger.warn(
+                "WARNING: Figma access token file '${file.absolutePath}' is world-" +
+                    "${if (worldReadable && worldWritable) "readable and writable" else if (worldReadable) "readable" else "writable"}. " +
+                    "This could expose your Figma access token to other users. " +
+                    "Run 'chmod 600 ${file.absolutePath}' to restrict access to owner only."
+            )
+        } else if (groupReadable) {
+            logger.warn(
+                "WARNING: Figma access token file '${file.absolutePath}' is group-readable. " +
+                    "Consider running 'chmod 600 ${file.absolutePath}' to restrict access to owner only."
+            )
+        }
+    } catch (e: Exception) {
+        // Don't fail the build if we can't check permissions (e.g. on unsupported filesystems)
+        logger.debug("Could not check Figma token file permissions: ${e.message}")
+    }
+}
+


### PR DESCRIPTION
## Summary
Adds a security check that warns when the Figma access token file has overly permissive file permissions on Unix/macOS systems.

## Problem
The Figma access token file could be world-readable, exposing the token to other users on shared systems. There was no check or warning about this.

## Changes
- **`plugins/gradle-plugin/src/main/kotlin/com/android/designcompose/gradle/PluginExtension.kt`**:
  - Added `checkTokenFilePermissions()` function that runs when the token is read from a file
  - Uses `java.nio.file.Files.getPosixFilePermissions()` to check Unix permissions
  - Warns about world-readable, world-writable, and group-readable files
  - Provides remediation command: `chmod 600 <filepath>`
  - Skipped on Windows; fails gracefully on unsupported filesystems

## Behavior
| Permissions | Warning |
|-------------|---------|
| `-rw-------` (600) | None — secure ✅ |
| `-rw-r-----` (640) | Group-readable warning |
| `-rw-r--r--` (644) | World-readable warning |
| `-rw-rw-rw-` (666) | World-readable and writable warning |

> The check only runs when the token comes from a file. Environment variables and Gradle properties are not checked.

## Validation
- `./gradlew :plugins:gradle-plugin:compileKotlin`: Passes ✅
- `./gradlew :plugins:gradle-plugin:test`: All 4 existing tests pass ✅

Fixes #249