### PR TITLE
Formatting fixes, 0.39.2-RC02

### DIFF
--- a/crates/dc_figma_import/src/document.rs
+++ b/crates/dc_figma_import/src/document.rs
@@ -2142,7 +2142,6 @@ mod tests {
     fn test_compute_component_overrides_coverage() {
         use dc_bundle::positioning::ScrollInfo;
         use dc_bundle::view::view::RenderMethod;
-        use dc_bundle::view::view_data::View_data_type;
         use dc_bundle::view_shape::ViewShape;
         use std::collections::HashMap;
 

--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -2437,7 +2437,6 @@ mod tests {
             AlignItems::ALIGN_ITEMS_BASELINE.into()
         );
     }
-
     /// Test that a node with Left-Right + Top-Bottom constraints preserves
     /// its constraint anchoring even when fetched without a parent context
     /// (i.e. as a replacement content node).

--- a/crates/dc_figma_import/tests/animation_tests.rs
+++ b/crates/dc_figma_import/tests/animation_tests.rs
@@ -30,21 +30,18 @@ fn test_keyframes_present() {
         if let Some(style) = view.style.as_ref() {
             if let Some(node_style) = style.node_style.as_ref() {
                 if let Some(override_anim) = node_style.animation_override.as_ref() {
-                    if let Some(custom_value) = &override_anim.animation_override {
-                        match custom_value {
-                            animation_override::Animation_override::Custom(custom) => {
-                                for (prop, timeline) in &custom.custom_keyframe_data {
-                                    println!("Found timeline for prop: {} in view: {}", prop, name);
-                                    for kf in &timeline.keyframes {
-                                        println!(
-                                            "  Keyframe: fraction={}, value={:?}",
-                                            kf.fraction, kf.value
-                                        );
-                                        found_keyframes = true;
-                                    }
-                                }
+                    if let Some(animation_override::Animation_override::Custom(custom)) =
+                        &override_anim.animation_override
+                    {
+                        for (prop, timeline) in &custom.custom_keyframe_data {
+                            println!("Found timeline for prop: {} in view: {}", prop, name);
+                            for kf in &timeline.keyframes {
+                                println!(
+                                    "  Keyframe: fraction={}, value={:?}",
+                                    kf.fraction, kf.value
+                                );
+                                found_keyframes = true;
                             }
-                            _ => {}
                         }
                     }
                 }

--- a/crates/dc_figma_import/tests/layout_tests.rs
+++ b/crates/dc_figma_import/tests/layout_tests.rs
@@ -36,7 +36,6 @@ use dc_bundle::view::view_data::View_data_type::Text;
 use dc_bundle::view::View;
 use dc_layout::LayoutManager;
 use protobuf::Enum;
-use std::collections::HashMap;
 
 fn measure_func(
     layout_id: i32,
@@ -69,12 +68,10 @@ fn add_view_to_layout(
     id: &mut i32,
     parent_layout_id: i32,
     child_index: i32,
-    replacements: &HashMap<String, String>,
-    views: &HashMap<NodeQuery, View>,
 ) {
     //println!("add_view_to_layout {}, {}, {}, {}", view.name, id, parent_layout_id, child_index);
-    let my_id: i32 = id.clone();
-    *id = *id + 1;
+    let my_id: i32 = *id;
+    *id += 1;
     let data: &View_data_type = view.data.as_ref().unwrap().view_data_type.as_ref().unwrap();
 
     if let Text { .. } = data {
@@ -137,10 +134,8 @@ fn add_view_to_layout(
                 None,
             )
             .unwrap();
-        let mut index = 0;
-        for child in children {
-            add_view_to_layout(child, manager, id, my_id, index, replacements, views);
-            index = index + 1;
+        for (index, child) in children.iter().enumerate() {
+            add_view_to_layout(child, manager, id, my_id, index as i32);
         }
     }
 
@@ -160,15 +155,7 @@ fn load_view(node_name: &str, doc: &DesignComposeDefinition) -> LayoutManager {
     let view = view_result.unwrap();
     let mut id = 0;
     let mut manager = LayoutManager::new(measure_func);
-    add_view_to_layout(
-        &view,
-        &mut manager,
-        &mut id,
-        -1,
-        -1,
-        &HashMap::new(),
-        &doc.views().unwrap(),
-    );
+    add_view_to_layout(view, &mut manager, &mut id, -1, -1);
     manager
 }
 

--- a/crates/dc_figma_import/tests/live_update_tests.rs
+++ b/crates/dc_figma_import/tests/live_update_tests.rs
@@ -369,7 +369,7 @@ mod phase3_node_tracker {
             tracker.track(page_id, page_name, &children);
         }
 
-        assert!(tracker.len() > 0, "Should have tracked at least one page");
+        assert!(!tracker.is_empty(), "Should have tracked at least one page");
 
         // Self-diff should show no changes
         let same_nodes: Vec<_> = pages
@@ -452,7 +452,7 @@ mod phase4_library_resolver {
 
         // Check for alias variables
         let has_alias = variables.values().any(|v| {
-            v["valuesByMode"].as_object().map_or(false, |modes| {
+            v["valuesByMode"].as_object().is_some_and(|modes| {
                 modes.values().any(|val| {
                     val.is_object()
                         && val.get("type").and_then(|t| t.as_str()) == Some("VARIABLE_ALIAS")
@@ -615,7 +615,7 @@ mod e2e_pipeline {
         };
 
         // Time sequential vs concurrent fetches
-        let urls: Vec<String> = vec![DOC_DESIGN_SWITCHER, DOC_VARIABLES_TEST]
+        let urls: Vec<String> = [DOC_DESIGN_SWITCHER, DOC_VARIABLES_TEST]
             .iter()
             .map(|id| format!("https://api.figma.com/v1/files/{}?depth=1", id))
             .collect();

--- a/crates/dc_layout/src/debug.rs
+++ b/crates/dc_layout/src/debug.rs
@@ -105,7 +105,6 @@ impl DumpAsCss for taffy::Display {
         match self {
             Display::Flex => "flex",
             Display::None => "none",
-            _ => "unknown",
         }
         .to_string()
     }

--- a/crates/dc_layout/src/into_taffy/dimension_rect.rs
+++ b/crates/dc_layout/src/into_taffy/dimension_rect.rs
@@ -72,12 +72,13 @@ mod tests {
     use dc_bundle::geometry::DimensionProto;
 
     fn create_test_dimension_rect() -> DimensionRect {
-        let mut rect = DimensionRect::default();
-        rect.start = DimensionProto::new_points(10.0);
-        rect.end = DimensionProto::new_points(20.0);
-        rect.top = DimensionProto::new_points(30.0);
-        rect.bottom = DimensionProto::new_points(40.0);
-        rect
+        DimensionRect {
+            start: DimensionProto::new_points(10.0),
+            end: DimensionProto::new_points(20.0),
+            top: DimensionProto::new_points(30.0),
+            bottom: DimensionProto::new_points(40.0),
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/crates/dc_layout/src/layout_manager.rs
+++ b/crates/dc_layout/src/layout_manager.rs
@@ -686,7 +686,7 @@ mod tests {
             layout_manager.taffy.children(*parent_node_after_remove).unwrap();
         assert_eq!(children_after_remove.len(), 0);
 
-        assert!(layout_manager.layout_id_to_taffy_node.get(&child_id).is_none());
+        assert!(!layout_manager.layout_id_to_taffy_node.contains_key(&child_id));
     }
 
     #[test]
@@ -767,7 +767,7 @@ mod tests {
         let children_before = layout_manager.taffy.children(*parent_node).unwrap();
         assert_eq!(children_before.len(), 0);
 
-        layout_manager.update_children(parent_id, &vec![child1_id, child2_id]);
+        layout_manager.update_children(parent_id, &[child1_id, child2_id]);
 
         let parent_node_after = layout_manager.layout_id_to_taffy_node.get(&parent_id).unwrap();
         let children_after = layout_manager.taffy.children(*parent_node_after).unwrap();
@@ -1173,7 +1173,7 @@ mod tests {
         lm.compute_node_layout(1);
         assert_eq!(lm.get_node_layout(2).unwrap().left, 0.0);
         assert_eq!(lm.get_node_layout(3).unwrap().left, 60.0);
-        lm.update_children(1, &vec![3, 2]);
+        lm.update_children(1, &[3, 2]);
         lm.compute_node_layout(1);
         assert_eq!(lm.get_node_layout(3).unwrap().left, 0.0);
         assert_eq!(lm.get_node_layout(2).unwrap().left, 80.0);

--- a/crates/dc_squoosh_animation/src/lib.rs
+++ b/crates/dc_squoosh_animation/src/lib.rs
@@ -19,8 +19,9 @@ use std::sync::Arc;
 // --- High Level Runtime Types ---
 
 /// Supported easing functions for interpolation.
-#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize, Deserialize, Default)]
 pub enum Easing {
+    #[default]
     Inherit,
     Linear,
     Instant,
@@ -31,12 +32,6 @@ pub enum Easing {
     EaseOutCubic,
     EaseInOutCubic,
     CubicBezier(f32, f32, f32, f32),
-}
-
-impl Default for Easing {
-    fn default() -> Self {
-        Easing::Inherit
-    }
 }
 
 impl Easing {

--- a/support-figma/dc_squoosh_designer/rs/src/lib.rs
+++ b/support-figma/dc_squoosh_designer/rs/src/lib.rs
@@ -277,10 +277,7 @@ impl PropertyLookup {
             if let Some((node, prop)) = clean_key.rsplit_once('-') {
                 let property = prop.parse::<AnimatableProperty>().unwrap();
                 if let Ok(parsed) = ParsedTimelineData::parse(val) {
-                    temp_timelines
-                        .entry(node.to_string())
-                        .or_insert_with(NodeTimelines::default)
-                        .insert(property, parsed);
+                    temp_timelines.entry(node.to_string()).or_default().insert(property, parsed);
                 }
             }
         }


### PR DESCRIPTION
This PR applies several code quality (clippy) and formatting (rustfmt) fixes to various Rust crates in the workspace to clean up warnings and ensure consistent formatting.

These fixes were identified during conflict resolution for the stable release PR. Applying them to `main` keeps the branches in sync and prevents future PRs from failing CI due to pre-existing warnings.
