### PR TITLE
Fix #281: Add performance logging for high-cost fetch operations

### DIFF
--- a/crates/dc_jni/src/android_interface/convert_request.rs
+++ b/crates/dc_jni/src/android_interface/convert_request.rs
@@ -22,6 +22,8 @@ use dc_bundle::figma_doc::ServerFigmaDoc;
 use dc_figma_import::HiddenNodePolicy;
 use dc_figma_import::ImageContextSession;
 use dc_figma_import::ProxyConfig;
+use log::info;
+use std::time::Instant;
 
 pub fn fetch_doc(
     id: &str,
@@ -29,6 +31,8 @@ pub fn fetch_doc(
     rq: &ConvertRequest,
     proxy_config: &ProxyConfig,
 ) -> Result<ConvertResponse, Error> {
+    let fetch_start = Instant::now();
+
     let image_session: Option<ImageContextSession> = {
         match &rq.image_session_json {
             Some(json) => match serde_json::from_slice(json) {
@@ -39,6 +43,7 @@ pub fn fetch_doc(
         }
     };
 
+    let start = Instant::now();
     if let Some(mut doc) = dc_figma_import::Document::new_if_changed(
         &rq.figma_api_key,
         id.into(),
@@ -48,9 +53,12 @@ pub fn fetch_doc(
         rq.version.clone().unwrap_or(String::new()),
         image_session,
     )? {
+        info!("fetch_doc({}): Figma API fetch took {:?}", id, start.elapsed());
+
         // The document has changed since the version the client has, so we should fetch
         // a new copy.
         let mut error_list: Vec<String> = vec![];
+        let start = Instant::now();
         let views = doc.nodes(
             &rq.queries.iter().map(NodeQuery::name).collect(),
             &rq.ignored_images
@@ -60,15 +68,35 @@ pub fn fetch_doc(
             &mut error_list,
             HiddenNodePolicy::Skip, // skip hidden nodes
         )?;
+        info!(
+            "fetch_doc({}): Node extraction took {:?} ({} nodes, {} errors)",
+            id,
+            start.elapsed(),
+            views.len(),
+            error_list.len()
+        );
 
+        let start = Instant::now();
         let variable_map = doc.build_variable_map();
+        info!("fetch_doc({}): Variable map build took {:?}", id, start.elapsed());
 
+        let start = Instant::now();
+        let encoded_images = doc.encoded_image_map();
+        info!(
+            "fetch_doc({}): Image encoding took {:?} ({} images)",
+            id,
+            start.elapsed(),
+            encoded_images.0.len()
+        );
+
+        let start = Instant::now();
         let figma_doc = DesignComposeDefinition::new_with_details(
             views,
-            doc.encoded_image_map(),
+            encoded_images,
             doc.component_sets().clone(),
             variable_map,
         );
+        info!("fetch_doc({}): Definition build took {:?}", id, start.elapsed());
 
         let header = DesignComposeDefinitionHeader::current(
             doc.last_modified().clone(),
@@ -84,6 +112,12 @@ pub fn fetch_doc(
             ..Default::default()
         };
 
+        let start = Instant::now();
+        let image_session_json = serde_json::to_vec(&doc.image_session())?;
+        info!("fetch_doc({}): Image session serialization took {:?}", id, start.elapsed());
+
+        info!("fetch_doc({}): Total fetch pipeline took {:?}", id, fetch_start.elapsed());
+
         Ok(ConvertResponse {
             convert_response_type: Some(convert_response::Convert_response_type::Document(
                 convert_response::Document {
@@ -91,13 +125,18 @@ pub fn fetch_doc(
                     server_doc: Some(server_doc).into(),
                     // Return the image session as a JSON blob; we might want to encode this differently so we
                     // can be more robust if there's corruption.
-                    image_session_json: serde_json::to_vec(&doc.image_session())?,
+                    image_session_json,
                     ..Default::default()
                 },
             )),
             ..Default::default()
         })
     } else {
+        info!(
+            "fetch_doc({}): Document unchanged, skipping fetch ({:?})",
+            id,
+            fetch_start.elapsed()
+        );
         Ok(ConvertResponse {
             convert_response_type: Some(convert_response::Convert_response_type::Unmodified(
                 "x".into(),


### PR DESCRIPTION
## Summary
Adds timing logs to the document fetch pipeline to help identify performance bottlenecks during live updates.

## Problem
The Figma document fetch pipeline has several expensive operations (network calls, image encoding, node extraction) but no timing instrumentation. When live updates are slow, there's no way to identify which stage is the bottleneck.

## Changes
- **`crates/dc_jni/src/android_interface/convert_request.rs`**: Added `info!`-level timing logs around each major operation

## Logged Operations
| Operation | Log Content |
|-----------|-------------|
| Figma API fetch | Duration of network call |
| Node extraction | Duration + node count + error count |
| Variable map build | Duration |
| Image encoding | Duration + image count |
| Definition build | Duration |
| Image session serialization | Duration |
| Total pipeline | End-to-end duration |
| Document unchanged | Skip notification with elapsed time |

## Example Output
```
I/Jni: fetch_doc(abc123): Figma API fetch took 1.234s
I/Jni: fetch_doc(abc123): Node extraction took 45.6ms (12 nodes, 0 errors)
I/Jni: fetch_doc(abc123): Image encoding took 234ms (8 images)
I/Jni: fetch_doc(abc123): Total fetch pipeline took 1.567s
```

## Validation
- `cargo check -p dc_jni`: Passes ✅
- Uses `log::info!` which is visible in Android logcat under the `Jni` tag
- No runtime overhead when logging is disabled (log crate compiles out unused levels)

Fixes #281