### PR TITLE
Fix #154: Design switcher visibility behind overlays

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -886,7 +886,6 @@ fun SquooshRoot(
                 }
             },
         )
-        designSwitcher()
 
         for (overlay in composableList.overlayNodes) {
             val contentAlignment: Alignment =
@@ -932,6 +931,10 @@ fun SquooshRoot(
                 )
             }
         }
+
+        // Render design switcher AFTER overlays so it's always
+        // the topmost z-order element and remains visible.
+        designSwitcher()
     }
 }
 


### PR DESCRIPTION
## Summary
Fix the design switcher being hidden behind overlay composables (modals, bottom sheets, etc.).

## Root Cause
`designSwitcher()` was rendered BEFORE the overlay rendering loop. Overlays with `Modifier.fillMaxSize()` were drawn on top of the switcher, making it completely invisible and inaccessible.

## Changes
- **designcompose/.../squoosh/SquooshRoot.kt**: Move `designSwitcher()` to AFTER the overlay rendering loop so it's always the topmost z-order element.

## Testing
- Verified Kotlin compilation succeeds (BUILD SUCCESSFUL)

Fixes #154