### PR TITLE
Fix #291: Progress marker alignment in nested instances

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
@@ -91,7 +91,7 @@ internal class SquooshResolvedNode(
             }
             val childProgressMarkerDescendant = child.findProgressMarkerDescendant()
             if (childProgressMarkerDescendant != null) {
-                return child
+                return childProgressMarkerDescendant
             }
             child = child.nextSibling
         }


### PR DESCRIPTION
## Summary
Fix `findProgressMarkerDescendant()` returning the wrong node when the progress marker is nested deeper than one level in component instances.

## Root Cause
When the progress marker was found recursively (not as a direct child), the function returned the intermediate `child` node instead of the actual `childProgressMarkerDescendant`. This caused incorrect alignment calculations.

## Changes
- **designcompose/.../squoosh/SquooshResolvedNode.kt**: Return `childProgressMarkerDescendant` instead of `child`.

## Testing
- Verified Kotlin compilation succeeds (BUILD SUCCESSFUL)

Fixes #291