### PR TITLE
Fix #2282: Add adaptive polling with exponential backoff for LiveUpdate

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/DocServer.kt
+++ b/designcompose/src/main/java/com/android/designcompose/DocServer.kt
@@ -235,6 +235,7 @@ internal object SpanCache {
 
 internal object DocServer {
     internal const val FETCH_INTERVAL_MILLIS: Long = 5000L
+    internal const val MAX_FETCH_INTERVAL_MILLIS: Long = 60_000L
     internal const val DEFAULT_HTTP_PROXY_PORT = "3128"
     internal val documents: HashMap<DesignDocId, DocContent> = HashMap()
     internal val subscriptions: HashMap<DesignDocId, LiveDocSubscriptions> = HashMap()
@@ -243,6 +244,14 @@ internal object DocServer {
     internal val mainHandler = Handler(Looper.getMainLooper())
     internal var firstFetch = true
     internal var pauseUpdates = false
+
+    // Adaptive polling: tracks the current fetch interval and the number of consecutive
+    // unchanged responses. The interval increases exponentially (5s -> 10s -> 20s -> 40s -> 60s)
+    // when no changes are detected, and resets to FETCH_INTERVAL_MILLIS when a document changes.
+    // This reduces Figma API calls and avoids rate limiting. (Issue #2282)
+    internal var currentFetchIntervalMillis: Long = FETCH_INTERVAL_MILLIS
+    internal var consecutiveUnchangedCount: Int = 0
+
     internal var periodicFetchRunnable: Runnable =
         Runnable() {
             thread {
@@ -297,6 +306,9 @@ internal fun DocServer.startLiveUpdates() {
     if (DesignSettings.liveUpdatesEnabled) {
         Log.i(TAG, "Starting Live Updates")
         pauseUpdates = false
+        // Reset to base interval when explicitly starting
+        currentFetchIntervalMillis = FETCH_INTERVAL_MILLIS
+        consecutiveUnchangedCount = 0
         scheduleLiveUpdate()
     }
 }
@@ -309,7 +321,7 @@ internal fun DocServer.scheduleLiveUpdate() {
     if (DesignSettings.liveUpdatesEnabled && !pauseUpdates) {
         // Stop any live updates that have already been scheduled.
         removeScheduledPeriodicFetchRunnables()
-        mainHandler.postDelayed(periodicFetchRunnable, FETCH_INTERVAL_MILLIS)
+        mainHandler.postDelayed(periodicFetchRunnable, currentFetchIntervalMillis)
     }
 }
 
@@ -397,11 +409,37 @@ internal fun DocServer.fetchDocuments(firstFetch: Boolean): Boolean {
                     }
                 }
                 Feedback.documentUpdated(id, subs.size)
+
+                // Document changed — reset to base polling interval
+                if (currentFetchIntervalMillis != FETCH_INTERVAL_MILLIS) {
+                    Log.i(
+                        TAG,
+                        "Document changed, resetting poll interval to ${FETCH_INTERVAL_MILLIS}ms",
+                    )
+                }
+                currentFetchIntervalMillis = FETCH_INTERVAL_MILLIS
+                consecutiveUnchangedCount = 0
             } else {
                 synchronized(DesignSettings.fileFetchStatus) {
                     DesignSettings.fileFetchStatus[id]?.lastFetch = Instant.now()
                 }
                 Feedback.documentUnchanged(id)
+
+                // No changes — increase polling interval with exponential backoff
+                consecutiveUnchangedCount++
+                val newInterval =
+                    minOf(
+                        FETCH_INTERVAL_MILLIS * (1L shl consecutiveUnchangedCount.coerceAtMost(4)),
+                        MAX_FETCH_INTERVAL_MILLIS,
+                    )
+                if (newInterval != currentFetchIntervalMillis) {
+                    Log.i(
+                        TAG,
+                        "No changes detected ($consecutiveUnchangedCount consecutive), " +
+                            "increasing poll interval to ${newInterval}ms",
+                    )
+                    currentFetchIntervalMillis = newInterval
+                }
             }
         } catch (exception: Exception) {
             val msg =


### PR DESCRIPTION
## Summary
Implements exponential backoff for LiveUpdate polling to prevent Figma rate limiting during long sessions.

## Problem
LiveUpdate polls Figma every 5 seconds unconditionally. During long development sessions with no active Figma changes, this exhausts the Figma API rate limit, resulting in 'Too many requests to Figma.com' errors.

This was exacerbated by Figma's introduction of [rate limits](https://developers.figma.com/docs/rest-api/rate-limits/) in November 2025.

## Solution
Adaptive polling with exponential backoff:

| Consecutive Unchanged | Interval |
|---|---|
| 0 (change detected) | 5s (base) |
| 1 | 10s |
| 2 | 20s |
| 3 | 40s |
| 4+ | 60s (max) |

When a document change is detected, the interval resets to 5s immediately. The interval also resets when live updates are explicitly restarted (activity resume, toggle).

## Changes
- **`DocServer.kt`**:
  - Added `MAX_FETCH_INTERVAL_MILLIS` (60s), `currentFetchIntervalMillis`, and `consecutiveUnchangedCount` fields
  - `scheduleLiveUpdate()` uses `currentFetchIntervalMillis` instead of hardcoded interval
  - `startLiveUpdates()` resets interval and counter on explicit start
  - `fetchDocuments()` increments/resets backoff based on whether document changed
  - Added info-level logs for interval changes

## Validation
- `./gradlew designcompose:compileDebugKotlin`: ✅
- `./gradlew spotCheck`: ✅
- Backoff logic uses bit-shift (`1L shl n`) capped to 4 shifts max, ensuring interval never exceeds 60s

Fixes #2282