### PR TITLE
Fix fontFamily customization in Squoosh

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
@@ -130,7 +130,8 @@ internal fun squooshComputeTextInfo(
         customizations.getText(v.name) ?: customizations.getTextState(v.name)?.value
     val customTextStyle = customizations.getTextStyle(v.name)
     val fontFamily =
-        DesignSettings.fontFamily(v.style.nodeStyle.takeIf { it.hasFontFamily() }?.fontFamily)
+        customTextStyle?.fontFamily
+            ?: DesignSettings.fontFamily(v.style.nodeStyle.takeIf { it.hasFontFamily() }?.fontFamily)
 
     // Compose only supports a single outset shadow on text; we must use a canvas and perform
     // manual text layout (and editing, and accessibility) to do fancier text.

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshText.kt
@@ -131,7 +131,9 @@ internal fun squooshComputeTextInfo(
     val customTextStyle = customizations.getTextStyle(v.name)
     val fontFamily =
         customTextStyle?.fontFamily
-            ?: DesignSettings.fontFamily(v.style.nodeStyle.takeIf { it.hasFontFamily() }?.fontFamily)
+            ?: DesignSettings.fontFamily(
+                v.style.nodeStyle.takeIf { it.hasFontFamily() }?.fontFamily
+            )
 
     // Compose only supports a single outset shadow on text; we must use a canvas and perform
     // manual text layout (and editing, and accessibility) to do fancier text.

--- a/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTextTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTextTest.kt
@@ -97,16 +97,10 @@ class SquooshTextTest {
                 nodeStyle = nodeStyle {
                     fontFamily = fontFamilyName
                     fontSize = numOrVar { num = 12f }
-                    fontWeight = fontWeight {
-                        weight = numOrVar { num = 400f }
-                    }
+                    fontWeight = fontWeight { weight = numOrVar { num = 400f } }
                 }
             }
-            data = viewData {
-                text = text {
-                    content = "Hello"
-                }
-            }
+            data = viewData { text = text { content = "Hello" } }
         }
     }
 
@@ -119,19 +113,20 @@ class SquooshTextTest {
         // Register FigmaFont in DesignSettings
         DesignSettings.addFontFamily("FigmaFont", FontFamily.SansSerif)
 
-        val result = squooshComputeTextInfo(
-            v = view,
-            overrideViewData = null,
-            layoutId = 1,
-            density = Density(1f),
-            document = docContent,
-            customizations = customizations,
-            fontResolver = fontResolver,
-            variableState = variableState,
-            appContext = context,
-            textMeasureCache = textMeasureCache,
-            textHash = textHash
-        )
+        val result =
+            squooshComputeTextInfo(
+                v = view,
+                overrideViewData = null,
+                layoutId = 1,
+                density = Density(1f),
+                document = docContent,
+                customizations = customizations,
+                fontResolver = fontResolver,
+                variableState = variableState,
+                appContext = context,
+                textMeasureCache = textMeasureCache,
+                textHash = textHash,
+            )
 
         assertThat(result).isNotNull()
         val (_, textStyle) = result!!
@@ -151,19 +146,20 @@ class SquooshTextTest {
         val customStyle = TextStyle(fontFamily = FontFamily.Serif)
         customizations.setTextStyle("text-node", customStyle)
 
-        val result = squooshComputeTextInfo(
-            v = view,
-            overrideViewData = null,
-            layoutId = 1,
-            density = Density(1f),
-            document = docContent,
-            customizations = customizations,
-            fontResolver = fontResolver,
-            variableState = variableState,
-            appContext = context,
-            textMeasureCache = textMeasureCache,
-            textHash = textHash
-        )
+        val result =
+            squooshComputeTextInfo(
+                v = view,
+                overrideViewData = null,
+                layoutId = 1,
+                density = Density(1f),
+                document = docContent,
+                customizations = customizations,
+                fontResolver = fontResolver,
+                variableState = variableState,
+                appContext = context,
+                textMeasureCache = textMeasureCache,
+                textHash = textHash,
+            )
 
         assertThat(result).isNotNull()
         val (_, textStyle) = result!!

--- a/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTextTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTextTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.designcompose.squoosh
+
+import android.content.Context
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.unit.Density
+import androidx.test.core.app.ApplicationProvider
+import com.android.designcompose.CustomizationContext
+import com.android.designcompose.DesignSettings
+import com.android.designcompose.DocContent
+import com.android.designcompose.VariableState
+import com.android.designcompose.common.DesignDocId
+import com.android.designcompose.common.GenericDocContent
+import com.android.designcompose.common.VariantPropertyMap
+import com.android.designcompose.definition.DesignComposeDefinition
+import com.android.designcompose.definition.DesignComposeDefinitionHeader
+import com.android.designcompose.definition.element.fontWeight
+import com.android.designcompose.definition.element.numOrVar
+import com.android.designcompose.definition.view.View
+import com.android.designcompose.definition.view.ViewDataKt.text
+import com.android.designcompose.definition.view.nodeStyle
+import com.android.designcompose.definition.view.view
+import com.android.designcompose.definition.view.viewData
+import com.android.designcompose.definition.view.viewStyle
+import com.android.designcompose.setTextStyle
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SquooshTextTest {
+
+    private lateinit var context: Context
+    private lateinit var docContent: DocContent
+    private lateinit var fontResolver: FontFamily.Resolver
+    private lateinit var textMeasureCache: TextMeasureCache
+    private lateinit var textHash: HashSet<String>
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        docContent = createDummyDocContent()
+        fontResolver = createFontFamilyResolver(context)
+        textMeasureCache = TextMeasureCache()
+        textHash = HashSet()
+        DesignSettings.clearRawResources()
+    }
+
+    private fun createDummyDocContent(): DocContent {
+        val docId = DesignDocId("dummy")
+        val header = DesignComposeDefinitionHeader.getDefaultInstance()
+        val document = DesignComposeDefinition.getDefaultInstance()
+        val variantViewMap = HashMap<String, HashMap<String, View>>()
+        val variantPropertyMap = VariantPropertyMap()
+        val nodeIdMap = HashMap<String, View>()
+        val imageSession = ByteString.EMPTY
+
+        val genericDocContent =
+            GenericDocContent(
+                docId,
+                header,
+                document,
+                variantViewMap,
+                variantPropertyMap,
+                nodeIdMap,
+                imageSession,
+            )
+        return DocContent(genericDocContent, null)
+    }
+
+    private fun createTextView(fontFamilyName: String): View {
+        return view {
+            name = "text-node"
+            style = viewStyle {
+                nodeStyle = nodeStyle {
+                    fontFamily = fontFamilyName
+                    fontSize = numOrVar { num = 12f }
+                    fontWeight = fontWeight {
+                        weight = numOrVar { num = 400f }
+                    }
+                }
+            }
+            data = viewData {
+                text = text {
+                    content = "Hello"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDefaultFontFamily() {
+        val view = createTextView("FigmaFont")
+        val customizations = CustomizationContext()
+        val variableState = VariableState()
+
+        // Register FigmaFont in DesignSettings
+        DesignSettings.addFontFamily("FigmaFont", FontFamily.SansSerif)
+
+        val result = squooshComputeTextInfo(
+            v = view,
+            overrideViewData = null,
+            layoutId = 1,
+            density = Density(1f),
+            document = docContent,
+            customizations = customizations,
+            fontResolver = fontResolver,
+            variableState = variableState,
+            appContext = context,
+            textMeasureCache = textMeasureCache,
+            textHash = textHash
+        )
+
+        assertThat(result).isNotNull()
+        val (_, textStyle) = result!!
+        assertThat(textStyle.fontFamily).isEqualTo(FontFamily.SansSerif)
+    }
+
+    @Test
+    fun testCustomFontFamily() {
+        val view = createTextView("FigmaFont")
+        val customizations = CustomizationContext()
+        val variableState = VariableState()
+
+        // Register FigmaFont in DesignSettings
+        DesignSettings.addFontFamily("FigmaFont", FontFamily.SansSerif)
+
+        // Customize TextStyle with a different fontFamily
+        val customStyle = TextStyle(fontFamily = FontFamily.Serif)
+        customizations.setTextStyle("text-node", customStyle)
+
+        val result = squooshComputeTextInfo(
+            v = view,
+            overrideViewData = null,
+            layoutId = 1,
+            density = Density(1f),
+            document = docContent,
+            customizations = customizations,
+            fontResolver = fontResolver,
+            variableState = variableState,
+            appContext = context,
+            textMeasureCache = textMeasureCache,
+            textHash = textHash
+        )
+
+        assertThat(result).isNotNull()
+        val (_, textStyle) = result!!
+        assertThat(textStyle.fontFamily).isEqualTo(FontFamily.Serif)
+    }
+}


### PR DESCRIPTION
Fixes an issue where custom `fontFamily` overrides applied via `TextStyle` customizations were ignored in Squoosh rendering, defaulting instead to the Figma-defined font family.

**Changes:**
- Updated Squoosh text resolution to check `customTextStyle?.fontFamily` before falling back to the Figma style.
- Added unit tests in `SquooshTextTest` (`testCustomFontFamily` and `testDefaultFontFamily`) to verify font family resolution behavior.