### PR TITLE
Support #indicator child node for progress bar sizing in Squoosh

### DIFF
--- a/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/FrameRender.kt
@@ -379,7 +379,7 @@ internal fun ContentDrawScope.squooshShapeRender(
     if (size.width <= 0F && size.height <= 0F) return
     val overrideLayoutSize = node.overrideLayoutSize
     val style = node.style
-    val name = node.view.name
+    val name = node.customizationName ?: node.view.name
 
     drawContext.canvas.save()
 

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshInteraction.kt
@@ -96,7 +96,9 @@ internal fun Modifier.progressBarSlider(
             val pbMeterData = pbNode?.style?.getProgressBarData()
             pbMeterData?.let {
                 val progressChanged =
-                    customizations.getOnProgressChangedCallback(pbNode.unresolvedName)
+                    customizations.getOnProgressChangedCallback(
+                        pbNode.customizationName ?: pbNode.unresolvedName
+                    )
                 val progress: Float
                 if (it.vertical) {
                     val startY = it.startY * density
@@ -111,14 +113,19 @@ internal fun Modifier.progressBarSlider(
                 }
                 progressChanged?.onProgressChanged(progress)
                 meterState.value = progress
-                customizations.setMeterState(pbNode.unresolvedName, meterState)
+                customizations.setMeterState(
+                    pbNode.customizationName ?: pbNode.unresolvedName,
+                    meterState,
+                )
             }
 
             val pmNode = node.findProgressMarkerDescendant()
             val pmMeterData = pmNode?.style?.getProgressMarkerData()
             pmMeterData?.let {
                 val progressChanged =
-                    customizations.getOnProgressChangedCallback(pmNode.unresolvedName)
+                    customizations.getOnProgressChangedCallback(
+                        pmNode.customizationName ?: pmNode.unresolvedName
+                    )
                 val progress: Float
                 if (it.vertical) {
                     val startY = it.startY * density
@@ -133,7 +140,10 @@ internal fun Modifier.progressBarSlider(
                 }
                 progressChanged?.onProgressChanged(progress)
                 meterState.value = progress
-                customizations.setMeterState(pmNode.unresolvedName, meterState)
+                customizations.setMeterState(
+                    pmNode.customizationName ?: pmNode.unresolvedName,
+                    meterState,
+                )
             }
         }
 

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshListWidget.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshListWidget.kt
@@ -289,7 +289,11 @@ private fun addGridContent(
             val density = LocalDensity.current.density
             val lazyGridState = rememberLazyGridState()
             val setScrollableStateCallback =
-                customizations.getScrollCallbacks(resolvedView.unresolvedName)?.setScrollableState
+                customizations
+                    .getScrollCallbacks(
+                        resolvedView.customizationName ?: resolvedView.unresolvedName
+                    )
+                    ?.setScrollableState
             LaunchedEffect(lazyGridState, setScrollableStateCallback) {
                 setScrollableStateCallback?.invoke(lazyGridState)
             }

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRender.kt
@@ -125,8 +125,11 @@ internal fun Modifier.squooshRender(
                     node.parent?.let {
                         // Don't scroll for custom list content since it scrolled in layout
                         val customContent =
-                            customizations.getContent(it.unresolvedName) != null ||
-                                customizations.getListContent(it.unresolvedName) != null
+                            customizations.getContent(it.customizationName ?: it.unresolvedName) !=
+                                null ||
+                                customizations.getListContent(
+                                    it.customizationName ?: it.unresolvedName
+                                ) != null
                         scroll = !customContent && it.view == parentNode
                     }
                     if (scroll) {
@@ -199,7 +202,10 @@ internal fun Modifier.squooshRender(
                             shaderBrushCache,
                             appContext,
                         ) {
-                            val shapeInsets = customizations.getWindowInsets(node.unresolvedName)
+                            val shapeInsets =
+                                customizations.getWindowInsets(
+                                    node.customizationName ?: node.unresolvedName
+                                )
                             val topInset = shapeInsets?.getTop(this) ?: 0
                             val leftInset = shapeInsets?.getLeft(this, layoutDirection) ?: 0
 

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshResolvedNode.kt
@@ -58,6 +58,8 @@ internal class SquooshResolvedNode(
     // check were not here.
     var skipLayoutScroll: Boolean = false,
 ) {
+    var customizationName: String? = null
+
     fun offsetFromAncestor(ancestor: SquooshResolvedNode? = null): PointF {
         var n: SquooshResolvedNode? = this
         var x = 0f

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshRoot.kt
@@ -82,6 +82,7 @@ import com.android.designcompose.KeyEventTracker
 import com.android.designcompose.KeyInjectManager
 import com.android.designcompose.LayoutManager
 import com.android.designcompose.LiveUpdateMode
+import com.android.designcompose.LocalCustomizationContext
 import com.android.designcompose.LocalDesignDocSettings
 import com.android.designcompose.LocalVariableState
 import com.android.designcompose.ShaderBrushCache
@@ -699,7 +700,10 @@ fun SquooshRoot(
     //
     // This is covered in the interaction test document's "Combos" screen; the purple button has no
     // interactions in its ON_PRESS variant.
-    CompositionLocalProvider(LocalSquooshIsRootContext provides SquooshIsRoot(false)) {
+    CompositionLocalProvider(
+        LocalSquooshIsRootContext provides SquooshIsRoot(false),
+        LocalCustomizationContext provides customizationContext,
+    ) {
         androidx.compose.ui.layout.Layout(
             modifier =
                 modifier
@@ -845,8 +849,18 @@ fun SquooshRoot(
                             val pmChild = child.node.findProgressMarkerDescendant()
                             val interactionSource = remember { MutableInteractionSource() }
                             val meter = remember { mutableStateOf<Float?>(null) }
-                            pbChild?.let { customizationContext.setMeterState(it.view.name, meter) }
-                            pmChild?.let { customizationContext.setMeterState(it.view.name, meter) }
+                            pbChild?.let {
+                                customizationContext.setMeterState(
+                                    it.customizationName ?: it.view.name,
+                                    meter,
+                                )
+                            }
+                            pmChild?.let {
+                                customizationContext.setMeterState(
+                                    it.customizationName ?: it.view.name,
+                                    meter,
+                                )
+                            }
                             // Give this node a Modifier that tracks tap/drag
                             composableChildModifier =
                                 composableChildModifier.progressBarSlider(

--- a/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
+++ b/designcompose/src/main/java/com/android/designcompose/squoosh/SquooshTreeBuilder.kt
@@ -73,7 +73,9 @@ import com.android.designcompose.definition.view.ViewDataKt.container
 import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.definition.view.containerOrNull
 import com.android.designcompose.definition.view.frameExtrasOrNull
+import com.android.designcompose.definition.view.meterDataOrNull
 import com.android.designcompose.definition.view.nodeStyle
+import com.android.designcompose.definition.view.nodeStyleOrNull
 import com.android.designcompose.definition.view.styleOrNull
 import com.android.designcompose.definition.view.view
 import com.android.designcompose.definition.view.viewData
@@ -509,6 +511,43 @@ internal fun resolveVariantsRecursively(
                 if (previousChild != null) previousChild.nextSibling = childResolvedNode
 
                 previousChild = childResolvedNode
+            }
+
+            // Transfer progress bar data from parent container to child "#indicator" or "indicator"
+            // if present. This allows the indicator bar inside the track container to resize/move,
+            // rather than resizing the entire progress bar background/track.
+            if (resolvedView.style.nodeStyleOrNull?.meterDataOrNull?.hasProgressBarData() == true) {
+                var child = resolvedView.firstChild
+                var indicatorChild: SquooshResolvedNode? = null
+                while (child != null) {
+                    if (child.view.name == "#indicator" || child.view.name == "indicator") {
+                        indicatorChild = child
+                        break
+                    }
+                    child = child.nextSibling
+                }
+                if (indicatorChild != null) {
+                    val meterData = resolvedView.style.nodeStyle.meterData
+
+                    val childNodeStyleBuilder = indicatorChild.style.nodeStyle.toBuilder()
+                    childNodeStyleBuilder.setMeterData(meterData)
+
+                    indicatorChild.style =
+                        indicatorChild.style
+                            .toBuilder()
+                            .setNodeStyle(childNodeStyleBuilder.build())
+                            .build()
+
+                    indicatorChild.customizationName = resolvedView.unresolvedName
+
+                    val parentNodeStyleBuilder = resolvedView.style.nodeStyle.toBuilder()
+                    parentNodeStyleBuilder.clearMeterData()
+                    resolvedView.style =
+                        resolvedView.style
+                            .toBuilder()
+                            .setNodeStyle(parentNodeStyleBuilder.build())
+                            .build()
+                }
             }
         }
     }

--- a/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTreeBuilderTest.kt
+++ b/designcompose/src/test/kotlin/com/android/designcompose/squoosh/SquooshTreeBuilderTest.kt
@@ -27,9 +27,14 @@ import com.android.designcompose.common.GenericDocContent
 import com.android.designcompose.common.VariantPropertyMap
 import com.android.designcompose.definition.DesignComposeDefinition
 import com.android.designcompose.definition.DesignComposeDefinitionHeader
+import com.android.designcompose.definition.plugin.MeterData
+import com.android.designcompose.definition.plugin.ProgressBarMeterData
+import com.android.designcompose.definition.view.NodeStyle
 import com.android.designcompose.definition.view.View
 import com.android.designcompose.definition.view.ViewDataKt.container
+import com.android.designcompose.definition.view.ViewStyle
 import com.android.designcompose.definition.view.componentInfo
+import com.android.designcompose.definition.view.nodeStyle
 import com.android.designcompose.definition.view.view
 import com.android.designcompose.definition.view.viewData
 import com.google.common.truth.Truth.assertThat
@@ -322,5 +327,76 @@ class SquooshTreeBuilderTest {
             composableList3.childComposables.find { it.node.unresolvedName == iconSlotInstanceName }
         assertThat(child3).isNotNull()
         assertThat(child3!!.component).isEqualTo(replacementComponent)
+    }
+
+    @Test
+    fun testProgressBarDataTransferToIndicator() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val density = Density(1f)
+        val fontResolver = createFontFamilyResolver(context)
+
+        // 1. Create progress bar parent view style with progress bar meter data
+        val pbMeterData = ProgressBarMeterData.newBuilder().setEnabled(true).build()
+        val meterData = MeterData.newBuilder().setProgressBarData(pbMeterData).build()
+        val parentNodeStyle = NodeStyle.newBuilder().setMeterData(meterData).build()
+        val parentStyle = ViewStyle.newBuilder().setNodeStyle(parentNodeStyle).build()
+
+        // 2. Create indicator child view
+        val childView = view {
+            uniqueId = 2
+            id = "indicator-id"
+            name = "#indicator"
+        }
+
+        // 3. Create parent view "#progress" with the indicator child
+        val parentView = view {
+            uniqueId = 1
+            id = "progress-id"
+            name = "#progress"
+            style = parentStyle
+            data = viewData { container = container { children.add(childView) } }
+        }
+
+        val docContent = createDocContent(rootView = parentView)
+        val customizations = CustomizationContext()
+        val variantTransition = SquooshVariantTransition()
+        val interactionState = InteractionState()
+        val keyTracker = KeyEventTracker()
+        val layoutIdAllocator = SquooshLayoutIdAllocator()
+
+        val resolvedNode =
+            resolveVariantsRecursively(
+                viewFromTree = parentView,
+                document = docContent,
+                customizations = customizations,
+                variantTransition = variantTransition,
+                interactionState = interactionState,
+                keyTracker = keyTracker,
+                parentComponents = null,
+                density = density,
+                fontResolver = fontResolver,
+                composableList = null,
+                layoutIdAllocator = layoutIdAllocator,
+                isRoot = true,
+                variableState = VariableState(),
+                appContext = context,
+                customVariantTransition = null,
+                textMeasureCache = TextMeasureCache(),
+                textHash = HashSet(),
+            )
+
+        assertThat(resolvedNode).isNotNull()
+        // Parent "#progress" should NOT have progress bar data anymore
+        assertThat(resolvedNode!!.style.nodeStyle.hasMeterData()).isFalse()
+
+        // Child "#indicator" should have progress bar data transferred
+        val indicatorNode = resolvedNode.firstChild
+        assertThat(indicatorNode).isNotNull()
+        assertThat(indicatorNode!!.unresolvedName).isEqualTo("#indicator")
+        assertThat(indicatorNode.style.nodeStyle.hasMeterData()).isTrue()
+        assertThat(indicatorNode.style.nodeStyle.meterData.hasProgressBarData()).isTrue()
+
+        // Child customizationName should be set to parent's unresolved name "#progress"
+        assertThat(indicatorNode.customizationName).isEqualTo("#progress")
     }
 }


### PR DESCRIPTION
Fixes an issue where progress bar component container nodes with progress meter customizations were resizing the entire container/background track, rather than resizing/moving only the indicator child node (named #indicator or indicator).

Changes:
- SquooshTreeBuilder: Automatically transfer progressBarData from container to child '#indicator' or 'indicator' if present. Assign customizationName key override on the child node so it uses parent's name for customizations lookup.
- FrameRender, SquooshInteraction, SquooshListWidget, SquooshRender, SquooshRoot: Fallback to customizationName when looking up meter values, tap/scroll/meter state callbacks, and setting state values in customizations context.
- SquooshTreeBuilderTest: Added testProgressBarDataTransferToIndicator to verify the transfer of progress bar properties and customizations fallback.