### PR TITLE
Add support for LongPressCallback in customizations and Squoosh

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
+++ b/designcompose/src/main/java/com/android/designcompose/CustomizationContext.kt
@@ -73,6 +73,8 @@ data class ReplacementContent(
 
 typealias TapCallback = () -> Unit
 
+typealias LongPressCallback = () -> Unit
+
 typealias MeterState = MutableState<Float?>
 
 typealias Meter = Float
@@ -123,6 +125,8 @@ data class Customization(
     var modifier: Optional<Modifier> = Optional.empty(),
     // Tap callback customization
     var tapCallback: Optional<TapCallback> = Optional.empty(),
+    // Long press callback customization
+    var longPressCallback: Optional<LongPressCallback> = Optional.empty(),
     // On progress changed callback customization
     var onProgressChangedCallback: Optional<OnProgressChangedCallback> = Optional.empty(),
     // Child content customization V2
@@ -282,6 +286,13 @@ fun CustomizationContext.setTapCallback(nodeName: String, tapCallback: TapCallba
     customize(nodeName) { c -> c.tapCallback = Optional.ofNullable(tapCallback) }
 }
 
+fun CustomizationContext.setLongPressCallback(
+    nodeName: String,
+    longPressCallback: LongPressCallback,
+) {
+    customize(nodeName) { c -> c.longPressCallback = Optional.ofNullable(longPressCallback) }
+}
+
 fun CustomizationContext.setOnProgressChangedCallback(
     nodeName: String,
     callback: OnProgressChangedCallback,
@@ -419,6 +430,10 @@ fun CustomizationContext.getTapCallback(nodeName: String): TapCallback? {
     return cs[nodeName]?.tapCallback?.getOrNull()
 }
 
+fun CustomizationContext.getLongPressCallback(nodeName: String): LongPressCallback? {
+    return cs[nodeName]?.longPressCallback?.getOrNull()
+}
+
 fun CustomizationContext.getOnProgressChangedCallback(
     nodeName: String
 ): OnProgressChangedCallback? {
@@ -434,6 +449,15 @@ fun CustomizationContext.getTapCallback(view: View): TapCallback? {
         tapCallback = getTapCallback(componentSetName)
     }
     return tapCallback
+}
+
+fun CustomizationContext.getLongPressCallback(view: View): LongPressCallback? {
+    var longPressCallback = getLongPressCallback(view.name)
+    val componentSetName = view.componentInfoOrNull?.componentSetName
+    if (longPressCallback == null && !componentSetName.isNullOrBlank()) {
+        longPressCallback = getLongPressCallback(componentSetName)
+    }
+    return longPressCallback
 }
 
 fun CustomizationContext.getContent(nodeName: String): ReplacementContent? {

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
@@ -44,6 +44,7 @@ import com.android.designcompose.definition.interaction.Action
 import com.android.designcompose.definition.modifier.TextOverflow
 import com.android.designcompose.dispatch
 import com.android.designcompose.getKey
+import com.android.designcompose.getLongPressCallback
 import com.android.designcompose.getOnProgressChangedCallback
 import com.android.designcompose.getPressedReactionList
 import com.android.designcompose.getPressedTapCallback
@@ -284,6 +285,11 @@ internal fun Modifier.squooshInteraction(
             customizations.getTapCallback(childComposable.node.unresolvedName)
                 ?: customizations.getTapCallback(childComposable.node.view)
         )
+    val latestLongPressCallback by
+        androidx.compose.runtime.rememberUpdatedState(
+            customizations.getLongPressCallback(childComposable.node.unresolvedName)
+                ?: customizations.getLongPressCallback(childComposable.node.view)
+        )
     val latestParentComponents by
         androidx.compose.runtime.rememberUpdatedState(childComposable.parentComponents)
 
@@ -292,6 +298,7 @@ internal fun Modifier.squooshInteraction(
             val node = childComposable.node
             val viewName = node.view.name
             detectTapGestures(
+                onLongPress = { latestLongPressCallback?.invoke() },
                 onPress = {
                     var pressInteraction: PressInteraction.Press? = null
                     var success = false
@@ -386,7 +393,7 @@ internal fun Modifier.squooshInteraction(
                         isPressed.value = false
                         interactionState.removePressed(node.unresolvedNodeId)
                     }
-                }
+                },
             )
         }
     )

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -83,6 +83,7 @@ import com.android.designcompose.getComponent
 import com.android.designcompose.getContent
 import com.android.designcompose.getKey
 import com.android.designcompose.getListContent
+import com.android.designcompose.getLongPressCallback
 import com.android.designcompose.getMatchingVariant
 import com.android.designcompose.getTapCallback
 import com.android.designcompose.getVisible
@@ -372,6 +373,9 @@ internal fun resolveVariantsRecursively(
     var tapCallback = customizations.getTapCallback(viewFromTree.name)
     if (tapCallback == null) tapCallback = customizations.getTapCallback(view)
     if (tapCallback != null) hasSupportedInteraction = true
+    var longPressCallback = customizations.getLongPressCallback(viewFromTree.name)
+    if (longPressCallback == null) longPressCallback = customizations.getLongPressCallback(view)
+    if (longPressCallback != null) hasSupportedInteraction = true
     if (textInfo?.hyperlinkOffsetMap?.isNotEmpty() == true) hasSupportedInteraction = true
     val progressChildTouch = view.getProgressChildWithTouch(customizations)
     if (progressChildTouch != null) hasSupportedInteraction = true

--- a/designcompose/src/test/kotlin/com/android/designcompose/CustomizationContextTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/CustomizationContextTest.kt
@@ -88,6 +88,14 @@ class CustomizationContextTest {
     }
 
     @Test
+    fun testSetAndGetLongPressCallback() {
+        val context = CustomizationContext()
+        val callback = {}
+        context.setLongPressCallback("node1", callback)
+        assertThat(context.getLongPressCallback("node1")).isEqualTo(callback)
+    }
+
+    @Test
     fun testSetAndGetOnProgressChangedCallback() {
         val context = CustomizationContext()
         val callback =


### PR DESCRIPTION
Allows developers to register a long press callback on any Figma node by name using CustomizationContext.setLongPressCallback.

Changes:
- CustomizationContext: Added LongPressCallback typealias, customization field, and setLongPressCallback / getLongPressCallback helper extensions.
- SquooshTreeBuilder: Added checks for longPressCallback to ensure nodes with long press callbacks are marked as interactive (hasSupportedInteraction = true).
- SquooshInteraction: Resolved latestLongPressCallback and wired it up to the onLongPress parameter of detectTapGestures.
- CustomizationContextTest: Added unit test testSetAndGetLongPressCallback to verify registration and retrieval.