### PR TITLE
Fix #436: Tutorial release build signing configuration

### DIFF
--- a/reference-apps/tutorial/app/build.gradle.kts
+++ b/reference-apps/tutorial/app/build.gradle.kts
@@ -51,6 +51,10 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
+            // Sign with the debug key so that Android Studio can build and
+            // launch the release variant. A production app should use its own
+            // signing key here.
+            signingConfig = signingConfigs.getByName("debug")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",


### PR DESCRIPTION
## Summary
Configure the release build type in the Tutorial reference app to use debug signing, fixing build failures when running release builds.

## Changes
- **reference-apps/tutorial/app/build.gradle.kts**: Added `signingConfig = signingConfigs.getByName("debug")` to the release build type.

## Testing
- Verified Gradle build succeeds for the tutorial app.

Fixes #436