### PR TITLE
Security: Update rustls-webpki 0.103.10 → 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
Updates `rustls-webpki` from `0.103.10` to `0.103.12` to fix two security advisories that are currently breaking the `cargo-deny (advisories)` CI check on **all branches**.

## Security Advisories Fixed

### RUSTSEC-2026-0098 — Name constraints for URI names incorrectly accepted
- **Severity**: Name constraints for URI names were ignored and therefore accepted
- **Impact**: Requires misissuance to exploit (reachable only after signature verification)
- **Advisory**: [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5)

### RUSTSEC-2026-0099 — Name constraints accepted for wildcard certificates
- **Severity**: Permitted subtree name constraints for DNS names were accepted for certificates asserting a wildcard name
- **Impact**: Requires misissuance to exploit (reachable only after signature verification)
- **Advisory**: [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh)

## Changes
- **`Cargo.lock`**: Updated `rustls-webpki` version `0.103.10` → `0.103.12`
- Semver-compatible patch update — no code changes required
- Dependency chain: `rustls-webpki` ← `rustls` ← `hyper-rustls` / `reqwest` ← `dc_figma_import` / `dc_jni`

## Validation
- `cargo check -p dc_jni`: ✅
- `cargo check -p dc_figma_import`: ✅
- `cargo test -p dc_figma_import --lib`: ✅ (15 tests pass)
- This fix will turn `cargo-deny (advisories)` green across **all branches**