### PR TITLE
Update DesignCompose version to 0.39.4 RC01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "dc_bundle"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "log",
  "protobuf",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "dc_figma_import"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "dc_jni"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "android_logger",
  "bytes",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "dc_layout"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "android_logger",
  "dc_bundle",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "dc_squoosh_animation"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "dc_bundle",
  "log",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "dc_squoosh_parser"
-version = "0.39.3"
+version = "0.39.4"
 dependencies = [
  "dc_squoosh_animation",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["crates/dc_figma_import", "crates/dc_jni", "crates/dc_layout", "crate
 
 [workspace.package]
 # LINT.IfChange
-version = "0.39.3"
+version = "0.39.4"
 # LINT.ThenChange(gradle/libs.versions.toml)
 edition = "2021"
 authors = ["DesignCompose Team <aae-design-compose@google.com>"]
@@ -39,12 +39,12 @@ strip = "debuginfo"
 
 [workspace.dependencies]
 # dc_* crates specify a version because they are dependencies published on crates.io
-dc_bundle = { version = "0.39.3", path = "crates/dc_bundle" }
-dc_layout = { version = "0.39.3", path = "crates/dc_layout" }
-dc_figma_import = { version = "0.39.3", path = "crates/dc_figma_import" }
-dc_jni = { version = "0.39.3", path = "crates/dc_jni" }
-dc_squoosh_animation = { version = "0.39.3", path = "crates/dc_squoosh_animation" }
-dc_squoosh_parser = { version = "0.39.3", path = "support-figma/dc_squoosh_designer/rs" }
+dc_bundle = { version = "0.39.4", path = "crates/dc_bundle" }
+dc_layout = { version = "0.39.4", path = "crates/dc_layout" }
+dc_figma_import = { version = "0.39.4", path = "crates/dc_figma_import" }
+dc_jni = { version = "0.39.4", path = "crates/dc_jni" }
+dc_squoosh_animation = { version = "0.39.4", path = "crates/dc_squoosh_animation" }
+dc_squoosh_parser = { version = "0.39.4", path = "support-figma/dc_squoosh_designer/rs" }
 android_logger = "0.13.1"
 anyhow = "1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@
 [versions]
 # DesignCompose
 # LINT.IfChange
-designcompose = "0.39.3"
+designcompose = "0.39.4-SNAPSHOT"
 # LINT.ThenChange(Cargo.toml)
 
 


### PR DESCRIPTION
Update DesignCompose version to 0.39.4 RC01

- Bump version in Cargo.toml and gradle/libs.versions.toml
- Update Cargo.lock
