### PR TITLE
chore: remove unclaimed Open VSX extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     "recommendations": [
         "figma.figma-vscode-extension", // Figma!
         "GitHub.vscode-pull-request-github", // Pull requests, comments, etc
-        "arahata.linter-actionlint", // Github Action linting
         "xaver.clang-format", // Protobuf formatting
         "vadimcn.vscode-lldb", // Needed for Rust debugging
         "usernamehw.errorlens", // Not needed, very helpful


### PR DESCRIPTION
Removes `arahata.linter-actionlint` from `.vscode/extensions.json` as the 
publisher namespace `arahata` is unclaimed on the Open VSX registry.

VS Code derivatives that resolve extensions against Open VSX (VSCodium, 
Gitpod, Theia-based IDEs) will attempt to install whatever is published 
under this ID on Open VSX. Since the namespace is unregistered, any party 
can claim it and publish arbitrary code under this exact extension ID.

Developers can still use actionlint linting via the CLI directly or through 
an alternative extension with an active maintainer on Open VSX.