### PR TITLE
Fix #660: Clarify visibility documentation — parameter name is flexible

### DIFF
--- a/docs/_docs/modifiers/modifiers.md
+++ b/docs/_docs/modifiers/modifiers.md
@@ -230,10 +230,26 @@ The generated `MainFrame` `Composable` function contains a single `Boolean`
 argument called `showText`, which controls the visibility of the Figma node
 called `#name`.
 
+**Note:** The parameter name (e.g. `showText`) can be any valid Kotlin
+identifier — it does not need to match the Figma node name. What matters is the
+`@Design(node = "#name")` annotation, which binds the parameter to the Figma
+node named `#name`. Any `Boolean` parameter with a `@Design` annotation is
+treated as a visibility toggle by the code generator. For example, this is
+equally valid:
+
+```kotlin
+@DesignComponent(node = "#MainFrame")
+fun MainFrame(
+    @Design(node = "#name") isNameVisible: Boolean,
+)
+
+HelloWorldDoc.MainFrame(isNameVisible = true)
+```
+
 Visibility can also be customized using a `State<Boolean>`. Using a `State` can
 have performance benefits because reading the `value` out of a `State` will only
 cause the closest `@Composable` function in the call stack to be recomposed,
-wherease the simpler `Boolean` customization will always recompose the function
+whereas the simpler `Boolean` customization will always recompose the function
 that uses the customization. The following example illustrates how to use a
 `State<Boolean>` as the visibility customization type:
 


### PR DESCRIPTION
## Summary
Clarifies the visibility customization documentation to explain that the parameter name can be any valid Kotlin identifier.

## Problem
The docs used `showText` as the parameter name in the example, which led users to believe the parameter name itself controlled visibility. Users were confused about whether to use the variable name `showText` specifically.

## Changes
- **`docs/_docs/modifiers/modifiers.md`**:
  - Added a **Note** explaining that the parameter name is arbitrary
  - Clarified that the `@Design(node = ...)` annotation is what binds the parameter to the Figma node
  - Added a second example using `isNameVisible` to demonstrate name flexibility
  - Fixed a typo: 'wherease' → 'whereas'

## Notes
Documentation-only change, no code modifications.

Fixes #660