### PR TITLE
Update DesignCompose version to 0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "dc_bundle"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "log",
  "protobuf",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "dc_figma_import"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "dc_jni"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "android_logger",
  "bytes",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "dc_layout"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "android_logger",
  "dc_bundle",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "dc_squoosh_animation"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "dc_bundle",
  "log",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "dc_squoosh_parser"
-version = "0.38.4"
+version = "0.39.0"
 dependencies = [
  "dc_squoosh_animation",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/dc_figma_import", "crates/dc_jni", "crates/dc_layout", "crate
 
 [workspace.package]
 # LINT.IfChange
-version = "0.38.4"
+version = "0.39.0"
 # LINT.ThenChange(gradle/libs.versions.toml)
 edition = "2021"
 authors = ["DesignCompose Team <aae-design-compose@google.com>"]
@@ -21,9 +21,12 @@ panic = 'abort'
 
 [workspace.dependencies]
 # dc_* crates specify a version because they are dependencies published on crates.io
-dc_bundle = { version = "0.38.4", path = "crates/dc_bundle" }
-dc_layout = { version = "0.38.4", path = "crates/dc_layout" }
-dc_figma_import = { version = "0.38.4", path = "crates/dc_figma_import" }
+dc_bundle = { version = "0.39.0", path = "crates/dc_bundle" }
+dc_layout = { version = "0.39.0", path = "crates/dc_layout" }
+dc_figma_import = { version = "0.39.0", path = "crates/dc_figma_import" }
+dc_jni = { version = "0.39.0", path = "crates/dc_jni" }
+dc_squoosh_animation = { version = "0.39.0", path = "crates/dc_squoosh_animation" }
+dc_squoosh_parser = { version = "0.39.0", path = "support-figma/dc_squoosh_designer/rs" }
 android_logger = "0.13.1"
 anyhow = "1.0"
 

--- a/crates/dc_squoosh_animation/Cargo.toml
+++ b/crates/dc_squoosh_animation/Cargo.toml
@@ -8,6 +8,6 @@ rust-version.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-dc_bundle = { path = "../dc_bundle" }
+dc_bundle.workspace = true
 thiserror = "1.0"
 log.workspace = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # DesignCompose
 # LINT.IfChange
-designcompose = "0.38.4-SNAPSHOT"
+designcompose = "0.39.0-SNAPSHOT"
 # LINT.ThenChange(Cargo.toml)
 
 

--- a/support-figma/dc_squoosh_designer/rs/Cargo.toml
+++ b/support-figma/dc_squoosh_designer/rs/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 log.workspace = true
-dc_squoosh_animation = { path = "../../../crates/dc_squoosh_animation" }
+dc_squoosh_animation.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
This commit bumps the version across all Gradle (`gradle/libs.versions.toml`) and Cargo configuration files to `0.39.0` (`0.39.0-SNAPSHOT` in Gradle). It also unifies the `dc_squoosh_animation` and `dc_squoosh_parser` crates under the workspace dependencies.

Changes and issues addressed since 0.38.4:
- Enhance LiveUpdate feature (Issues #2282, #2379)
- Add cargo publish steps to GitHub release workflow (Issues #2435, #2436)
- Squoosh Designer Plugin: Figma plugin for orchestrating layout animations (Issue #2402)
- Replace println!/eprintln! with Rust log API in library code (Issues #2403, #2411)
- Update dc_figma_import README to reflect current architecture (Issues #426, #2427)
- Add comprehensive unit tests for mergeStyles function (Issues #1963, #2416)
- Avoid double key events during animated transitions (Issues #1514, #2417)
- Clean up unwrap() calls in dc_jni crate (Issues #670, #2415)
- Security: Update rustls-webpki 0.103.10 -> 0.103.12 (Issue #2434)
- Document supported Android SDK levels (Issues #163, #2429)
- Restore Modifier customization support in squoosh renderer (Issues #2292, #2426)
- Handle unknown Figma features in deserialization (Issues #2305, #2414)
- Add adaptive polling with exponential backoff for LiveUpdate (Issues #2282, #2423)
- Add comprehensive Rust layout unit tests (Issues #405, #2413)
- Update JNI dependency to 0.22.4 and refactor dc_jni (Issue #2432)
- Enable CodeQL security scanning (Issues #926, #2412)
- Prevent Design Switcher from briefly showing 'Offline' (Issues #142, #2421)
- Stroke gradients account for stroke thickness (Issues #1549, #2420)
- Add performance logging for high-cost fetch operations (Issues #281, #2419)
- Remove unclaimed Open VSX extension recommendation (Issue #2431)
- Add assembleRelease to CI to catch minified build issues (Issues #435, #2425)
- Deprecate and remove publish_designcompose.sh script (Issue #2433)
- Clarify visibility documentation — parameter name is flexible (Issues #660, #2428)
- Add JDK installation instructions to Getting Started docs (Issues #707, #2424)
- Add security check for Figma token file permissions (Issues #249, #2418)
- Fix whilePressing interaction getting stuck on multi-touch drag (Issue #2422)
- Fix SquooshRoot infinite recomposition and freeze on rapid tap (Issue #2409)
