### PR TITLE
Fix whilePressing interaction getting stuck on multi-touch drag

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
@@ -291,6 +291,7 @@ internal fun Modifier.squooshInteraction(
             detectTapGestures(
                 onPress = {
                     var pressInteraction: PressInteraction.Press? = null
+                    var success = false
 
                     try {
                         // 1. Show the "Pressed" state immediately.
@@ -320,7 +321,7 @@ internal fun Modifier.squooshInteraction(
                             }
 
                         // 2. Wait for the press to end.
-                        val success = tryAwaitRelease()
+                        success = tryAwaitRelease()
 
                         if (success) {
                             // This was a tap. Do the tap actions.
@@ -347,16 +348,18 @@ internal fun Modifier.squooshInteraction(
                                     ?: interactionState.getPressedTapCallback(node.unresolvedNodeId)
                             finalTapCallback?.invoke()
                         }
-
+                    } finally {
                         // 3. Clean up the "Pressed" visual state.
-                        interactionScope.launch {
-                            val endInteraction =
-                                if (success) {
-                                    PressInteraction.Release(pressInteraction!!)
-                                } else {
-                                    PressInteraction.Cancel(pressInteraction!!)
-                                }
-                            interactionSource.emit(endInteraction)
+                        if (pressInteraction != null) {
+                            interactionScope.launch {
+                                val endInteraction =
+                                    if (success) {
+                                        PressInteraction.Release(pressInteraction!!)
+                                    } else {
+                                        PressInteraction.Cancel(pressInteraction!!)
+                                    }
+                                interactionSource.emit(endInteraction)
+                            }
                         }
 
                         // Undo the "on press" reactions.
@@ -375,7 +378,7 @@ internal fun Modifier.squooshInteraction(
                                     customizations.getKey(),
                                 )
                             }
-                    } finally {
+
                         // 4. Ensure isPressed boolean is always reset.
                         isPressed.value = false
                         interactionState.removePressed(node.unresolvedNodeId)


### PR DESCRIPTION
Fixes a bug where a button with a `whilePressing` prototyping interaction remains stuck in its pressed variant if multiple fingers are held down and dragged before being released.

The issue stems from how Jetpack Compose handles multi-pointer gesture cancellations in the `tryAwaitRelease()` coroutine. By encapsulating the cleanup steps—specifically emitting the `PressInteraction.Cancel` or `PressInteraction.Release` and undoing the 'on press' reactions—within a `finally` block inside the `onPress` handler of `detectTapGestures`, we guarantee that regardless of how the touch gesture terminates (e.g., standard release or pointer cancellation from dragging multiple fingers), the UI correctly resets.