### PR TITLE
Fix component collapse on variant switch in Squoosh

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -94,6 +94,7 @@ import com.android.designcompose.utils.getProgressChildWithTouch
 import com.android.designcompose.utils.hasScrolling
 import com.android.designcompose.utils.isSupportedInteraction
 import com.android.designcompose.utils.mergeStyles
+import com.android.designcompose.utils.mergeStylesWithVariant
 
 // Helper class to hold the list of child composables and overlays that need to be composed
 // separately.
@@ -213,6 +214,8 @@ internal fun resolveVariantsRecursively(
     var overrideViewData: ViewData? = null
     var view = viewFromTree
 
+    var defaultVariantView: View? = null
+
     // If we have a component then we might need to get an override style, and we definitely
     // need to get a different layout id.
     if (viewFromTree.hasComponentInfo()) {
@@ -227,6 +230,17 @@ internal fun resolveVariantsRecursively(
             viewFromTree.componentInfo.overridesTableMap[
                     viewFromTree.componentInfo.componentSetName]
                 ?.viewDataOrNull
+
+        defaultVariantView =
+            interactionState.squooshRootNode(
+                NodeQuery.NodeVariant(
+                    viewFromTree.componentInfo.name,
+                    viewFromTree.componentInfo.componentSetName,
+                ),
+                document,
+                isRoot,
+                customizations,
+            )
 
         // Ensure that the children of this component get unique layout ids, even though there
         // may be multiple instances of the same component in one tree.
@@ -293,6 +307,13 @@ internal fun resolveVariantsRecursively(
     val style =
         if (overrideStyle == null) {
             view.style
+        } else if (defaultVariantView != null) {
+            mergeStylesWithVariant(
+                view.style,
+                overrideStyle,
+                viewFromTree.style,
+                defaultVariantView.style,
+            )
         } else {
             // XXX-PERF: This is not needed by Battleship, and takes over 50% of the runtime of
             //           resolveVariants (not including computeTextInfo).

--- a/designcompose/src/main/java/com/android/designcompose/utils/ViewStyleUtils.kt
+++ b/designcompose/src/main/java/com/android/designcompose/utils/ViewStyleUtils.kt
@@ -44,6 +44,104 @@ import com.android.designcompose.definition.view.nodeSizeOrNull
 import com.android.designcompose.definition.view.strokeOrNull
 import com.android.designcompose.definition.view.viewStyle
 
+// Merge styles, but restore target variant layout style properties if they were not explicitly
+// overridden on the component instance.
+internal fun mergeStylesWithVariant(
+    base: ViewStyle,
+    override: ViewStyle,
+    instanceStyle: ViewStyle,
+    defaultVariantStyle: ViewStyle,
+): ViewStyle {
+    val merged = mergeStyles(base, override)
+
+    return merged.copy {
+        val originalLayoutStyle = defaultVariantStyle.layoutStyle
+        val instLayoutStyle = instanceStyle.layoutStyle
+
+        val isWidthOverridden = instLayoutStyle.width != originalLayoutStyle.width
+        val isHeightOverridden = instLayoutStyle.height != originalLayoutStyle.height
+        val isMinWidthOverridden = instLayoutStyle.minWidth != originalLayoutStyle.minWidth
+        val isMinHeightOverridden = instLayoutStyle.minHeight != originalLayoutStyle.minHeight
+        val isMaxWidthOverridden = instLayoutStyle.maxWidth != originalLayoutStyle.maxWidth
+        val isMaxHeightOverridden = instLayoutStyle.maxHeight != originalLayoutStyle.maxHeight
+        val isPositionTypeOverridden =
+            instLayoutStyle.positionType != originalLayoutStyle.positionType
+        val isAlignSelfOverridden = instLayoutStyle.alignSelf != originalLayoutStyle.alignSelf
+        val isFlexGrowOverridden = instLayoutStyle.flexGrow != originalLayoutStyle.flexGrow
+        val isFlexShrinkOverridden = instLayoutStyle.flexShrink != originalLayoutStyle.flexShrink
+        val isFlexBasisOverridden = instLayoutStyle.flexBasis != originalLayoutStyle.flexBasis
+        val isMarginOverridden = instLayoutStyle.margin != originalLayoutStyle.margin
+        val isPaddingOverridden = instLayoutStyle.padding != originalLayoutStyle.padding
+
+        if (
+            !isWidthOverridden ||
+                !isHeightOverridden ||
+                !isMinWidthOverridden ||
+                !isMinHeightOverridden ||
+                !isMaxWidthOverridden ||
+                !isMaxHeightOverridden ||
+                !isPositionTypeOverridden ||
+                !isAlignSelfOverridden ||
+                !isFlexGrowOverridden ||
+                !isFlexShrinkOverridden ||
+                !isFlexBasisOverridden ||
+                !isMarginOverridden ||
+                !isPaddingOverridden
+        ) {
+            layoutStyle =
+                layoutStyle.copy {
+                    if (!isWidthOverridden) {
+                        width = base.layoutStyle.width
+                    }
+                    if (!isHeightOverridden) {
+                        height = base.layoutStyle.height
+                    }
+                    val newW =
+                        if (isWidthOverridden) boundingBox.width
+                        else base.layoutStyle.boundingBox.width
+                    val newH =
+                        if (isHeightOverridden) boundingBox.height
+                        else base.layoutStyle.boundingBox.height
+                    boundingBox =
+                        com.android.designcompose.definition.element.size {
+                            width = newW
+                            height = newH
+                        }
+                    if (!isMinWidthOverridden) minWidth = base.layoutStyle.minWidth
+                    if (!isMinHeightOverridden) minHeight = base.layoutStyle.minHeight
+                    if (!isMaxWidthOverridden) maxWidth = base.layoutStyle.maxWidth
+                    if (!isMaxHeightOverridden) maxHeight = base.layoutStyle.maxHeight
+                    if (!isPositionTypeOverridden) positionType = base.layoutStyle.positionType
+                    if (!isAlignSelfOverridden) alignSelf = base.layoutStyle.alignSelf
+                    if (!isFlexGrowOverridden) flexGrow = base.layoutStyle.flexGrow
+                    if (!isFlexShrinkOverridden) flexShrink = base.layoutStyle.flexShrink
+                    if (!isFlexBasisOverridden) flexBasis = base.layoutStyle.flexBasis
+                    if (!isMarginOverridden) margin = base.layoutStyle.margin
+                    if (!isPaddingOverridden) padding = base.layoutStyle.padding
+                }
+        }
+
+        val originalNodeStyle = defaultVariantStyle.nodeStyle
+        val instNodeStyle = instanceStyle.nodeStyle
+
+        val isHorizontalSizingOverridden =
+            instNodeStyle.horizontalSizing != originalNodeStyle.horizontalSizing
+        val isVerticalSizingOverridden =
+            instNodeStyle.verticalSizing != originalNodeStyle.verticalSizing
+        val isNodeSizeOverridden = instNodeStyle.nodeSize != originalNodeStyle.nodeSize
+
+        if (!isHorizontalSizingOverridden || !isVerticalSizingOverridden || !isNodeSizeOverridden) {
+            nodeStyle =
+                nodeStyle.copy {
+                    if (!isHorizontalSizingOverridden)
+                        horizontalSizing = base.nodeStyle.horizontalSizing
+                    if (!isVerticalSizingOverridden) verticalSizing = base.nodeStyle.verticalSizing
+                    if (!isNodeSizeOverridden) nodeSize = base.nodeStyle.nodeSize
+                }
+        }
+    }
+}
+
 // Merge styles; any non-default properties of the override style are copied over the base style.
 // TODO: look into if we can use proto's own merge functionalities.
 internal fun mergeStyles(base: ViewStyle, override: ViewStyle): ViewStyle {

--- a/designcompose/src/test/kotlin/com/android/designcompose/MergeStylesTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/MergeStylesTest.kt
@@ -32,6 +32,7 @@ import com.android.designcompose.definition.view.Display
 import com.android.designcompose.definition.view.nodeStyle
 import com.android.designcompose.definition.view.viewStyle
 import com.android.designcompose.utils.mergeStyles
+import com.android.designcompose.utils.mergeStylesWithVariant
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -247,5 +248,105 @@ class MergeStylesTest {
         assertThat(merged.nodeStyle.blendMode).isEqualTo(BlendMode.BLEND_MODE_SCREEN)
         // Base value preserved
         assertThat(merged.layoutStyle.flexGrow).isEqualTo(1.0f)
+    }
+
+    @Test
+    fun testMergeStylesWithVariantNotOverridden() {
+        val base = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 200f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 200f
+                        height = 50f
+                    }
+            }
+        }
+        val override = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 100f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 100f
+                        height = 40f
+                    }
+            }
+        }
+        val instanceStyle = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 100f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 100f
+                        height = 40f
+                    }
+            }
+        }
+        val defaultVariantStyle = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 100f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 100f
+                        height = 40f
+                    }
+            }
+        }
+
+        val merged = mergeStylesWithVariant(base, override, instanceStyle, defaultVariantStyle)
+        // Width should be restored to base because it was not overridden on the instance (instance
+        // == defaultVariant)
+        assertThat(merged.layoutStyle.width.points).isEqualTo(200f)
+        assertThat(merged.layoutStyle.boundingBox.width).isEqualTo(200f)
+    }
+
+    @Test
+    fun testMergeStylesWithVariantOverridden() {
+        val base = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 200f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 200f
+                        height = 50f
+                    }
+            }
+        }
+        val override = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 120f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 120f
+                        height = 40f
+                    }
+            }
+        }
+        val instanceStyle = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 120f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 120f
+                        height = 40f
+                    }
+            }
+        }
+        val defaultVariantStyle = viewStyle {
+            layoutStyle = layoutStyle {
+                width = dimensionProto { points = 100f }
+                boundingBox =
+                    com.android.designcompose.definition.element.size {
+                        width = 100f
+                        height = 40f
+                    }
+            }
+        }
+
+        val merged = mergeStylesWithVariant(base, override, instanceStyle, defaultVariantStyle)
+        // Width should be override style (120f) because it was explicitly overridden on the
+        // instance (instance != defaultVariant)
+        assertThat(merged.layoutStyle.width.points).isEqualTo(120f)
+        assertThat(merged.layoutStyle.boundingBox.width).isEqualTo(120f)
     }
 }


### PR DESCRIPTION
Fixes an issue where switching a variant caused the default variant's dimensions to override the target variant's dimensions, leading to layout collapse.

**Changes:**
- Added `mergeStylesWithVariant` during style resolution to compare layout properties and ensure that the switched variant's styling is preserved if the property was not explicitly overridden on the component instance.
- Added `MergeStylesTest` (`testMergeStylesWithVariantNotOverridden` and `testMergeStylesWithVariantOverridden`) to verify styling priority during variant changes.