### PR TITLE
Fix DesignCompose exporter to explicitly serialize 1.0/0.0 opacity

### DIFF
--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -1474,7 +1474,7 @@ fn visit_node(
     // Blend mode is common to all elements.
     style.node_style_mut().blend_mode = convert_blend_mode(node.blend_mode).into();
 
-    style.node_style_mut().opacity = if node.opacity < 1.0 { Some(node.opacity) } else { None };
+    style.node_style_mut().opacity = Some(node.opacity);
 
     style.node_style_mut().stroke.as_mut().map(|stroke| {
         for visible_stroke in node.strokes.iter().filter(|paint| paint.visible) {
@@ -1639,7 +1639,7 @@ fn visit_node(
             })
             .into(),
         };
-        style.node_style_mut().opacity = if node.opacity < 1.0 { Some(node.opacity) } else { None };
+        style.node_style_mut().opacity = Some(node.opacity);
         let convert_opentype_flags = |flags: &HashMap<String, u32>| -> Vec<FontFeature> {
             let mut font_features = Vec::new();
             for (flag, value) in flags {
@@ -2817,3 +2817,68 @@ fn test_absolute_position_in_autolayout_import() {
         });
     assert_eq!(top_margin, Some(&100.0), "Top margin should be 100 (child_y - parent_y)");
 }
+
+#[test]
+fn test_opacity_serialization() {
+    // Test case 1: Opacity omitted (defaults to 1.0)
+    let json_omitted = r#"{
+        "id": "1",
+        "name": "omitted",
+        "type": "FRAME",
+        "constraints": { "vertical": "TOP", "horizontal": "LEFT" },
+        "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }
+    }"#;
+
+    // Test case 2: Opacity explicitly 0.0
+    let json_zero = r#"{
+        "id": "2",
+        "name": "zero",
+        "type": "FRAME",
+        "opacity": 0.0,
+        "constraints": { "vertical": "TOP", "horizontal": "LEFT" },
+        "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }
+    }"#;
+
+    // Test case 3: Opacity explicitly 0.5
+    let json_half = r#"{
+        "id": "3",
+        "name": "half",
+        "type": "FRAME",
+        "opacity": 0.5,
+        "constraints": { "vertical": "TOP", "horizontal": "LEFT" },
+        "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }
+    }"#;
+
+    let mut key_to_global_id_map = HashMap::new();
+    let mut component_context = ComponentContext::new(&vec![]);
+    let mut image_context = ImageContext::new(HashMap::new(), HashMap::new(), &crate::proxy_config::ProxyConfig::None);
+
+    let mut convert_node = |json: &str| -> dc_bundle::view::View {
+        let node: figma_schema::Node = serde_json::from_str(json).unwrap();
+        create_component_flexbox(
+            &node,
+            &HashMap::new(),
+            &HashMap::new(),
+            &mut component_context,
+            &mut image_context,
+            crate::document::HiddenNodePolicy::Keep,
+            &mut key_to_global_id_map,
+        ).unwrap()
+    };
+
+    let view_omitted = convert_node(json_omitted);
+    assert!(view_omitted.style.is_some());
+    let style_omitted = view_omitted.style.as_ref().unwrap();
+    assert!(style_omitted.node_style.is_some());
+    let node_style_omitted = style_omitted.node_style.as_ref().unwrap();
+    assert_eq!(node_style_omitted.opacity, Some(1.0));
+
+    let view_zero = convert_node(json_zero);
+    let node_style_zero = view_zero.style.as_ref().unwrap().node_style.as_ref().unwrap();
+    assert_eq!(node_style_zero.opacity, Some(0.0));
+
+    let view_half = convert_node(json_half);
+    let node_style_half = view_half.style.as_ref().unwrap().node_style.as_ref().unwrap();
+    assert_eq!(node_style_half.opacity, Some(0.5));
+}
+

--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -2851,7 +2851,8 @@ fn test_opacity_serialization() {
 
     let mut key_to_global_id_map = HashMap::new();
     let mut component_context = ComponentContext::new(&vec![]);
-    let mut image_context = ImageContext::new(HashMap::new(), HashMap::new(), &crate::proxy_config::ProxyConfig::None);
+    let mut image_context =
+        ImageContext::new(HashMap::new(), HashMap::new(), &crate::proxy_config::ProxyConfig::None);
 
     let mut convert_node = |json: &str| -> dc_bundle::view::View {
         let node: figma_schema::Node = serde_json::from_str(json).unwrap();
@@ -2863,7 +2864,8 @@ fn test_opacity_serialization() {
             &mut image_context,
             crate::document::HiddenNodePolicy::Keep,
             &mut key_to_global_id_map,
-        ).unwrap()
+        )
+        .unwrap()
     };
 
     let view_omitted = convert_node(json_omitted);
@@ -2881,4 +2883,3 @@ fn test_opacity_serialization() {
     let node_style_half = view_half.style.as_ref().unwrap().node_style.as_ref().unwrap();
     assert_eq!(node_style_half.opacity, Some(0.5));
 }
-


### PR DESCRIPTION
### Summary
Fixes the exporter in `dc_figma_import` to explicitly set `1.0` opacity values instead of omitting them. 

### Details
Previously, the DesignCompose Figma plugin exporter omitted the `opacity` field (setting it to `None` in the protobuf) when its value was `1.0`. Because proto3 defaults missing float fields to `0.0` in primitive deserializers, this created ambiguity. To work around it, deserializers (such as Squoosh Rust and Kotlin) had to treat `0.0` as `1.0`, which meant that any layers intentionally set to `0.0` (fully transparent) in Figma were incorrectly rendered as fully opaque.

This change:
1. Updates frame and text converters in `crates/dc_figma_import/src/transform_flexbox.rs` to always set `style.node_style_mut().opacity = Some(node.opacity);`.
2. Adds a new Rust unit test `test_opacity_serialization` to verify that omitted (defaults to 1.0), explicitly `0.0`, and explicitly `0.5` opacities are all preserved and serialized correctly.
3. Preserves backward compatibility: deserializers will still fall back to `1.0` if they encounter older `.dcf` files where opacity is missing (`None`).

### Validation
- Ran Rust Cargo unit tests (`cargo test` in `crates/dc_figma_import`): **Passed**
- Ran Android JVM unit tests (`./gradlew :designcompose:testDebugUnitTest`): **Passed**
- Ran Roborazzi screenshot tests: **Passed**