### PR TITLE
Fix #2292: Restore Modifier customization support in squoosh renderer

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -105,6 +105,7 @@ import com.android.designcompose.dispatch
 import com.android.designcompose.doc
 import com.android.designcompose.getContent
 import com.android.designcompose.getKey
+import com.android.designcompose.getModifier
 import com.android.designcompose.getOpenLinkCallback
 import com.android.designcompose.getScrollCallbacks
 import com.android.designcompose.getTapCallback
@@ -750,6 +751,13 @@ fun SquooshRoot(
                             }
                             .then(SquooshParentData(node = child.node))
                             .then(Modifier.testTag(child.node.view.name))
+
+                    // Apply any user-provided Modifier customization. This was lost during the
+                    // Squoosh migration — the setModifier/getModifier API existed but squoosh
+                    // never retrieved and applied the custom modifier. (Issue #2292)
+                    customizationContext.getModifier(child.node.view.name)?.let {
+                        composableChildModifier = composableChildModifier.then(it)
+                    }
 
                     if (child.scrollView != null) {
                         // Compose a scrollable view as a separate composable in order to detect


### PR DESCRIPTION
## Summary
Restores the `Modifier` customization feature that was lost during the Squoosh migration (v0.32 → v0.37).

## Problem
Users reported that `Modifier.clickable()` and other Modifier-based customizations on `@Design` nodes stopped working after the Squoosh migration. The `setModifier`/`getModifier` API on `CustomizationContext` still existed, but the squoosh renderer never called `getModifier()` to retrieve and apply user-provided modifiers.

**Root cause:** In `SquooshRoot.kt`, the `composableChildModifier` was constructed with only the internal draw/layout/testTag modifiers:
```kotlin
var composableChildModifier =
    Modifier.drawWithContent { ... }
        .then(SquooshParentData(node = child.node))
        .then(Modifier.testTag(child.node.view.name))
```
The user's custom modifier from `getModifier()` was never applied — unlike the old renderer.

## Fix
After constructing the base `composableChildModifier`, retrieve and apply the custom modifier:
```kotlin
customizationContext.getModifier(child.node.view.name)?.let {
    composableChildModifier = composableChildModifier.then(it)
}
```

## Changes
- **`SquooshRoot.kt`**: Added `getModifier` import and modifier application after base modifier construction

## Validation
- `./gradlew designcompose:compileDebugKotlin`: ✅
- `./gradlew spotCheck`: ✅
- API contract: `setModifier()` sets → `getModifier()` retrieves → `.then()` applies

Fixes #2292