### PR TITLE
Fix #1549: Stroke gradients account for stroke thickness

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -557,6 +557,13 @@ internal fun ContentDrawScope.squooshShapeRender(
                 }
             }
         }
+    // For stroke gradients, ensure the brush size accounts for stroke thickness.
+    // A horizontal line has 0 height, and a vertical line has 0 width. Without this,
+    // gradient coordinates that reference size.height or size.width collapse to 0,
+    // rendering the gradient as a solid color or black. (Issue #1549)
+    val strokeWeight = style.nodeStyle.stroke.strokeWeight.toUniform() * density
+    val strokeBrushSize =
+        Size(maxOf(brushSize.width, strokeWeight), maxOf(brushSize.height, strokeWeight))
     val strokeBrush =
         style.nodeStyle.stroke.shaderDataOrNull?.let { shaderData ->
             getShaderBrush(
@@ -576,7 +583,7 @@ internal fun ContentDrawScope.squooshShapeRender(
                     progressVectorMeterData?.let {
                         calculateProgressVectorData(it, shapePaths, p, style, meterValue!!, density)
                     }
-                    brush.applyTo(brushSize, p, 1.0f)
+                    brush.applyTo(strokeBrushSize, p, 1.0f)
                     listOf(p)
                 }
         }
@@ -588,7 +595,7 @@ internal fun ContentDrawScope.squooshShapeRender(
                 val b = background.asBrush(appContext, document, density, variableState)
                 if (b != null) {
                     val (brush, strokeOpacity) = b
-                    brush.applyTo(brushSize, p, strokeOpacity)
+                    brush.applyTo(strokeBrushSize, p, strokeOpacity)
                     p
                 } else {
                     null


### PR DESCRIPTION
## Summary
Fixes stroke gradients rendering as solid black on thin nodes (horizontal/vertical lines).

## Problem
When a stroke gradient is applied to a node with 0 height (horizontal line) or 0 width (vertical line), the gradient collapses because:
1. `RelativeLinearGradient.createShader(size)` multiplies gradient coords by `size.width`/`size.height`
2. For a horizontal line, `size.height = 0`, so `startY * 0 = 0` and `endY * 0 = 0`
3. Both gradient endpoints have the same Y, making the gradient a single point → solid black

## Root Cause
The gradient brush size (`brushSize`) was computed from the node's render size without considering that strokes extend beyond the node bounds. This is correct for fill brushes but wrong for stroke brushes.

## Fix
Compute a `strokeBrushSize` that ensures each dimension is at least the stroke weight:
```kotlin
val strokeWeight = style.nodeStyle.stroke.strokeWeight.toUniform() * density
val strokeBrushSize = Size(
    maxOf(brushSize.width, strokeWeight),
    maxOf(brushSize.height, strokeWeight),
)
```

## Changes
- **`designcompose/src/main/java/com/android/designcompose/FrameRender.kt`**: Use `strokeBrushSize` instead of `brushSize` for stroke gradient rendering (both shader-based and background-based strokes)

## Validation
- `./gradlew designcompose:compileDebugKotlin`: Passes ✅
- Fill brushes are unchanged (still use `brushSize`)
- Only affects stroke rendering where node width or height < stroke weight

Fixes #1549