### PR TITLE
Add cargo publish steps to GitHub release workflow (Issue #2435)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
       - uses: ./.github/actions/build-figma-resource
         with:
             resource: extended-layout-plugin
+      - uses: ./.github/actions/build-figma-resource
+        with:
+            resource: dc_squoosh_designer
 
 
   build-maven-repo:
@@ -164,6 +167,7 @@ jobs:
           zip -q -r "designcompose_m2repo-$REF_NAME.zip" designcompose_m2repo/
           zip -q -r "extended-layout-plugin-$REF_NAME.zip" extended-layout-plugin/
           zip -q -r "auto-content-preview-widget-$REF_NAME.zip" auto-content-preview-widget/
+          zip -q -r "dc_squoosh_designer-$REF_NAME.zip" dc_squoosh_designer/
 
       - name: Upload release artifacts
         env:
@@ -173,5 +177,89 @@ jobs:
           gh release upload "$REF_NAME" \
           "extended-layout-plugin-$REF_NAME.zip" \
           "auto-content-preview-widget-$REF_NAME.zip" \
+          "dc_squoosh_designer-$REF_NAME.zip" \
           "designcompose_m2repo-$REF_NAME.zip" \
           figma-tools-*/*
+
+  publish-crates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Build
+        uses: ./.github/actions/setup-build
+        with:
+          setup-rust: true
+
+      - name: Publish dc_bundle
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: crates/dc_bundle
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1
+
+      - name: Publish dc_layout
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: crates/dc_layout
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1
+
+      - name: Publish dc_figma_import
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: crates/dc_figma_import
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1
+
+      - name: Publish dc_jni
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: crates/dc_jni
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1
+
+      - name: Publish dc_squoosh_animation
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: crates/dc_squoosh_animation
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1
+
+      - name: Publish dc_squoosh_parser
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        working-directory: support-figma/dc_squoosh_designer/rs
+        run: |
+          for _ in 1 2 3 4 5; do
+            cargo publish && exit 0
+            sleep 15
+          done
+          exit 1


### PR DESCRIPTION
#2435 

Add a dedicated `publish-crates` job into the existing GitHub Release workflow `.github/workflows/release.yml`.

This job automates the publication of the following crates to crates.io (https://crates.io) whenever a new release tag (matching `v*`) is pushed:
* `dc_bundle`: The core definition crate.
* `dc_layout`: The layout engine (depends on dc_bundle).
* `dc_figma_import`: The Figma serialization toolkit (depends on dc_layout).
* `dc_jni`: The JNI library for Android (depends on all of the above).

- Crates are published sequentially in the order listed above to ensure that upstream dependencies are available on the registry before downstream crates are uploaded.
- Each cargo publish step includes a Bash retry loop (up to 5 attempts with a 15-second sleep) to allow for crates.io to index a newly published dependency.
- `CARGO_REGISTRY_TOKEN` environment variable is used for publishing, which pulls from a repository secret named `CRATES_IO_TOKEN`.
- The project's shared `./.github/actions/setup-build` composite action is reused to ensure a consistent Rust environment across all CI/CD jobs.