### PR TITLE
Preserve swapped component instances when parent variant changes

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshAnimate.kt
@@ -606,6 +606,7 @@ private fun SquooshResolvedNode.cloneSelf(parent: SquooshResolvedNode?): Squoosh
         layoutId = this.layoutId,
         textInfo = this.textInfo,
         unresolvedNodeId = this.unresolvedNodeId,
+        unresolvedName = this.unresolvedName,
         layoutNode = this,
         parent = parent,
         computedLayout = this.computedLayout,

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
@@ -95,7 +95,8 @@ internal fun Modifier.progressBarSlider(
             val pbNode = node.findProgressBarChild()
             val pbMeterData = pbNode?.style?.getProgressBarData()
             pbMeterData?.let {
-                val progressChanged = customizations.getOnProgressChangedCallback(pbNode.view.name)
+                val progressChanged =
+                    customizations.getOnProgressChangedCallback(pbNode.unresolvedName)
                 val progress: Float
                 if (it.vertical) {
                     val startY = it.startY * density
@@ -110,13 +111,14 @@ internal fun Modifier.progressBarSlider(
                 }
                 progressChanged?.onProgressChanged(progress)
                 meterState.value = progress
-                customizations.setMeterState(pbNode.view.name, meterState)
+                customizations.setMeterState(pbNode.unresolvedName, meterState)
             }
 
             val pmNode = node.findProgressMarkerDescendant()
             val pmMeterData = pmNode?.style?.getProgressMarkerData()
             pmMeterData?.let {
-                val progressChanged = customizations.getOnProgressChangedCallback(pmNode.view.name)
+                val progressChanged =
+                    customizations.getOnProgressChangedCallback(pmNode.unresolvedName)
                 val progress: Float
                 if (it.vertical) {
                     val startY = it.startY * density
@@ -131,7 +133,7 @@ internal fun Modifier.progressBarSlider(
                 }
                 progressChanged?.onProgressChanged(progress)
                 meterState.value = progress
-                customizations.setMeterState(pmNode.view.name, meterState)
+                customizations.setMeterState(pmNode.unresolvedName, meterState)
             }
         }
 
@@ -279,7 +281,8 @@ internal fun Modifier.squooshInteraction(
         androidx.compose.runtime.rememberUpdatedState(childComposable.node.view.reactionsList)
     val latestTapCallback by
         androidx.compose.runtime.rememberUpdatedState(
-            customizations.getTapCallback(childComposable.node.view)
+            customizations.getTapCallback(childComposable.node.unresolvedName)
+                ?: customizations.getTapCallback(childComposable.node.view)
         )
     val latestParentComponents by
         androidx.compose.runtime.rememberUpdatedState(childComposable.parentComponents)

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshListWidget.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshListWidget.kt
@@ -289,7 +289,7 @@ private fun addGridContent(
             val density = LocalDensity.current.density
             val lazyGridState = rememberLazyGridState()
             val setScrollableStateCallback =
-                customizations.getScrollCallbacks(resolvedView.view.name)?.setScrollableState
+                customizations.getScrollCallbacks(resolvedView.unresolvedName)?.setScrollableState
             LaunchedEffect(lazyGridState, setScrollableStateCallback) {
                 setScrollableStateCallback?.invoke(lazyGridState)
             }

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
@@ -125,8 +125,8 @@ internal fun Modifier.squooshRender(
                     node.parent?.let {
                         // Don't scroll for custom list content since it scrolled in layout
                         val customContent =
-                            customizations.getContent(it.view.name) != null ||
-                                customizations.getListContent(it.view.name) != null
+                            customizations.getContent(it.unresolvedName) != null ||
+                                customizations.getListContent(it.unresolvedName) != null
                         scroll = !customContent && it.view == parentNode
                     }
                     if (scroll) {
@@ -199,7 +199,7 @@ internal fun Modifier.squooshRender(
                             shaderBrushCache,
                             appContext,
                         ) {
-                            val shapeInsets = customizations.getWindowInsets(node.view.name)
+                            val shapeInsets = customizations.getWindowInsets(node.unresolvedName)
                             val topInset = shapeInsets?.getTop(this) ?: 0
                             val leftInset = shapeInsets?.getLeft(this, layoutDirection) ?: 0
 

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
@@ -37,6 +37,7 @@ internal class SquooshResolvedNode(
     val textInfo: TextMeasureData?,
     // The node id before we resolved variants; used for interactions
     val unresolvedNodeId: String,
+    val unresolvedName: String = view.name,
     // The node we look at for layout info, if we're in a tree that was derived
     // from other trees (i.e.: the tree that combines the base and transition
     // trees).

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
@@ -125,10 +125,12 @@ internal fun squooshComputeTextInfo(
     appContext: Context,
     textMeasureCache: TextMeasureCache,
     textHash: HashSet<String>,
+    customizedNodeName: String = v.name,
 ): Pair<TextMeasureData?, TextStyle>? {
     val customizedText =
-        customizations.getText(v.name) ?: customizations.getTextState(v.name)?.value
-    val customTextStyle = customizations.getTextStyle(v.name)
+        customizations.getText(customizedNodeName)
+            ?: customizations.getTextState(customizedNodeName)?.value
+    val customTextStyle = customizations.getTextStyle(customizedNodeName)
     val fontFamily =
         DesignSettings.fontFamily(v.style.nodeStyle.takeIf { it.hasFontFamily() }?.fontFamily)
 
@@ -151,7 +153,7 @@ internal fun squooshComputeTextInfo(
 
     // Evaluate the custom brush BEFORE the cache check so that
     // brush function changes (e.g., from State updates) invalidate the cache.
-    val customBrush = customizations.getBrush(v.name)
+    val customBrush = customizations.getBrush(customizedNodeName)
 
     val cachedText = textMeasureCache.get(layoutId)
     if (

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -319,6 +319,7 @@ internal fun resolveVariantsRecursively(
             appContext,
             textMeasureCache,
             textHash,
+            customizedNodeName = viewFromTree.name,
         )
     val textInfo = textData?.first
     val textStyle = textData?.second
@@ -347,7 +348,8 @@ internal fun resolveVariantsRecursively(
             }
         }
     }
-    val tapCallback = customizations.getTapCallback(view)
+    var tapCallback = customizations.getTapCallback(viewFromTree.name)
+    if (tapCallback == null) tapCallback = customizations.getTapCallback(view)
     if (tapCallback != null) hasSupportedInteraction = true
     if (textInfo?.hyperlinkOffsetMap?.isNotEmpty() == true) hasSupportedInteraction = true
     val progressChildTouch = view.getProgressChildWithTouch(customizations)
@@ -357,13 +359,21 @@ internal fun resolveVariantsRecursively(
 
     // If this node has a content customization, then we make a special record of it so that we can
     // zip through all of them after layout and render them in the right location.
-    val replacementContent = customizations.getContent(view.name)
-    val replacementComponent = customizations.getComponent(view.name)
-    val listWidgetContent = customizations.getListContent(view.name)
+    val replacementContent = customizations.getContent(viewFromTree.name)
+    val replacementComponent = customizations.getComponent(viewFromTree.name)
+    val listWidgetContent = customizations.getListContent(viewFromTree.name)
 
     // If this is a text node being replaced, don't store textInfo into resolvedView
     val resolvedTextInfo = if (replacementComponent != null) null else textInfo
-    val resolvedView = SquooshResolvedNode(view, style, layoutId, resolvedTextInfo, viewFromTree.id)
+    val resolvedView =
+        SquooshResolvedNode(
+            view = view,
+            style = style,
+            layoutId = layoutId,
+            textInfo = resolvedTextInfo,
+            unresolvedNodeId = viewFromTree.id,
+            unresolvedName = viewFromTree.name,
+        )
 
     var skipChildren = false // Set to true for customizations that replace children
     var skipComposableList =

--- a/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTreeBuilderTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTreeBuilderTest.kt
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.designcompose.squoosh
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.unit.Density
+import androidx.test.core.app.ApplicationProvider
+import com.android.designcompose.*
+import com.android.designcompose.common.DesignDocId
+import com.android.designcompose.common.GenericDocContent
+import com.android.designcompose.common.VariantPropertyMap
+import com.android.designcompose.definition.DesignComposeDefinition
+import com.android.designcompose.definition.DesignComposeDefinitionHeader
+import com.android.designcompose.definition.view.View
+import com.android.designcompose.definition.view.ViewDataKt.container
+import com.android.designcompose.definition.view.componentInfo
+import com.android.designcompose.definition.view.view
+import com.android.designcompose.definition.view.viewData
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SquooshTreeBuilderTest {
+
+    private fun createDocContent(
+        rootView: View,
+        variantViewMap: HashMap<String, HashMap<String, View>> = HashMap(),
+        nodeIdMap: HashMap<String, View> = HashMap(),
+        variantPropertyMap: VariantPropertyMap = VariantPropertyMap(),
+    ): DocContent {
+        val docId = DesignDocId("dummy")
+        val header = DesignComposeDefinitionHeader.getDefaultInstance()
+        val document = DesignComposeDefinition.getDefaultInstance()
+        val imageSession = ByteString.EMPTY
+
+        val genericDocContent =
+            GenericDocContent(
+                docId,
+                header,
+                document,
+                variantViewMap,
+                variantPropertyMap,
+                nodeIdMap,
+                imageSession,
+            )
+        return DocContent(genericDocContent, null)
+    }
+
+    @Test
+    fun testComponentReplacementPreservedOnVariantChange() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val density = Density(1f)
+        val fontResolver = createFontFamilyResolver(context)
+
+        // 1. Create a child slot component "DefaultIcon"
+        val iconSlotComponentSetName = "DefaultIcon"
+        val iconSlotInstanceName = "#icon-slot"
+
+        // Child component views for DefaultIcon
+        val iconLightView = view {
+            uniqueId = 3
+            id = "icon-light-id"
+            name = "theme=Light"
+            componentInfo = componentInfo {
+                id = "icon-light-id"
+                name = "theme=Light"
+                componentSetName = iconSlotComponentSetName
+            }
+        }
+        val iconDarkView = view {
+            uniqueId = 4
+            id = "icon-dark-id"
+            name = "theme=Dark"
+            componentInfo = componentInfo {
+                id = "icon-dark-id"
+                name = "theme=Dark"
+                componentSetName = iconSlotComponentSetName
+            }
+        }
+
+        // 2. Create parent component "MyParent" with variants Light and Dark
+        val parentComponentSetName = "MyParent"
+        val parentLightView = view {
+            uniqueId = 1
+            id = "parent-light-id"
+            name = "theme=Light"
+            componentInfo = componentInfo {
+                id = "parent-light-id"
+                name = "theme=Light"
+                componentSetName = parentComponentSetName
+            }
+            data = viewData {
+                container = container {
+                    // It has child icon-slot-light
+                    children.add(
+                        view {
+                            uniqueId = 5
+                            id = "icon-slot-light-id"
+                            name = iconSlotInstanceName
+                            componentInfo = componentInfo {
+                                id = "icon-slot-light-id"
+                                name = "theme=Light"
+                                componentSetName = iconSlotComponentSetName
+                            }
+                        }
+                    )
+                }
+            }
+        }
+
+        val parentDarkView = view {
+            uniqueId = 2
+            id = "parent-dark-id"
+            name = "theme=Dark"
+            componentInfo = componentInfo {
+                id = "parent-dark-id"
+                name = "theme=Dark"
+                componentSetName = parentComponentSetName
+            }
+            data = viewData {
+                container = container {
+                    // It has child icon-slot-dark
+                    children.add(
+                        view {
+                            uniqueId = 6
+                            id = "icon-slot-dark-id"
+                            name = iconSlotInstanceName
+                            componentInfo = componentInfo {
+                                id = "icon-slot-dark-id"
+                                name = "theme=Light" // Default variant
+                                componentSetName = iconSlotComponentSetName
+                            }
+                        }
+                    )
+                }
+            }
+        }
+
+        // Populate doc maps
+        val variantViewMap = HashMap<String, HashMap<String, View>>()
+        val parentMap = HashMap<String, View>()
+        parentMap["theme=Light"] = parentLightView
+        parentMap["theme=Dark"] = parentDarkView
+        variantViewMap[parentComponentSetName] = parentMap
+
+        val iconMap = HashMap<String, View>()
+        iconMap["theme=Light"] = iconLightView
+        iconMap["theme=Dark"] = iconDarkView
+        variantViewMap[iconSlotComponentSetName] = iconMap
+
+        val variantPropertyMap = VariantPropertyMap()
+        variantPropertyMap.addProperty(parentComponentSetName, "theme", "Light")
+        variantPropertyMap.addProperty(parentComponentSetName, "theme", "Dark")
+        variantPropertyMap.addProperty(iconSlotComponentSetName, "theme", "Light")
+        variantPropertyMap.addProperty(iconSlotComponentSetName, "theme", "Dark")
+
+        val docContent =
+            createDocContent(
+                rootView = parentLightView,
+                variantViewMap = variantViewMap,
+                variantPropertyMap = variantPropertyMap,
+            )
+
+        // 3. Setup Customizations
+        val customizations = CustomizationContext()
+        customizations.setVariantProperties(hashMapOf("theme" to "Light"))
+
+        var replacementInvoked = false
+        val replacementComponent: @Composable (ComponentReplacementContext) -> Unit =
+            @Composable { _ -> replacementInvoked = true }
+        customizations.setComponent(iconSlotInstanceName, replacementComponent)
+
+        val variantTransition = SquooshVariantTransition()
+        val interactionState = InteractionState()
+        val keyTracker = KeyEventTracker()
+        val layoutIdAllocator = SquooshLayoutIdAllocator()
+
+        // ==========================================
+        // Phase 1: Render Light Variant (BasePhase)
+        // ==========================================
+        variantTransition.treeBuildPhase = TreeBuildPhase.BasePhase
+        val composableList1 = ComposableList()
+        val resolvedNode1 =
+            resolveVariantsRecursively(
+                viewFromTree = parentLightView,
+                document = docContent,
+                customizations = customizations,
+                variantTransition = variantTransition,
+                interactionState = interactionState,
+                keyTracker = keyTracker,
+                parentComponents = null,
+                density = density,
+                fontResolver = fontResolver,
+                composableList = composableList1,
+                layoutIdAllocator = layoutIdAllocator,
+                isRoot = true,
+                variableState = VariableState(),
+                appContext = context,
+                customVariantTransition = null,
+                textMeasureCache = TextMeasureCache(),
+                textHash = HashSet(),
+            )
+
+        assertThat(resolvedNode1).isNotNull()
+        val child1 =
+            composableList1.childComposables.find { it.node.unresolvedName == iconSlotInstanceName }
+        assertThat(child1).isNotNull()
+        assertThat(child1!!.component).isEqualTo(replacementComponent)
+
+        // Cycle layout IDs
+        layoutIdAllocator.removalNodes()
+
+        // ==========================================
+        // Phase 2: Start transition to Dark variant
+        // ==========================================
+        customizations.setVariantProperties(hashMapOf("theme" to "Dark"))
+
+        // Run BasePhase pass of Phase 2 (this registers the transition)
+        variantTransition.treeBuildPhase = TreeBuildPhase.BasePhase
+        val composableList2Base = ComposableList()
+        resolveVariantsRecursively(
+            viewFromTree = parentLightView,
+            document = docContent,
+            customizations = customizations,
+            variantTransition = variantTransition,
+            interactionState = interactionState,
+            keyTracker = keyTracker,
+            parentComponents = null,
+            density = density,
+            fontResolver = fontResolver,
+            composableList = composableList2Base,
+            layoutIdAllocator = layoutIdAllocator,
+            isRoot = true,
+            variableState = VariableState(),
+            appContext = context,
+            customVariantTransition = null,
+            textMeasureCache = TextMeasureCache(),
+            textHash = HashSet(),
+        )
+
+        // Cycle layout IDs
+        layoutIdAllocator.removalNodes()
+
+        // Run TransitionTargetPhase of Phase 2
+        variantTransition.treeBuildPhase = TreeBuildPhase.TransitionTargetPhase
+        val composableList2Target = ComposableList()
+        resolveVariantsRecursively(
+            viewFromTree = parentLightView,
+            document = docContent,
+            customizations = customizations,
+            variantTransition = variantTransition,
+            interactionState = interactionState,
+            keyTracker = keyTracker,
+            parentComponents = null,
+            density = density,
+            fontResolver = fontResolver,
+            composableList = composableList2Target,
+            layoutIdAllocator = layoutIdAllocator,
+            isRoot = true,
+            variableState = VariableState(),
+            appContext = context,
+            customVariantTransition = null,
+            textMeasureCache = TextMeasureCache(),
+            textHash = HashSet(),
+        )
+
+        // Complete the transition
+        variantTransition.afterRenderPhases()
+        // Cycle layout IDs
+        layoutIdAllocator.removalNodes()
+
+        // ==========================================
+        // Phase 3: Final Stable Dark variant (BasePhase)
+        // ==========================================
+        variantTransition.treeBuildPhase = TreeBuildPhase.BasePhase
+        val composableList3 = ComposableList()
+        val resolvedNode3 =
+            resolveVariantsRecursively(
+                viewFromTree = parentLightView,
+                document = docContent,
+                customizations = customizations,
+                variantTransition = variantTransition,
+                interactionState = interactionState,
+                keyTracker = keyTracker,
+                parentComponents = null,
+                density = density,
+                fontResolver = fontResolver,
+                composableList = composableList3,
+                layoutIdAllocator = layoutIdAllocator,
+                isRoot = true,
+                variableState = VariableState(),
+                appContext = context,
+                customVariantTransition = null,
+                textMeasureCache = TextMeasureCache(),
+                textHash = HashSet(),
+            )
+
+        assertThat(resolvedNode3).isNotNull()
+        // Verify child replacement component is STILL added to composable list in Dark variant
+        val child3 =
+            composableList3.childComposables.find { it.node.unresolvedName == iconSlotInstanceName }
+        assertThat(child3).isNotNull()
+        assertThat(child3!!.component).isEqualTo(replacementComponent)
+    }
+}


### PR DESCRIPTION
Fixes an issue where child slot replacements (instance swaps) were reset to their default components when the parent component's variant changed.
**Changes:**
- Added `unresolvedName` tracking to `SquooshResolvedNode`.
- Updated customization lookups (for components, content, tap callbacks, etc.) in `SquooshTreeBuilder`, `SquooshRender`, and `SquooshInteraction` to prioritize looking up customizations using the original unresolved instance name instead of the resolved variant name.
- Added `SquooshTreeBuilderTest.testComponentReplacementPreservedOnVariantChange` to verify instance swap preservation.