### PR TITLE
Fix #435: Add assembleRelease to CI to catch minified build issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           setup-protoc: true
           setup-rust: true
       - name: Full Gradle Test
-        run: ./gradlew assembleDebug assembleAndroidTest assembleUnitTest test
+        run: ./gradlew assembleDebug assembleRelease assembleAndroidTest assembleUnitTest test
       - name: Generate JaCoCo Report
         run: ./gradlew jacocoTestReport
       - name: Upload JaCoCo Report


### PR DESCRIPTION
## Summary
Adds `assembleRelease` to the main CI workflow to ensure minified/proguard builds are validated on every push and PR.

## Problem
The CI only ran `assembleDebug`, which meant that ProGuard/R8 minification issues were not caught until someone manually tried a release build. Issue #406 demonstrated this gap: JNI class names were mangled by ProGuard, causing `ClassNotFoundException` crashes at runtime.

## Fix
Added `assembleRelease` to the `sdk-build` CI job's Gradle command:
```diff
-run: ./gradlew assembleDebug assembleAndroidTest assembleUnitTest test
+run: ./gradlew assembleDebug assembleRelease assembleAndroidTest assembleUnitTest test
```

## Changes
- **`.github/workflows/main.yml`**: Added `assembleRelease` to the sdk-build step

This ensures ProGuard rule gaps, missing keep rules, and class-not-found errors in minified builds are caught early in CI.

Fixes #435