### PR TITLE
Fix #244: Rotated node margin calculation uses pre-rotation size

### DIFF
--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -453,9 +453,9 @@ fn compute_layout(
                     (bounds.width().ceil(), bounds.height().ceil())
                 };
                 let left = (bounds.x() - parent_bounds.x()).round();
-                let right = parent_bounds.width().ceil() - (left + bounds.width().ceil()); // px from our right edge to parent's right edge
+                let right = parent_bounds.width().ceil() - (left + width); // px from our right edge to parent's right edge
                 let top = (bounds.y() - parent_bounds.y()).round();
-                let bottom = parent_bounds.height().ceil() - (top + bounds.height().ceil());
+                let bottom = parent_bounds.height().ceil() - (top + height);
 
                 match node.constraints().map(|c| c.horizontal) {
                     Some(figma_schema::HorizontalLayoutConstraintValue::Left) | None => {
@@ -2217,6 +2217,134 @@ mod tests {
         assert_eq!(
             view.style.unwrap().node_style.unwrap().flex_wrap,
             FlexWrap::FLEX_WRAP_WRAP.into()
+        );
+    }
+
+    /// Test that a 90° rotated child node with Left-Right + Top-Bottom constraints
+    /// computes correct right/bottom margins using node.size (pre-rotation) rather
+    /// than absoluteBoundingBox dimensions (post-rotation). Bug #244.
+    #[test]
+    fn test_rotated_node_constraint_margins() {
+        // A parent frame (200x200) containing a child frame (100x50) rotated 90°.
+        // When rotated 90°, the bounding box becomes 50x100 (swapped dimensions).
+        // The child is at position (25, 50) in the parent coordinate system post-rotation.
+        //
+        // Parent absolute bbox: (0, 0, 200, 200)
+        // Child absolute bbox:  (25, 50, 50, 100) -- post-rotation bounding box
+        // Child node.size:      (100, 50)          -- pre-rotation actual size
+        //
+        // For LEFT_RIGHT constraint:
+        //   left  = 25 - 0 = 25
+        //   right = 200 - (25 + node_width) = 200 - (25 + 100) = 75  (using pre-rotation)
+        //   right = 200 - (25 + 50) = 125   (WRONG, using post-rotation bbox width)
+        let json = r#"{
+            "id": "parent-1",
+            "name": "Parent",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+                "x": 0, "y": 0, "width": 200, "height": 200
+            },
+            "constraints": {
+                "vertical": "TOP",
+                "horizontal": "LEFT"
+            },
+            "children": [
+                {
+                    "id": "rotated-child-1",
+                    "name": "RotatedChild",
+                    "type": "FRAME",
+                    "constraints": {
+                        "vertical": "TOP_BOTTOM",
+                        "horizontal": "LEFT_RIGHT"
+                    },
+                    "absoluteBoundingBox": {
+                        "x": 25, "y": 50, "width": 50, "height": 100
+                    },
+                    "size": {
+                        "x": 100,
+                        "y": 50
+                    }
+                }
+            ]
+        }"#;
+
+        let node: figma_schema::Node = serde_json::from_str(json).unwrap();
+
+        let mut key_to_global_id_map = HashMap::new();
+        let mut component_context = ComponentContext::new(&vec![]);
+        let mut image_context = ImageContext::new(
+            HashMap::new(),
+            HashMap::new(),
+            &crate::proxy_config::ProxyConfig::None,
+        );
+
+        let parent_view = create_component_flexbox(
+            &node,
+            &HashMap::new(),
+            &HashMap::new(),
+            &mut component_context,
+            &mut image_context,
+            crate::document::HiddenNodePolicy::Keep,
+            &mut key_to_global_id_map,
+        )
+        .unwrap();
+
+        // Get the child view via pattern matching
+        let child_layout = if let Some(data) = parent_view.data.as_ref() {
+            if let Some(dc_bundle::view::view_data::View_data_type::Container(
+                dc_bundle::view::view_data::Container { children, .. }
+            )) = &data.view_data_type {
+                assert_eq!(children.len(), 1, "Parent should have one child");
+                children[0].style().layout_style().clone()
+            } else {
+                panic!("Parent should be a Container");
+            }
+        } else {
+            panic!("Parent should have data");
+        };
+
+        // LEFT_RIGHT constraint: width should be auto (stretch)
+        assert_eq!(
+            child_layout.width,
+            DimensionProto::new_auto(),
+            "Width should be auto for LEFT_RIGHT constraint"
+        );
+
+        // The right margin should be computed from the actual node width (100),
+        // not the rotated bounding box width (50).
+        // right = parent_width - (left + node_width) = 200 - (25 + 100) = 75
+        let right_margin = child_layout.margin.as_ref()
+            .and_then(|m| m.end.as_ref())
+            .and_then(|d| d.Dimension.as_ref())
+            .and_then(|d| match d {
+                dc_bundle::geometry::dimension_proto::Dimension::Points(p) => Some(p),
+                _ => None,
+            });
+        assert_eq!(
+            right_margin, Some(75.0_f32).as_ref(),
+            "Right margin should use pre-rotation node width (100), not rotated bbox width (50)"
+        );
+
+        // TOP_BOTTOM constraint: height should be auto (stretch)
+        assert_eq!(
+            child_layout.height,
+            DimensionProto::new_auto(),
+            "Height should be auto for TOP_BOTTOM constraint"
+        );
+
+        // The bottom margin should be computed from the actual node height (50),
+        // not the rotated bounding box height (100).
+        // bottom = parent_height - (top + node_height) = 200 - (50 + 50) = 100
+        let bottom_margin = child_layout.margin.as_ref()
+            .and_then(|m| m.bottom.as_ref())
+            .and_then(|d| d.Dimension.as_ref())
+            .and_then(|d| match d {
+                dc_bundle::geometry::dimension_proto::Dimension::Points(p) => Some(p),
+                _ => None,
+            });
+        assert_eq!(
+            bottom_margin, Some(100.0_f32).as_ref(),
+            "Bottom margin should use pre-rotation node height (50), not rotated bbox height (100)"
         );
     }
 }

--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -2292,8 +2292,9 @@ mod tests {
         // Get the child view via pattern matching
         let child_layout = if let Some(data) = parent_view.data.as_ref() {
             if let Some(dc_bundle::view::view_data::View_data_type::Container(
-                dc_bundle::view::view_data::Container { children, .. }
-            )) = &data.view_data_type {
+                dc_bundle::view::view_data::Container { children, .. },
+            )) = &data.view_data_type
+            {
                 assert_eq!(children.len(), 1, "Parent should have one child");
                 children[0].style().layout_style().clone()
             } else {
@@ -2313,7 +2314,9 @@ mod tests {
         // The right margin should be computed from the actual node width (100),
         // not the rotated bounding box width (50).
         // right = parent_width - (left + node_width) = 200 - (25 + 100) = 75
-        let right_margin = child_layout.margin.as_ref()
+        let right_margin = child_layout
+            .margin
+            .as_ref()
             .and_then(|m| m.end.as_ref())
             .and_then(|d| d.Dimension.as_ref())
             .and_then(|d| match d {
@@ -2321,7 +2324,8 @@ mod tests {
                 _ => None,
             });
         assert_eq!(
-            right_margin, Some(75.0_f32).as_ref(),
+            right_margin,
+            Some(75.0_f32).as_ref(),
             "Right margin should use pre-rotation node width (100), not rotated bbox width (50)"
         );
 
@@ -2335,7 +2339,9 @@ mod tests {
         // The bottom margin should be computed from the actual node height (50),
         // not the rotated bounding box height (100).
         // bottom = parent_height - (top + node_height) = 200 - (50 + 50) = 100
-        let bottom_margin = child_layout.margin.as_ref()
+        let bottom_margin = child_layout
+            .margin
+            .as_ref()
             .and_then(|m| m.bottom.as_ref())
             .and_then(|d| d.Dimension.as_ref())
             .and_then(|d| match d {
@@ -2343,7 +2349,8 @@ mod tests {
                 _ => None,
             });
         assert_eq!(
-            bottom_margin, Some(100.0_f32).as_ref(),
+            bottom_margin,
+            Some(100.0_f32).as_ref(),
             "Bottom margin should use pre-rotation node height (50), not rotated bbox height (100)"
         );
     }


### PR DESCRIPTION
## Summary
Fix margin calculation for rotated nodes by using the pre-rotation `node.size` instead of the post-rotation AABB bounding box dimensions.

## Changes
- **crates/dc_figma_import/src/transform_flexbox.rs**: Use `node.size` for constraint margin math on rotated nodes; added regression test.

## Testing
- New regression test added
- All 36 existing tests pass

Fixes #244