### PR TITLE
Feat: Support Custom Animation Matrix and Transition Schemas in DCF generation

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="MarkdownSettings">
-    <option name="previewPanelProviderInfo">
-      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
-    </option>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,21 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2026 Google LLC
-
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-
 <project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bb/(\d+)(#\w+)?\b" />
+          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1$2" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:BUG=|FIXED=)(\d+)\b" />
+          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?i:bug|bugfix|issue|fix|fixes|fixing|fixed|google-bug-id):? ?(?:(?:https?://)?(?:b|b.android.com|issuetracker.google.com)/)?(\d+)\b" />
+          <option name="linkRegexp" value="https://issuetracker.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:cl/|cr/|OCL=|DIFFBASE=|ROLLBACK_OF=)(\d+)\b" />
+          <option name="linkRegexp" value="https://critique.corp.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="Change-Id: (\S+)" />
+          <option name="linkRegexp" value="https://googleplex-android-review.git.corp.google.com/q/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bomg/(\d+)\b" />
+          <option name="linkRegexp" value="https://omg.corp.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:go/|goto/)([^,.&lt;&gt;()&quot;\s]+(?:[.,][^,.&lt;&gt;()&quot;\s]+)*)" />
+          <option name="linkRegexp" value="https://goto.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bcs/([^\s]+[\w$])" />
+          <option name="linkRegexp" value="https://cs.corp.google.com/search/?q=$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(LINT\.IfChange)|(LINT\.ThenChange)" />
+          <option name="linkRegexp" value="https://goto.google.com/ifthisthenthatlint" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/crates/dc_bundle/src/proto" vcs="Git" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,47 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <project version="4">
-  <component name="IssueNavigationConfiguration">
-    <option name="links">
-      <list>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\bb/(\d+)(#\w+)?\b" />
-          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1$2" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\b(?:BUG=|FIXED=)(\d+)\b" />
-          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\b(?i:bug|bugfix|issue|fix|fixes|fixing|fixed|google-bug-id):? ?(?:(?:https?://)?(?:b|b.android.com|issuetracker.google.com)/)?(\d+)\b" />
-          <option name="linkRegexp" value="https://issuetracker.google.com/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\b(?:cl/|cr/|OCL=|DIFFBASE=|ROLLBACK_OF=)(\d+)\b" />
-          <option name="linkRegexp" value="https://critique.corp.google.com/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="Change-Id: (\S+)" />
-          <option name="linkRegexp" value="https://googleplex-android-review.git.corp.google.com/q/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\bomg/(\d+)\b" />
-          <option name="linkRegexp" value="https://omg.corp.google.com/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\b(?:go/|goto/)([^,.&lt;&gt;()&quot;\s]+(?:[.,][^,.&lt;&gt;()&quot;\s]+)*)" />
-          <option name="linkRegexp" value="https://goto.google.com/$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="\bcs/([^\s]+[\w$])" />
-          <option name="linkRegexp" value="https://cs.corp.google.com/search/?q=$1" />
-        </IssueNavigationLink>
-        <IssueNavigationLink>
-          <option name="issueRegexp" value="(LINT\.IfChange)|(LINT\.ThenChange)" />
-          <option name="linkRegexp" value="https://goto.google.com/ifthisthenthatlint" />
-        </IssueNavigationLink>
-      </list>
-    </option>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/crates/dc_bundle/src/proto" vcs="Git" />

--- a/crates/dc_bundle/src/definition.rs
+++ b/crates/dc_bundle/src/definition.rs
@@ -60,7 +60,7 @@ impl fmt::Display for DesignComposeDefinitionHeader {
         write!(
             f,
             "DC Version: {}\nDoc ID: {}\nName: {}\nLast Modified: {}\nResponse Version: {}",
-            &self.dc_version, &self.id, &self.name, &self.last_modified, &self.response_version
+            self.dc_version, self.id, self.name, self.last_modified, self.response_version
         )
     }
 }

--- a/crates/dc_bundle/src/definition/view.rs
+++ b/crates/dc_bundle/src/definition/view.rs
@@ -674,8 +674,8 @@ mod tests {
     #[test]
     fn test_view_new_rect() {
         let view = View::new_rect(
-            &"rect1".to_string(),
-            &"Rect View".to_string(),
+            "rect1",
+            "Rect View",
             ViewShape::default(),
             ViewStyle::new_default(),
             None,
@@ -697,8 +697,8 @@ mod tests {
     #[test]
     fn test_view_new_text() {
         let view = View::new_text(
-            &"text1".to_string(),
-            &"Text View".to_string(),
+            "text1",
+            "Text View",
             ViewStyle::new_default(),
             None,
             None,
@@ -716,8 +716,8 @@ mod tests {
     #[test]
     fn test_view_add_child() {
         let mut parent = View::new_rect(
-            &"parent".to_string(),
-            &"Parent".to_string(),
+            "parent",
+            "Parent",
             ViewShape::default(),
             ViewStyle::new_default(),
             None,
@@ -729,8 +729,8 @@ mod tests {
             HashMap::new(),
         );
         let child = View::new_rect(
-            &"child".to_string(),
-            &"Child".to_string(),
+            "child",
+            "Child",
             ViewShape::default(),
             ViewStyle::new_default(),
             None,
@@ -755,8 +755,8 @@ mod tests {
     #[test]
     fn test_find_view_by_id() {
         let child = View::new_rect(
-            &"child".to_string(),
-            &"Child".to_string(),
+            "child",
+            "Child",
             ViewShape::default(),
             ViewStyle::new_default(),
             None,
@@ -768,8 +768,8 @@ mod tests {
             HashMap::new(),
         );
         let mut parent = View::new_rect(
-            &"parent".to_string(),
-            &"Parent".to_string(),
+            "parent",
+            "Parent",
             ViewShape::default(),
             ViewStyle::new_default(),
             None,
@@ -781,10 +781,10 @@ mod tests {
             HashMap::new(),
         );
         parent.add_child(child);
-        assert!(parent.find_view_by_id(&"child".to_string()).is_some());
-        assert!(parent.find_view_by_id(&"parent".to_string()).is_some());
-        assert!(parent.find_view_by_id(&"I1;child".to_string()).is_some());
-        assert!(parent.find_view_by_id(&"nonexistent".to_string()).is_none());
+        assert!(parent.find_view_by_id("child").is_some());
+        assert!(parent.find_view_by_id("parent").is_some());
+        assert!(parent.find_view_by_id("I1;child").is_some());
+        assert!(parent.find_view_by_id("nonexistent").is_none());
     }
 
     #[test]

--- a/crates/dc_bundle/src/definition_file.rs
+++ b/crates/dc_bundle/src/definition_file.rs
@@ -128,7 +128,7 @@ mod tests {
 
         let view_name = "test_view".to_string();
         let view = View::new_rect(
-            &"test_id".to_string(),
+            "test_id",
             &view_name,
             ViewShape::default(),
             style,

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -17,11 +17,12 @@
 //! The protobuf structs are generated from `animations.proto`.
 
 use crate::animation_spec_schema::{
-    AnimationOverrideJson, AnimationSpec as AnimationSpecJson, Animations as AnimationsJson,
-    BezierCurve as BezierCurveJson, CustomKeyframe as CustomKeyframeJson,
-    CustomTimeline as CustomTimelineJson, Duration, Easing as EasingJson, KeyFrame as KeyFrameJson,
-    KeyFrameAnimation as KeyFrameAnimationJson, RepeatType as RepeatTypeJson,
-    SmoothAnimation as SmoothAnimationJson, StopType as StopTypeJson,
+    AnimationMatrixJson, AnimationOverrideJson, AnimationSpec as AnimationSpecJson,
+    Animations as AnimationsJson, BezierCurve as BezierCurveJson,
+    CustomKeyframe as CustomKeyframeJson, CustomTimeline as CustomTimelineJson, Duration,
+    Easing as EasingJson, KeyFrame as KeyFrameJson, KeyFrameAnimation as KeyFrameAnimationJson,
+    RepeatType as RepeatTypeJson, SmoothAnimation as SmoothAnimationJson, StopType as StopTypeJson,
+    TransitionSpecJson,
 };
 use dc_bundle::animationspec;
 use dc_bundle::animationspec::{
@@ -59,6 +60,12 @@ impl From<&AnimationOverrideJson> for AnimationOverride {
             AnimationOverrideJson::Custom(spec) => animationspec::AnimationOverride {
                 animation_override: Some(animation_override::Animation_override::Custom(
                     spec.clone().into(),
+                )),
+                ..Default::default()
+            },
+            AnimationOverrideJson::Matrix(matrix) => animationspec::AnimationOverride {
+                animation_override: Some(animation_override::Animation_override::Matrix(
+                    matrix.into(),
                 )),
                 ..Default::default()
             },
@@ -177,6 +184,35 @@ impl From<AnimationSpecJson> for AnimationSpec {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Converts from the JSON `TransitionSpecJson` to the protobuf `TransitionSpec`.
+impl From<TransitionSpecJson> for animationspec::TransitionSpec {
+    fn from(json: TransitionSpecJson) -> Self {
+        animationspec::TransitionSpec {
+            from_variant: json.from,
+            to_variant: json.to,
+            animation_name: json.name,
+            spec: json.spec.map(|s| s.into()).into(),
+            custom_keyframe_data: json
+                .timelines
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Converts from the JSON `AnimationMatrixJson` to the protobuf `AnimationMatrix`.
+impl From<AnimationMatrixJson> for animationspec::AnimationMatrix {
+    fn from(json: AnimationMatrixJson) -> Self {
+        animationspec::AnimationMatrix {
+            default_spec: json.default_spec.map(|s| s.into()).into(),
+            transitions: json.transitions.into_iter().map(|t| t.into()).collect(),
             ..Default::default()
         }
     }

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -65,7 +65,7 @@ impl From<&AnimationOverrideJson> for AnimationOverride {
             },
             AnimationOverrideJson::Matrix(matrix) => animationspec::AnimationOverride {
                 animation_override: Some(animation_override::Animation_override::Matrix(
-                    matrix.into(),
+                    matrix.clone().into(),
                 )),
                 ..Default::default()
             },
@@ -197,11 +197,7 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
             to_variant: json.to,
             animation_name: json.name,
             spec: json.spec.map(|s| s.into()).into(),
-            custom_keyframe_data: json
-                .timelines
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
+            custom_keyframe_data: json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect(),
             ..Default::default()
         }
     }

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -257,6 +257,22 @@ impl From<AnimationSpecJson> for AnimationSpec {
     }
 }
 
+/// Normalizes a comma-separated variant string by sorting "Property=Value" assignments alphabetically.
+/// For example: "#heartbeat=on, #debug=on" and "#debug=on, #heartbeat=on" both normalize to "#debug=on, #heartbeat=on".
+/// Wildcards ("*") or single-property strings are returned unchanged.
+fn normalize_variant_string(s: &str) -> String {
+    if s.is_empty() || s == "*" {
+        return s.to_string();
+    }
+    let mut parts: Vec<&str> =
+        s.split(',').map(|part| part.trim()).filter(|part| !part.is_empty()).collect();
+    if parts.len() <= 1 {
+        return s.to_string();
+    }
+    parts.sort_unstable();
+    parts.join(", ")
+}
+
 /// Converts from the JSON `TransitionSpecJson` to the protobuf `TransitionSpec`.
 impl From<TransitionSpecJson> for animationspec::TransitionSpec {
     fn from(json: TransitionSpecJson) -> Self {
@@ -266,8 +282,8 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
             timelines.insert(k, v.into());
         }
         animationspec::TransitionSpec {
-            from_variant: json.from,
-            to_variant: json.to,
+            from_variant: normalize_variant_string(&json.from),
+            to_variant: normalize_variant_string(&json.to),
             animation_name: json.name,
             spec: json.spec.map(|s| s.into()).into(),
             timelines,

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -282,8 +282,8 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
             timelines.insert(k, v.into());
         }
         animationspec::TransitionSpec {
-            from_variant: normalize_variant_string(&json.from),
-            to_variant: normalize_variant_string(&json.to),
+            source_variant: normalize_variant_string(&json.from),
+            target_variant: normalize_variant_string(&json.to),
             animation_name: json.name,
             spec: json.spec.map(|s| s.into()).into(),
             timelines,

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -73,12 +73,33 @@ impl From<&AnimationOverrideJson> for AnimationOverride {
     }
 }
 
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GradientStopJson {
+    position: f32,
+    color: crate::figma_schema::FigmaColor,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ArcDataJson {
+    #[serde(alias = "starting_angle")]
+    starting_angle: f32,
+    #[serde(alias = "ending_angle")]
+    ending_angle: f32,
+    #[serde(alias = "inner_radius")]
+    inner_radius: f32,
+}
+
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
 enum CustomKeyframeValueJson {
     Scalar(f64),
+    Radii([f64; 4]),
     String(String),
     Color(crate::figma_schema::FigmaColor),
+    Gradient(Vec<GradientStopJson>),
+    Arc(ArcDataJson),
 }
 
 /// Converts from the JSON `CustomKeyframeJson` to the protobuf `CustomKeyframe`.
@@ -92,6 +113,17 @@ impl From<CustomKeyframeJson> for CustomKeyframe {
                 CustomKeyframeValueJson::Scalar(scalar) => {
                     typed_value.value =
                         Some(animationspec::custom_keyframe_value::Value::Scalar(scalar as f32));
+                }
+                CustomKeyframeValueJson::Radii(radii) => {
+                    typed_value.value = Some(animationspec::custom_keyframe_value::Value::Radii(
+                        animationspec::CornerRadiiValue {
+                            top_left: radii[0] as f32,
+                            top_right: radii[1] as f32,
+                            bottom_right: radii[2] as f32,
+                            bottom_left: radii[3] as f32,
+                            ..Default::default()
+                        },
+                    ));
                 }
                 CustomKeyframeValueJson::String(s) => {
                     if s.starts_with('#') {
@@ -145,6 +177,39 @@ impl From<CustomKeyframeJson> for CustomKeyframe {
                         },
                     ));
                 }
+                CustomKeyframeValueJson::Gradient(stops) => {
+                    let proto_stops = stops
+                        .into_iter()
+                        .map(|s| animationspec::GradientStopValue {
+                            position: s.position,
+                            color: ::protobuf::MessageField::some(animationspec::RgbaValue {
+                                r: (s.color.r * 255.0) as u32,
+                                g: (s.color.g * 255.0) as u32,
+                                b: (s.color.b * 255.0) as u32,
+                                a: (s.color.a * 255.0) as u32,
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })
+                        .collect();
+                    typed_value.value =
+                        Some(animationspec::custom_keyframe_value::Value::Gradient(
+                            animationspec::GradientValue {
+                                stops: proto_stops,
+                                ..Default::default()
+                            },
+                        ));
+                }
+                CustomKeyframeValueJson::Arc(arc) => {
+                    typed_value.value = Some(animationspec::custom_keyframe_value::Value::Arc(
+                        animationspec::ArcDataValue {
+                            starting_angle: arc.starting_angle,
+                            ending_angle: arc.ending_angle,
+                            inner_radius: arc.inner_radius,
+                            ..Default::default()
+                        },
+                    ));
+                }
             }
         }
 
@@ -178,11 +243,7 @@ impl From<AnimationSpecJson> for AnimationSpec {
         let mut custom_keyframe_data: std::collections::HashMap<
             String,
             animationspec::CustomTimeline,
-        > = json
-            .custom_keyframe_data
-            .into_iter()
-            .map(|(k, v)| (k, v.into()))
-            .collect();
+        > = json.custom_keyframe_data.into_iter().map(|(k, v)| (k, v.into())).collect();
         for (k, v) in json.timelines {
             custom_keyframe_data.entry(k).or_insert_with(|| v.into());
         }
@@ -202,7 +263,7 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
         let mut timelines: std::collections::HashMap<String, animationspec::CustomTimeline> =
             json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect();
         for (k, v) in json.custom_keyframe_data {
-            timelines.entry(k).or_insert_with(|| v.into());
+            timelines.insert(k, v.into());
         }
         animationspec::TransitionSpec {
             from_variant: json.from,
@@ -218,19 +279,23 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
 /// Converts from the JSON `AnimationMatrixJson` to the protobuf `AnimationMatrix`.
 impl From<AnimationMatrixJson> for animationspec::AnimationMatrix {
     fn from(json: AnimationMatrixJson) -> Self {
-        let mut root_timelines = json.timelines;
+        let mut root_timelines: std::collections::HashMap<String, animationspec::CustomTimeline> =
+            json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect();
         for (k, v) in json.custom_keyframe_data {
-            root_timelines.entry(k).or_insert(v);
+            root_timelines.insert(k, v.into());
         }
 
         let transitions = json
             .transitions
             .into_iter()
-            .map(|mut t_json| {
-                for (k, v) in &root_timelines {
-                    t_json.timelines.entry(k.clone()).or_insert_with(|| v.clone());
+            .map(|t_json| {
+                let mut proto: animationspec::TransitionSpec = t_json.into();
+                for (k, proto_timeline) in &root_timelines {
+                    if !proto.timelines.contains_key(k) {
+                        proto.timelines.insert(k.clone(), proto_timeline.clone());
+                    }
                 }
-                t_json.into()
+                proto
             })
             .collect();
 
@@ -654,5 +719,143 @@ mod tests {
         let proto_duration: ::protobuf::well_known_types::duration::Duration = json_duration.into();
         assert_eq!(proto_duration.seconds, 10);
         assert_eq!(proto_duration.nanos, 123);
+    }
+
+    #[test]
+    fn test_custom_keyframe_value_json_variants() {
+        // Test Radii
+        let json_radii = CustomKeyframeJson {
+            fraction: 0.5,
+            value_json: serde_json::json!([1.0, 2.0, 3.0, 4.0]),
+            easing: EasingJson::String("Linear".to_string()),
+        };
+        let proto_radii: CustomKeyframe = json_radii.into();
+        match proto_radii.value.as_ref().and_then(|v| v.value.as_ref()) {
+            Some(animationspec::custom_keyframe_value::Value::Radii(r)) => {
+                assert_eq!(r.top_left, 1.0);
+                assert_eq!(r.top_right, 2.0);
+                assert_eq!(r.bottom_right, 3.0);
+                assert_eq!(r.bottom_left, 4.0);
+            }
+            other => panic!("Expected Radii variant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_transition_custom_keyframe_override_precedence() {
+        let root_tl = CustomTimelineJson {
+            target_easing: EasingJson::String("Linear".to_string()),
+            keyframes: vec![CustomKeyframeJson {
+                fraction: 0.0,
+                value_json: serde_json::json!(10.0),
+                easing: EasingJson::String("Linear".to_string()),
+            }],
+        };
+        let transition_tl = CustomTimelineJson {
+            target_easing: EasingJson::String("Linear".to_string()),
+            keyframes: vec![CustomKeyframeJson {
+                fraction: 0.0,
+                value_json: serde_json::json!(99.0),
+                easing: EasingJson::String("Linear".to_string()),
+            }],
+        };
+
+        let mut custom_keyframe_data = std::collections::HashMap::new();
+        custom_keyframe_data.insert("node-opacity".to_string(), transition_tl);
+
+        let mut root_timelines = std::collections::HashMap::new();
+        root_timelines.insert("node-opacity".to_string(), root_tl);
+
+        let transition_json = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: String::new(),
+            spec: None,
+            timelines: root_timelines,
+            custom_keyframe_data,
+        };
+        let proto_transition: animationspec::TransitionSpec = transition_json.into();
+        let tl = proto_transition.timelines.get("node-opacity").expect("timeline should exist");
+        let first_kf = &tl.keyframes[0];
+        match first_kf.value.as_ref().and_then(|v| v.value.as_ref()) {
+            Some(animationspec::custom_keyframe_value::Value::Scalar(val)) => {
+                assert_eq!(
+                    *val, 99.0,
+                    "Transition override (99.0) should take precedence over root timeline (10.0)"
+                );
+            }
+            other => panic!("Expected Scalar(99.0), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_root_timeline_deduplication_and_merging() {
+        let root_tl = CustomTimelineJson {
+            target_easing: EasingJson::String("Linear".to_string()),
+            keyframes: vec![CustomKeyframeJson {
+                fraction: 0.0,
+                value_json: serde_json::json!(5.0),
+                easing: EasingJson::String("Linear".to_string()),
+            }],
+        };
+        let override_tl = CustomTimelineJson {
+            target_easing: EasingJson::String("Linear".to_string()),
+            keyframes: vec![CustomKeyframeJson {
+                fraction: 0.0,
+                value_json: serde_json::json!(42.0),
+                easing: EasingJson::String("Linear".to_string()),
+            }],
+        };
+
+        let mut root_timelines = std::collections::HashMap::new();
+        root_timelines.insert("shared-prop".to_string(), root_tl);
+
+        let transition1 = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: String::new(),
+            spec: None,
+            timelines: std::collections::HashMap::new(),
+            custom_keyframe_data: std::collections::HashMap::new(),
+        };
+
+        let mut t2_timelines = std::collections::HashMap::new();
+        t2_timelines.insert("shared-prop".to_string(), override_tl);
+        let transition2 = TransitionSpecJson {
+            from: "B".to_string(),
+            to: "C".to_string(),
+            name: String::new(),
+            spec: None,
+            timelines: t2_timelines,
+            custom_keyframe_data: std::collections::HashMap::new(),
+        };
+
+        let matrix_json = AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![transition1, transition2],
+            timelines: root_timelines,
+            custom_keyframe_data: std::collections::HashMap::new(),
+        };
+
+        let proto_matrix: animationspec::AnimationMatrix = matrix_json.into();
+        assert_eq!(proto_matrix.transitions.len(), 2);
+
+        let t1 = &proto_matrix.transitions[0];
+        let t1_tl = t1.timelines.get("shared-prop").expect("t1 should inherit root timeline");
+        match t1_tl.keyframes[0].value.as_ref().and_then(|v| v.value.as_ref()) {
+            Some(animationspec::custom_keyframe_value::Value::Scalar(val)) => {
+                assert_eq!(*val, 5.0);
+            }
+            other => panic!("Expected Scalar(5.0), got {:?}", other),
+        }
+
+        let t2 = &proto_matrix.transitions[1];
+        let t2_tl = t2.timelines.get("shared-prop").expect("t2 should have override timeline");
+        match t2_tl.keyframes[0].value.as_ref().and_then(|v| v.value.as_ref()) {
+            Some(animationspec::custom_keyframe_value::Value::Scalar(val)) => {
+                assert_eq!(*val, 42.0);
+            }
+            other => panic!("Expected Scalar(42.0), got {:?}", other),
+        }
     }
 }

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -175,15 +175,22 @@ impl From<CustomTimelineJson> for CustomTimeline {
 /// Converts from the JSON `AnimationSpecJson` to the protobuf `AnimationSpec`.
 impl From<AnimationSpecJson> for AnimationSpec {
     fn from(json: AnimationSpecJson) -> Self {
+        let mut custom_keyframe_data: std::collections::HashMap<
+            String,
+            animationspec::CustomTimeline,
+        > = json
+            .custom_keyframe_data
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect();
+        for (k, v) in json.timelines {
+            custom_keyframe_data.entry(k).or_insert_with(|| v.into());
+        }
         AnimationSpec {
             initial_delay: Some(json.initial_delay.into()).into(),
             animation: Some(json.animation.into()).into(),
             interrupt_type: json.interrupt_type.map(|x| x.into()).into(),
-            custom_keyframe_data: json
-                .custom_keyframe_data
-                .into_iter()
-                .map(|(k, v)| (k, v.into()))
-                .collect(),
+            custom_keyframe_data,
             ..Default::default()
         }
     }
@@ -192,12 +199,17 @@ impl From<AnimationSpecJson> for AnimationSpec {
 /// Converts from the JSON `TransitionSpecJson` to the protobuf `TransitionSpec`.
 impl From<TransitionSpecJson> for animationspec::TransitionSpec {
     fn from(json: TransitionSpecJson) -> Self {
+        let mut timelines: std::collections::HashMap<String, animationspec::CustomTimeline> =
+            json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect();
+        for (k, v) in json.custom_keyframe_data {
+            timelines.entry(k).or_insert_with(|| v.into());
+        }
         animationspec::TransitionSpec {
             from_variant: json.from,
             to_variant: json.to,
             animation_name: json.name,
             spec: json.spec.map(|s| s.into()).into(),
-            timelines: json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            timelines,
             ..Default::default()
         }
     }
@@ -206,9 +218,25 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
 /// Converts from the JSON `AnimationMatrixJson` to the protobuf `AnimationMatrix`.
 impl From<AnimationMatrixJson> for animationspec::AnimationMatrix {
     fn from(json: AnimationMatrixJson) -> Self {
+        let mut root_timelines = json.timelines;
+        for (k, v) in json.custom_keyframe_data {
+            root_timelines.entry(k).or_insert(v);
+        }
+
+        let transitions = json
+            .transitions
+            .into_iter()
+            .map(|mut t_json| {
+                for (k, v) in &root_timelines {
+                    t_json.timelines.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+                t_json.into()
+            })
+            .collect();
+
         animationspec::AnimationMatrix {
             default_spec: json.default_spec.map(|s| s.into()).into(),
-            transitions: json.transitions.into_iter().map(|t| t.into()).collect(),
+            transitions,
             ..Default::default()
         }
     }
@@ -461,7 +489,7 @@ mod tests {
             initial_delay: Duration { secs: 1, nanos: 500_000_000.0 },
             animation: AnimationsJson::default(),
             interrupt_type: Some(StopTypeJson::Complete),
-            custom_keyframe_data: std::collections::HashMap::new(),
+            ..Default::default()
         };
         let proto_spec: AnimationSpec = json_spec.into();
         assert_eq!(proto_spec.initial_delay.get_or_default().seconds, 1);
@@ -477,7 +505,7 @@ mod tests {
             initial_delay: Duration { secs: 1, nanos: 500_000_000.0 },
             animation: AnimationsJson::default(),
             interrupt_type: None,
-            custom_keyframe_data: std::collections::HashMap::new(),
+            ..Default::default()
         };
         let proto_spec_no_interrupt: AnimationSpec = json_spec_no_interrupt.into();
         assert!(proto_spec_no_interrupt.interrupt_type.is_none());

--- a/crates/dc_figma_import/src/animation_override.rs
+++ b/crates/dc_figma_import/src/animation_override.rs
@@ -197,7 +197,7 @@ impl From<TransitionSpecJson> for animationspec::TransitionSpec {
             to_variant: json.to,
             animation_name: json.name,
             spec: json.spec.map(|s| s.into()).into(),
-            custom_keyframe_data: json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            timelines: json.timelines.into_iter().map(|(k, v)| (k, v.into())).collect(),
             ..Default::default()
         }
     }

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -206,6 +206,36 @@ pub struct AnimationMatrixJson {
     pub transitions: Vec<TransitionSpecJson>,
 }
 
+impl TransitionSpecJson {
+    /// Validates the transition spec fields.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.from.is_empty() && self.to.is_empty() {
+            return Err("TransitionSpec 'from' and 'to' cannot both be empty".to_string());
+        }
+        for (prop_name, timeline) in &self.timelines {
+            for keyframe in &timeline.keyframes {
+                if !(0.0..=1.0).contains(&keyframe.fraction) {
+                    return Err(format!(
+                        "Keyframe fraction {} for property '{}' is out of range [0.0, 1.0]",
+                        keyframe.fraction, prop_name
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AnimationMatrixJson {
+    /// Validates the animation matrix structure and all transition specs.
+    pub fn validate(&self) -> Result<(), String> {
+        for (idx, transition) in self.transitions.iter().enumerate() {
+            transition.validate().map_err(|e| format!("Transition [{}] invalid: {}", idx, e))?;
+        }
+        Ok(())
+    }
+}
+
 /// This is the top-level structure that the plugin saves to a Figma node.
 #[derive(Serialize, Clone, Debug, PartialEq)]
 pub enum AnimationOverrideJson {
@@ -222,6 +252,16 @@ pub enum AnimationOverrideJson {
 impl Default for AnimationOverrideJson {
     fn default() -> Self {
         AnimationOverrideJson::Default
+    }
+}
+
+impl AnimationOverrideJson {
+    /// Validates the animation override.
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            AnimationOverrideJson::Matrix(matrix) => matrix.validate(),
+            _ => Ok(()),
+        }
     }
 }
 
@@ -465,7 +505,9 @@ mod tests {
         }"#;
         let anim = serde_json::from_str::<AnimationOverrideJson>(json_str);
         assert!(anim.is_ok(), "Failed to parse Option A matrix JSON: {:?}", anim.err());
-        if let AnimationOverrideJson::Matrix(matrix) = anim.unwrap() {
+        let anim_val = anim.unwrap();
+        assert!(anim_val.validate().is_ok(), "Validation failed: {:?}", anim_val.validate());
+        if let AnimationOverrideJson::Matrix(matrix) = anim_val {
             assert!(matrix.default_spec.is_some());
             assert_eq!(matrix.transitions.len(), 2);
             assert_eq!(matrix.transitions[0].from, "VariantA");
@@ -476,5 +518,17 @@ mod tests {
         } else {
             panic!("Expected AnimationOverrideJson::Matrix");
         }
+    }
+
+    #[test]
+    fn test_validate_invalid_transition() {
+        let invalid_transition = TransitionSpecJson {
+            from: "".to_string(),
+            to: "".to_string(),
+            name: "Invalid".to_string(),
+            spec: None,
+            timelines: std::collections::HashMap::new(),
+        };
+        assert!(invalid_transition.validate().is_err());
     }
 }

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -175,16 +175,54 @@ pub struct AnimationSpec {
     pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
 }
 
+/// Represents a single transition specification between variant states (Option A).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+pub struct TransitionSpecJson {
+    /// Origin variant state or wildcard ("*")
+    pub from: String,
+    /// Destination variant state
+    pub to: String,
+    /// Custom animation identifier (defaults to "Default")
+    #[serde(default = "default_animation_name")]
+    pub name: String,
+    /// Optional animation specification (delay, duration, easing, etc.)
+    pub spec: Option<AnimationSpec>,
+    /// Timelines for custom properties
+    #[serde(default)]
+    pub timelines: std::collections::HashMap<String, CustomTimeline>,
+}
+
+fn default_animation_name() -> String {
+    "Default".to_string()
+}
+
+/// Root animation matrix structure for Option A transition matrix storage.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+pub struct AnimationMatrixJson {
+    /// Default animation spec fallback across all transitions
+    pub default_spec: Option<AnimationSpec>,
+    /// Array of explicit transition specifications
+    #[serde(default)]
+    pub transitions: Vec<TransitionSpecJson>,
+}
+
 /// This is the top-level structure that the plugin saves to a Figma node.
-#[derive(Serialize, Clone, Debug, PartialEq, Default)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 pub enum AnimationOverrideJson {
     /// Use the default animation behavior.
-    #[default]
     Default,
     /// Use a custom animation specification.
     Custom(AnimationSpec),
+    /// Use a transition matrix specification (Option A).
+    Matrix(AnimationMatrixJson),
     /// Disable all animations.
     DisableAnimations,
+}
+
+impl Default for AnimationOverrideJson {
+    fn default() -> Self {
+        AnimationOverrideJson::Default
+    }
 }
 
 impl<'de> Deserialize<'de> for AnimationOverrideJson {
@@ -208,10 +246,18 @@ impl<'de> Deserialize<'de> for AnimationOverrideJson {
             spec: Option<AnimationSpec>,
             #[serde(rename = "customKeyframeData", default)]
             custom_keyframe_data_raw: std::collections::HashMap<String, CustomTimelineRaw>,
+            default_spec: Option<AnimationSpec>,
+            transitions: Option<Vec<TransitionSpecJson>>,
         }
 
         let tmp = Tmp::deserialize(deserializer)?;
-        if tmp.override_type == "Custom" || (tmp.override_type.is_empty() && tmp.spec.is_some()) {
+        if tmp.transitions.is_some() || tmp.default_spec.is_some() {
+            let matrix = AnimationMatrixJson {
+                default_spec: tmp.default_spec,
+                transitions: tmp.transitions.unwrap_or_default(),
+            };
+            Ok(AnimationOverrideJson::Matrix(matrix))
+        } else if tmp.override_type == "Custom" || (tmp.override_type.is_empty() && tmp.spec.is_some()) {
             if let Some(mut spec) = tmp.spec {
                 let mut custom_keyframe_data = std::collections::HashMap::new();
                 for (k, v) in tmp.custom_keyframe_data_raw {
@@ -366,5 +412,67 @@ mod tests {
         let anim = serde_json::from_str::<AnimationOverrideJson>(json_str);
         assert!(anim.is_ok(), "Failed to parse JSON: {:?}", anim.err());
         println!("Successfully parsed: {:?}", anim.unwrap());
+    }
+
+    #[test]
+    fn test_deserialize_animation_matrix() {
+        let json_str = r#"{
+            "default_spec": {
+                "initial_delay": { "secs": 0, "nanos": 0 },
+                "animation": {
+                    "Smooth": {
+                        "duration": { "secs": 0, "nanos": 300000000 },
+                        "repeat_type": "NoRepeat",
+                        "easing": "Linear"
+                    }
+                },
+                "interrupt_type": "None"
+            },
+            "transitions": [
+                {
+                    "from": "VariantA",
+                    "to": "VariantB",
+                    "name": "Default",
+                    "spec": {
+                        "initial_delay": { "secs": 0, "nanos": 0 },
+                        "animation": {
+                            "Smooth": {
+                                "duration": { "secs": 0, "nanos": 500000000 },
+                                "repeat_type": "NoRepeat",
+                                "easing": "EaseInOut"
+                            }
+                        },
+                        "interrupt_type": "None"
+                    },
+                    "timelines": {
+                        "PRNDState-x": {
+                            "target_easing": "Linear",
+                            "keyframes": [
+                                { "fraction": 0.5, "value_json": 100.0, "easing": "EaseIn" }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "from": "*",
+                    "to": "VariantB",
+                    "name": "AlertPop",
+                    "timelines": {}
+                }
+            ]
+        }"#;
+        let anim = serde_json::from_str::<AnimationOverrideJson>(json_str);
+        assert!(anim.is_ok(), "Failed to parse Option A matrix JSON: {:?}", anim.err());
+        if let AnimationOverrideJson::Matrix(matrix) = anim.unwrap() {
+            assert!(matrix.default_spec.is_some());
+            assert_eq!(matrix.transitions.len(), 2);
+            assert_eq!(matrix.transitions[0].from, "VariantA");
+            assert_eq!(matrix.transitions[0].to, "VariantB");
+            assert_eq!(matrix.transitions[0].name, "Default");
+            assert_eq!(matrix.transitions[1].from, "*");
+            assert_eq!(matrix.transitions[1].name, "AlertPop");
+        } else {
+            panic!("Expected AnimationOverrideJson::Matrix");
+        }
     }
 }

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -257,7 +257,9 @@ impl<'de> Deserialize<'de> for AnimationOverrideJson {
                 transitions: tmp.transitions.unwrap_or_default(),
             };
             Ok(AnimationOverrideJson::Matrix(matrix))
-        } else if tmp.override_type == "Custom" || (tmp.override_type.is_empty() && tmp.spec.is_some()) {
+        } else if tmp.override_type == "Custom"
+            || (tmp.override_type.is_empty() && tmp.spec.is_some())
+        {
             if let Some(mut spec) = tmp.spec {
                 let mut custom_keyframe_data = std::collections::HashMap::new();
                 for (k, v) in tmp.custom_keyframe_data_raw {

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -530,5 +530,243 @@ mod tests {
             timelines: std::collections::HashMap::new(),
         };
         assert!(invalid_transition.validate().is_err());
+
+        let mut valid_transition = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: "Valid".to_string(),
+            spec: None,
+            timelines: std::collections::HashMap::new(),
+        };
+        assert!(valid_transition.validate().is_ok());
+
+        let timeline = CustomTimeline {
+            target_easing: Easing::String("Linear".to_string()),
+            keyframes: vec![CustomKeyframe {
+                fraction: 1.5,
+                value_json: serde_json::Value::Null,
+                easing: Easing::String("Linear".to_string()),
+            }],
+        };
+        valid_transition.timelines.insert("Prop".to_string(), timeline);
+        assert!(valid_transition.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_animation_matrix() {
+        let matrix = AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "".to_string(),
+                to: "".to_string(),
+                name: "Invalid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        };
+        let err = matrix.validate().unwrap_err();
+        assert!(err.contains("Transition [0] invalid:"));
+    }
+
+    #[test]
+    fn test_validate_animation_override() {
+        let default_override = AnimationOverrideJson::Default;
+        assert!(default_override.validate().is_ok());
+
+        let custom_override = AnimationOverrideJson::Custom(AnimationSpec::default());
+        assert!(custom_override.validate().is_ok());
+
+        let disable_override = AnimationOverrideJson::DisableAnimations;
+        assert!(disable_override.validate().is_ok());
+
+        let invalid_matrix = AnimationOverrideJson::Matrix(AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "".to_string(),
+                to: "".to_string(),
+                name: "Invalid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        });
+        assert!(invalid_matrix.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_transition_invalid_keyframe_fraction() {
+        let mut timelines = std::collections::HashMap::new();
+        timelines.insert(
+            "Prop".to_string(),
+            CustomTimeline {
+                target_easing: Easing::String("Linear".to_string()),
+                keyframes: vec![CustomKeyframe {
+                    fraction: 1.5,
+                    value_json: serde_json::Value::Null,
+                    easing: Easing::String("Linear".to_string()),
+                }],
+            },
+        );
+        let invalid_transition = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: "Test".to_string(),
+            spec: None,
+            timelines,
+        };
+        assert!(invalid_transition.validate().is_err());
+
+        let mut timelines_neg = std::collections::HashMap::new();
+        timelines_neg.insert(
+            "Prop".to_string(),
+            CustomTimeline {
+                target_easing: Easing::String("Linear".to_string()),
+                keyframes: vec![CustomKeyframe {
+                    fraction: -0.1,
+                    value_json: serde_json::Value::Null,
+                    easing: Easing::String("Linear".to_string()),
+                }],
+            },
+        );
+        let invalid_transition_neg = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: "Test".to_string(),
+            spec: None,
+            timelines: timelines_neg,
+        };
+        assert!(invalid_transition_neg.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_transition_valid() {
+        let mut timelines = std::collections::HashMap::new();
+        timelines.insert(
+            "Prop".to_string(),
+            CustomTimeline {
+                target_easing: Easing::String("Linear".to_string()),
+                keyframes: vec![CustomKeyframe {
+                    fraction: 1.0,
+                    value_json: serde_json::Value::Null,
+                    easing: Easing::String("Linear".to_string()),
+                }],
+            },
+        );
+        let valid_transition = TransitionSpecJson {
+            from: "A".to_string(),
+            to: "B".to_string(),
+            name: "Test".to_string(),
+            spec: None,
+            timelines,
+        };
+        assert!(valid_transition.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_matrix_invalid_transition() {
+        let matrix = AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "".to_string(),
+                to: "".to_string(),
+                name: "Invalid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        };
+        assert!(matrix.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_matrix_valid() {
+        let matrix = AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "A".to_string(),
+                to: "B".to_string(),
+                name: "Valid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        };
+        assert!(matrix.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_animation_override_extended() {
+        let invalid_matrix = AnimationOverrideJson::Matrix(AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "".to_string(),
+                to: "".to_string(),
+                name: "Invalid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        });
+        assert!(invalid_matrix.validate().is_err());
+
+        let valid_matrix = AnimationOverrideJson::Matrix(AnimationMatrixJson {
+            default_spec: None,
+            transitions: vec![TransitionSpecJson {
+                from: "A".to_string(),
+                to: "B".to_string(),
+                name: "Valid".to_string(),
+                spec: None,
+                timelines: std::collections::HashMap::new(),
+            }],
+        });
+        assert!(valid_matrix.validate().is_ok());
+
+        assert!(AnimationOverrideJson::Default.validate().is_ok());
+        assert!(AnimationOverrideJson::DisableAnimations.validate().is_ok());
+        assert!(AnimationOverrideJson::Custom(AnimationSpec::default()).validate().is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_matrix_default_animation_name() {
+        let json_str = r#"{
+            "transitions": [
+                {
+                    "from": "A",
+                    "to": "B"
+                }
+            ]
+        }"#;
+        let anim = serde_json::from_str::<AnimationOverrideJson>(json_str).unwrap();
+        if let AnimationOverrideJson::Matrix(matrix) = anim {
+            assert_eq!(matrix.transitions[0].name, "Default");
+        } else {
+            unreachable!("Expected Matrix");
+        }
+    }
+
+    #[test]
+    fn test_deserialize_matrix_missing_transitions_field() {
+        let json_str = r#"{
+            "default_spec": {
+                "initial_delay": { "secs": 0, "nanos": 0 },
+                "animation": {
+                    "Smooth": {
+                        "duration": { "secs": 0, "nanos": 300000000 },
+                        "repeat_type": "NoRepeat",
+                        "easing": "Linear"
+                    }
+                },
+                "interrupt_type": "None"
+            }
+        }"#;
+        let anim = serde_json::from_str::<AnimationOverrideJson>(json_str).unwrap();
+        if let AnimationOverrideJson::Matrix(matrix) = anim {
+            assert_eq!(matrix.transitions.len(), 0);
+            assert!(matrix.default_spec.is_some());
+        } else {
+            unreachable!("Expected Matrix");
+        }
+    }
+
+    #[test]
+    fn test_animation_override_json_default() {
+        let def = AnimationOverrideJson::default();
+        assert!(matches!(def, AnimationOverrideJson::Default));
     }
 }

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -133,10 +133,12 @@ pub struct Animations {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum StopType {
     /// No specific interruption behavior.
+    #[serde(alias = "Cancel")]
     None,
     /// Resets the animation to its starting state.
     ResetToStart,
     /// Immediately jumps to the final state of the animation.
+    #[serde(alias = "JumpToEnd")]
     Complete,
     /// Stops the animation at its current state.
     Stop,
@@ -159,6 +161,44 @@ pub struct CustomTimeline {
     pub keyframes: Vec<CustomKeyframe>,
 }
 
+/// Represents a raw custom timeline from JSON which can be either a typed struct or stringified JSON.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum CustomTimelineRaw {
+    Typed(CustomTimeline),
+    Stringified(String),
+}
+
+impl CustomTimelineRaw {
+    /// Decodes the raw timeline into a typed `CustomTimeline`.
+    pub fn into_timeline(self) -> Option<CustomTimeline> {
+        match self {
+            CustomTimelineRaw::Typed(ct) => Some(ct),
+            CustomTimelineRaw::Stringified(s) => serde_json::from_str::<CustomTimeline>(&s).ok(),
+        }
+    }
+}
+
+/// Helper function to deserialize a map of timelines from either typed structs or stringified JSON.
+pub fn deserialize_custom_timelines_map<'de, D>(
+    deserializer: D,
+) -> Result<std::collections::HashMap<String, CustomTimeline>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw_map =
+        std::collections::HashMap::<String, CustomTimelineRaw>::deserialize(deserializer)?;
+    let mut result = std::collections::HashMap::new();
+    for (key, val) in raw_map {
+        if let Some(timeline) = val.into_timeline() {
+            result.insert(key, timeline);
+        } else {
+            log::warn!("Failed to decode custom timeline JSON string for key: {}", key);
+        }
+    }
+    Ok(result)
+}
+
 /// The detailed specification for a custom animation, present when "Custom" is
 /// selected in the top-level "Animation" dropdown.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
@@ -172,7 +212,11 @@ pub struct AnimationSpec {
     pub interrupt_type: Option<StopType>,
     /// Optional dictionary containing Squoosh arbitrary layer property values to animate from
     /// strings directly written by the UI plugin format over into matching types in Compose
+    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
     pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
+    /// Timelines for custom properties
+    #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
+    pub timelines: std::collections::HashMap<String, CustomTimeline>,
 }
 
 /// Represents a single transition specification between variant states (Option A).
@@ -188,8 +232,11 @@ pub struct TransitionSpecJson {
     /// Optional animation specification (delay, duration, easing, etc.)
     pub spec: Option<AnimationSpec>,
     /// Timelines for custom properties
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
     pub timelines: std::collections::HashMap<String, CustomTimeline>,
+    /// Legacy/plugin field for custom property keyframe timelines exported as stringified JSON
+    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
+    pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
 }
 
 fn default_animation_name() -> String {
@@ -204,6 +251,12 @@ pub struct AnimationMatrixJson {
     /// Array of explicit transition specifications
     #[serde(default)]
     pub transitions: Vec<TransitionSpecJson>,
+    /// Node timelines stored at the matrix root level
+    #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
+    pub timelines: std::collections::HashMap<String, CustomTimeline>,
+    /// Legacy/alias name for node timelines stored at the matrix root level
+    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
+    pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
 }
 
 impl TransitionSpecJson {
@@ -212,7 +265,7 @@ impl TransitionSpecJson {
         if self.from.is_empty() && self.to.is_empty() {
             return Err("TransitionSpec 'from' and 'to' cannot both be empty".to_string());
         }
-        for (prop_name, timeline) in &self.timelines {
+        for (prop_name, timeline) in self.timelines.iter().chain(self.custom_keyframe_data.iter()) {
             for keyframe in &timeline.keyframes {
                 if !(0.0..=1.0).contains(&keyframe.fraction) {
                     return Err(format!(
@@ -273,47 +326,38 @@ impl<'de> Deserialize<'de> for AnimationOverrideJson {
         // Tmp structure to deserialize the format from the API and handle cases hard to describe
         // with serde attributes.
         #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum CustomTimelineRaw {
-            Typed(CustomTimeline),
-            Stringified(String),
-        }
-
-        #[derive(Deserialize)]
         struct Tmp {
             #[serde(rename = "override", default)]
             override_type: String,
             spec: Option<AnimationSpec>,
             #[serde(rename = "customKeyframeData", default)]
             custom_keyframe_data_raw: std::collections::HashMap<String, CustomTimelineRaw>,
+            #[serde(rename = "timelines", default)]
+            timelines_raw: std::collections::HashMap<String, CustomTimelineRaw>,
             default_spec: Option<AnimationSpec>,
             transitions: Option<Vec<TransitionSpecJson>>,
         }
 
         let tmp = Tmp::deserialize(deserializer)?;
+        let mut custom_keyframe_data = std::collections::HashMap::new();
+        for (k, v) in tmp.custom_keyframe_data_raw.into_iter().chain(tmp.timelines_raw.into_iter()) {
+            if let Some(ct) = v.into_timeline() {
+                custom_keyframe_data.insert(k, ct);
+            }
+        }
+
         if tmp.transitions.is_some() || tmp.default_spec.is_some() {
             let matrix = AnimationMatrixJson {
                 default_spec: tmp.default_spec,
                 transitions: tmp.transitions.unwrap_or_default(),
+                custom_keyframe_data: custom_keyframe_data.clone(),
+                timelines: custom_keyframe_data,
             };
             Ok(AnimationOverrideJson::Matrix(matrix))
         } else if tmp.override_type == "Custom"
             || (tmp.override_type.is_empty() && tmp.spec.is_some())
         {
             if let Some(mut spec) = tmp.spec {
-                let mut custom_keyframe_data = std::collections::HashMap::new();
-                for (k, v) in tmp.custom_keyframe_data_raw {
-                    match v {
-                        CustomTimelineRaw::Typed(ct) => {
-                            custom_keyframe_data.insert(k, ct);
-                        }
-                        CustomTimelineRaw::Stringified(s) => {
-                            if let Ok(ct) = serde_json::from_str::<CustomTimeline>(&s) {
-                                custom_keyframe_data.insert(k, ct);
-                            }
-                        }
-                    }
-                }
                 spec.custom_keyframe_data = custom_keyframe_data;
                 Ok(AnimationOverrideJson::Custom(spec))
             } else {
@@ -526,8 +570,7 @@ mod tests {
             from: "".to_string(),
             to: "".to_string(),
             name: "Invalid".to_string(),
-            spec: None,
-            timelines: std::collections::HashMap::new(),
+            ..Default::default()
         };
         assert!(invalid_transition.validate().is_err());
 
@@ -535,8 +578,7 @@ mod tests {
             from: "A".to_string(),
             to: "B".to_string(),
             name: "Valid".to_string(),
-            spec: None,
-            timelines: std::collections::HashMap::new(),
+            ..Default::default()
         };
         assert!(valid_transition.validate().is_ok());
 
@@ -560,9 +602,9 @@ mod tests {
                 from: "".to_string(),
                 to: "".to_string(),
                 name: "Invalid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         };
         let err = matrix.validate().unwrap_err();
         assert!(err.contains("Transition [0] invalid:"));
@@ -585,9 +627,9 @@ mod tests {
                 from: "".to_string(),
                 to: "".to_string(),
                 name: "Invalid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         });
         assert!(invalid_matrix.validate().is_err());
     }
@@ -612,6 +654,7 @@ mod tests {
             name: "Test".to_string(),
             spec: None,
             timelines,
+            ..Default::default()
         };
         assert!(invalid_transition.validate().is_err());
 
@@ -633,6 +676,7 @@ mod tests {
             name: "Test".to_string(),
             spec: None,
             timelines: timelines_neg,
+            ..Default::default()
         };
         assert!(invalid_transition_neg.validate().is_err());
     }
@@ -657,6 +701,7 @@ mod tests {
             name: "Test".to_string(),
             spec: None,
             timelines,
+            ..Default::default()
         };
         assert!(valid_transition.validate().is_ok());
     }
@@ -669,9 +714,9 @@ mod tests {
                 from: "".to_string(),
                 to: "".to_string(),
                 name: "Invalid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         };
         assert!(matrix.validate().is_err());
     }
@@ -684,9 +729,9 @@ mod tests {
                 from: "A".to_string(),
                 to: "B".to_string(),
                 name: "Valid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         };
         assert!(matrix.validate().is_ok());
     }
@@ -699,9 +744,9 @@ mod tests {
                 from: "".to_string(),
                 to: "".to_string(),
                 name: "Invalid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         });
         assert!(invalid_matrix.validate().is_err());
 
@@ -711,9 +756,9 @@ mod tests {
                 from: "A".to_string(),
                 to: "B".to_string(),
                 name: "Valid".to_string(),
-                spec: None,
-                timelines: std::collections::HashMap::new(),
+                ..Default::default()
             }],
+            ..Default::default()
         });
         assert!(valid_matrix.validate().is_ok());
 
@@ -768,5 +813,44 @@ mod tests {
     fn test_animation_override_json_default() {
         let def = AnimationOverrideJson::default();
         assert!(matches!(def, AnimationOverrideJson::Default));
+    }
+
+    #[test]
+    fn test_deserialize_matrix_custom_keyframe_data_stringified() {
+        let json_str = r##"{
+            "transitions": [
+                {
+                    "from": "#driving/shift-state=N",
+                    "to": "#driving/shift-state=D",
+                    "name": "SportMode",
+                    "spec": {
+                        "initial_delay": { "secs": 0, "nanos": 0 },
+                        "animation": {
+                            "Smooth": {
+                                "duration": { "secs": 1, "nanos": 500000000 },
+                                "repeat_type": "NoRepeat",
+                                "easing": "EaseOut"
+                            }
+                        },
+                        "interrupt_type": "None"
+                    },
+                    "customKeyframeData": {
+                        "D-opacity": "{\"targetEasing\": \"EaseOut\", \"keyframes\": [{\"fraction\": 0.2, \"value\": 0.0, \"easing\": \"EaseIn\"}, {\"fraction\": 1.0, \"value\": 1.0, \"easing\": \"EaseOut\"}]}"
+                    }
+                }
+            ]
+        }"##;
+        let anim = serde_json::from_str::<AnimationOverrideJson>(json_str).unwrap();
+        if let AnimationOverrideJson::Matrix(matrix) = anim {
+            assert_eq!(matrix.transitions.len(), 1);
+            let t = &matrix.transitions[0];
+            assert_eq!(t.name, "SportMode");
+            assert!(t.custom_keyframe_data.contains_key("D-opacity"), "Expected D-opacity in custom_keyframe_data map");
+            let timeline = &t.custom_keyframe_data["D-opacity"];
+            assert_eq!(timeline.keyframes.len(), 2);
+            assert_eq!(timeline.keyframes[0].fraction, 0.2);
+        } else {
+            unreachable!("Expected Matrix");
+        }
     }
 }

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -212,7 +212,11 @@ pub struct AnimationSpec {
     pub interrupt_type: Option<StopType>,
     /// Optional dictionary containing Squoosh arbitrary layer property values to animate from
     /// strings directly written by the UI plugin format over into matching types in Compose
-    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
+    #[serde(
+        rename = "customKeyframeData",
+        default,
+        deserialize_with = "deserialize_custom_timelines_map"
+    )]
     pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
     /// Timelines for custom properties
     #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
@@ -235,7 +239,11 @@ pub struct TransitionSpecJson {
     #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
     pub timelines: std::collections::HashMap<String, CustomTimeline>,
     /// Legacy/plugin field for custom property keyframe timelines exported as stringified JSON
-    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
+    #[serde(
+        rename = "customKeyframeData",
+        default,
+        deserialize_with = "deserialize_custom_timelines_map"
+    )]
     pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
 }
 
@@ -255,7 +263,11 @@ pub struct AnimationMatrixJson {
     #[serde(default, deserialize_with = "deserialize_custom_timelines_map")]
     pub timelines: std::collections::HashMap<String, CustomTimeline>,
     /// Legacy/alias name for node timelines stored at the matrix root level
-    #[serde(rename = "customKeyframeData", default, deserialize_with = "deserialize_custom_timelines_map")]
+    #[serde(
+        rename = "customKeyframeData",
+        default,
+        deserialize_with = "deserialize_custom_timelines_map"
+    )]
     pub custom_keyframe_data: std::collections::HashMap<String, CustomTimeline>,
 }
 
@@ -340,7 +352,8 @@ impl<'de> Deserialize<'de> for AnimationOverrideJson {
 
         let tmp = Tmp::deserialize(deserializer)?;
         let mut custom_keyframe_data = std::collections::HashMap::new();
-        for (k, v) in tmp.custom_keyframe_data_raw.into_iter().chain(tmp.timelines_raw.into_iter()) {
+        for (k, v) in tmp.custom_keyframe_data_raw.into_iter().chain(tmp.timelines_raw.into_iter())
+        {
             if let Some(ct) = v.into_timeline() {
                 custom_keyframe_data.insert(k, ct);
             }
@@ -845,7 +858,10 @@ mod tests {
             assert_eq!(matrix.transitions.len(), 1);
             let t = &matrix.transitions[0];
             assert_eq!(t.name, "SportMode");
-            assert!(t.custom_keyframe_data.contains_key("D-opacity"), "Expected D-opacity in custom_keyframe_data map");
+            assert!(
+                t.custom_keyframe_data.contains_key("D-opacity"),
+                "Expected D-opacity in custom_keyframe_data map"
+            );
             let timeline = &t.custom_keyframe_data["D-opacity"];
             assert_eq!(timeline.keyframes.len(), 2);
             assert_eq!(timeline.keyframes[0].fraction, 0.2);

--- a/crates/dc_figma_import/src/animation_spec_schema.rs
+++ b/crates/dc_figma_import/src/animation_spec_schema.rs
@@ -274,8 +274,12 @@ pub struct AnimationMatrixJson {
 impl TransitionSpecJson {
     /// Validates the transition spec fields.
     pub fn validate(&self) -> Result<(), String> {
-        if self.from.is_empty() && self.to.is_empty() {
-            return Err("TransitionSpec 'from' and 'to' cannot both be empty".to_string());
+        let from_is_wild = self.from.is_empty() || self.from == "*";
+        let to_is_wild = self.to.is_empty() || self.to == "*";
+        if from_is_wild && to_is_wild {
+            return Err(
+                "TransitionSpec 'from' and 'to' cannot both be wildcards (* -> *)".to_string()
+            );
         }
         for (prop_name, timeline) in self.timelines.iter().chain(self.custom_keyframe_data.iter()) {
             for keyframe in &timeline.keyframes {
@@ -586,6 +590,14 @@ mod tests {
             ..Default::default()
         };
         assert!(invalid_transition.validate().is_err());
+
+        let invalid_wildcard_transition = TransitionSpecJson {
+            from: "*".to_string(),
+            to: "*".to_string(),
+            name: "InvalidWildcard".to_string(),
+            ..Default::default()
+        };
+        assert!(invalid_wildcard_transition.validate().is_err());
 
         let mut valid_transition = TransitionSpecJson {
             from: "A".to_string(),

--- a/crates/dc_figma_import/src/tools/fetch.rs
+++ b/crates/dc_figma_import/src/tools/fetch.rs
@@ -160,7 +160,12 @@ pub fn fetch(args: Args) -> Result<(), ConvertError> {
         None,
     )?;
 
-    let dc_definition = build_definition(&mut doc, &args.nodes, !args.scalableui)?;
+    let nodes = if args.nodes.is_empty() {
+        doc.discover_top_level_nodes()
+    } else {
+        args.nodes.clone()
+    };
+    let dc_definition = build_definition(&mut doc, &nodes, !args.scalableui)?;
 
     println!("Fetched document");
     println!("  DC Version: {}", DesignComposeDefinitionHeader::current_version());

--- a/crates/dc_figma_import/src/tools/fetch.rs
+++ b/crates/dc_figma_import/src/tools/fetch.rs
@@ -160,11 +160,8 @@ pub fn fetch(args: Args) -> Result<(), ConvertError> {
         None,
     )?;
 
-    let nodes = if args.nodes.is_empty() {
-        doc.discover_top_level_nodes()
-    } else {
-        args.nodes.clone()
-    };
+    let nodes =
+        if args.nodes.is_empty() { doc.discover_top_level_nodes() } else { args.nodes.clone() };
     let dc_definition = build_definition(&mut doc, &nodes, !args.scalableui)?;
 
     println!("Fetched document");

--- a/crates/dc_figma_import/src/transform_flexbox.rs
+++ b/crates/dc_figma_import/src/transform_flexbox.rs
@@ -2244,7 +2244,7 @@ fn visit_node(
             );
             match serde_json::from_str::<AnimationOverrideJson>(anim_str) {
                 Ok(anim) => {
-                    log::info!("Figma Import: Successfully parsed squoosh animation format for node {}: {:?}", node.id, anim);
+                    log::info!("Figma Import: Successfully parsed squoosh animation format for node {}, name: {}", node.id, node.name);
                     parsed_plugin_override = Some(anim);
                 }
                 Err(e) => {

--- a/crates/dc_figma_import/tests/animation_tests.rs
+++ b/crates/dc_figma_import/tests/animation_tests.rs
@@ -51,3 +51,109 @@ fn test_keyframes_present() {
 
     assert!(found_keyframes, "No keyframes found in the document!");
 }
+
+#[test]
+fn test_animation_matrix_dcf_serialization() {
+    use dc_bundle::animationspec::animation_override;
+    use dc_bundle::definition_file::{load_design_def, save_design_def};
+    use dc_figma_import::animation_override::AnimationOverride;
+    use dc_figma_import::animation_spec_schema::AnimationOverrideJson;
+    use tempfile::tempdir;
+
+    let doc_path = "tests/ENJKMeYc2vE5pQfgN9aOrY";
+    let (header, mut doc) = load_design_def(doc_path).expect("Failed to load doc");
+
+    let matrix_json_str = r#"{
+        "default_spec": {
+            "initial_delay": { "secs": 0, "nanos": 0 },
+            "animation": {
+                "Smooth": {
+                    "duration": { "secs": 0, "nanos": 300000000 },
+                    "repeat_type": "NoRepeat",
+                    "easing": "Linear"
+                }
+            },
+            "interrupt_type": "None"
+        },
+        "transitions": [
+            {
+                "from": "VariantA",
+                "to": "VariantB",
+                "name": "Transition1",
+                "spec": {
+                    "initial_delay": { "secs": 0, "nanos": 0 },
+                    "animation": {
+                        "Smooth": {
+                            "duration": { "secs": 0, "nanos": 500000000 },
+                            "repeat_type": "NoRepeat",
+                            "easing": "EaseInOut"
+                        }
+                    },
+                    "interrupt_type": "None"
+                },
+                "timelines": {
+                    "PropA": {
+                        "target_easing": "Linear",
+                        "keyframes": [
+                            { "fraction": 0.5, "value_json": 12.5, "easing": "EaseIn" }
+                        ]
+                    }
+                }
+            }
+        ]
+    }"#;
+
+    let anim_json: AnimationOverrideJson =
+        serde_json::from_str(matrix_json_str).expect("Failed to parse matrix JSON");
+    let anim_proto: dc_bundle::animationspec::AnimationOverride =
+        AnimationOverride::from(&anim_json).into();
+
+    let target_view_name = doc.views.keys().next().expect("Doc has no views").clone();
+    if let Some(view) = doc.views.get_mut(&target_view_name) {
+        let style = view.style.mut_or_insert_default();
+        let node_style = style.node_style.mut_or_insert_default();
+        node_style.animation_override = Some(anim_proto).into();
+    }
+
+    let tmp_dir = tempdir().expect("Failed to create temp dir");
+    let tmp_dcf_path = tmp_dir.path().join("test_matrix.dcf");
+    save_design_def(&tmp_dcf_path, &header, &doc).expect("Failed to save .dcf with matrix");
+
+    let (loaded_header, loaded_doc) =
+        load_design_def(&tmp_dcf_path).expect("Failed to reload saved .dcf");
+    assert_eq!(loaded_header.id, header.id);
+
+    let reloaded_view = loaded_doc
+        .views
+        .get(&target_view_name)
+        .expect("Reloaded doc missing target view");
+
+    let reloaded_override = reloaded_view
+        .style
+        .as_ref()
+        .unwrap()
+        .node_style
+        .as_ref()
+        .unwrap()
+        .animation_override
+        .as_ref()
+        .unwrap();
+
+    if let Some(animation_override::Animation_override::Matrix(matrix)) =
+        &reloaded_override.animation_override
+    {
+        assert!(matrix.default_spec.is_some());
+        assert_eq!(matrix.transitions.len(), 1);
+        let transition = &matrix.transitions[0];
+        assert_eq!(transition.from_variant, "VariantA");
+        assert_eq!(transition.to_variant, "VariantB");
+        assert_eq!(transition.animation_name, "Transition1");
+        assert!(transition.custom_keyframe_data.contains_key("PropA"));
+        let timeline = &transition.custom_keyframe_data["PropA"];
+        assert_eq!(timeline.keyframes.len(), 1);
+        assert_eq!(timeline.keyframes[0].fraction, 0.5);
+    } else {
+        panic!("Expected Animation_override::Matrix after reloading .dcf");
+    }
+}
+

--- a/crates/dc_figma_import/tests/animation_tests.rs
+++ b/crates/dc_figma_import/tests/animation_tests.rs
@@ -123,10 +123,8 @@ fn test_animation_matrix_dcf_serialization() {
         load_design_def(&tmp_dcf_path).expect("Failed to reload saved .dcf");
     assert_eq!(loaded_header.id, header.id);
 
-    let reloaded_view = loaded_doc
-        .views
-        .get(&target_view_name)
-        .expect("Reloaded doc missing target view");
+    let reloaded_view =
+        loaded_doc.views.get(&target_view_name).expect("Reloaded doc missing target view");
 
     let reloaded_override = reloaded_view
         .style
@@ -139,6 +137,10 @@ fn test_animation_matrix_dcf_serialization() {
         .as_ref()
         .unwrap();
 
+    assert!(matches!(
+        reloaded_override.animation_override,
+        Some(animation_override::Animation_override::Matrix(_))
+    ));
     if let Some(animation_override::Animation_override::Matrix(matrix)) =
         &reloaded_override.animation_override
     {
@@ -148,12 +150,9 @@ fn test_animation_matrix_dcf_serialization() {
         assert_eq!(transition.from_variant, "VariantA");
         assert_eq!(transition.to_variant, "VariantB");
         assert_eq!(transition.animation_name, "Transition1");
-        assert!(transition.custom_keyframe_data.contains_key("PropA"));
-        let timeline = &transition.custom_keyframe_data["PropA"];
+        assert!(transition.timelines.contains_key("PropA"));
+        let timeline = &transition.timelines["PropA"];
         assert_eq!(timeline.keyframes.len(), 1);
         assert_eq!(timeline.keyframes[0].fraction, 0.5);
-    } else {
-        panic!("Expected Animation_override::Matrix after reloading .dcf");
     }
 }
-

--- a/crates/dc_figma_import/tests/animation_tests.rs
+++ b/crates/dc_figma_import/tests/animation_tests.rs
@@ -147,8 +147,8 @@ fn test_animation_matrix_dcf_serialization() {
         assert!(matrix.default_spec.is_some());
         assert_eq!(matrix.transitions.len(), 1);
         let transition = &matrix.transitions[0];
-        assert_eq!(transition.from_variant, "VariantA");
-        assert_eq!(transition.to_variant, "VariantB");
+        assert_eq!(transition.source_variant, "VariantA");
+        assert_eq!(transition.target_variant, "VariantB");
         assert_eq!(transition.animation_name, "Transition1");
         assert!(transition.timelines.contains_key("PropA"));
         let timeline = &transition.timelines["PropA"];

--- a/crates/dc_jni/src/jni.rs
+++ b/crates/dc_jni/src/jni.rs
@@ -76,6 +76,7 @@ fn get_proxy_config(env: &mut Env, input: &JObject) -> Result<ProxyConfig, jni::
     })
 }
 
+#[allow(deprecated)]
 fn jni_fetch_doc<'local>(
     mut env: EnvUnowned<'local>,
     _class: JClass,

--- a/crates/dc_squoosh_animation/src/lib.rs
+++ b/crates/dc_squoosh_animation/src/lib.rs
@@ -373,14 +373,38 @@ pub struct PropertyLookup {
 }
 
 impl PropertyLookup {
-    /// Retrieves all parsed timeline data for a specific node.
+    /// Retrieves all parsed timeline data for a specific node or variant property.
     pub fn get_for_node(&self, node: &str) -> Option<Arc<NodeTimelines>> {
-        self.timelines.get(node).cloned()
+        if let Some(res) = self.timelines.get(node) {
+            return Some(res.clone());
+        }
+        // Multi-property check: check each "Property=Value" assignment cleanly
+        for part in node.split(',') {
+            let val = part.trim().split_once('=').map(|(_, v)| v.trim()).unwrap_or(part.trim());
+            if let Some(res) = self.timelines.get(val) {
+                return Some(res.clone());
+            }
+        }
+        None
     }
 
     /// Retrieves the parsed timeline data for a specific node and property.
     pub fn get(&self, node: &str, prop: AnimatableProperty) -> Option<&ParsedTimelineData> {
-        self.timelines.get(node).and_then(|nt| nt.get(&prop))
+        if let Some(nt) = self.timelines.get(node) {
+            if let Some(res) = nt.get(&prop) {
+                return Some(res);
+            }
+        }
+        // Multi-property check: check each "Property=Value" assignment cleanly
+        for part in node.split(',') {
+            let val = part.trim().split_once('=').map(|(_, v)| v.trim()).unwrap_or(part.trim());
+            if let Some(nt) = self.timelines.get(val) {
+                if let Some(res) = nt.get(&prop) {
+                    return Some(res);
+                }
+            }
+        }
+        None
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,5 @@ roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirector
 # Migrate codegen from KSP1 to KSP2, then remove the below.
 # https://github.com/google/automotive-design-compose/issues/2231
 ksp.useKSP2=false
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -23,9 +23,10 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 
-# Allow two r8 minify tasks to run in parallel. Each task takes 20-50 seconds so this helps speed things up.
-# Uses more of the heap, but 4GB of heap still seems sufficient.
-android.r8.maxWorkers=2
+# Limit parallel workers to prevent heap exhaustion on CI runners.
+# On local developer machines, these can be overridden in ~/.gradle/gradle.properties.
+org.gradle.workers.max=2
+android.r8.maxWorkers=1
 roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory
 
 # Migrate codegen from KSP1 to KSP2, then remove the below.

--- a/support-figma/dc_squoosh_designer/DATA_FORMAT.md
+++ b/support-figma/dc_squoosh_designer/DATA_FORMAT.md
@@ -1,4 +1,4 @@
-# Data Format
+# Data Format (Option A Transition Matrix Schema)
 
 This document describes the data structures used by the DC Squoosh Designer plugin to store animation specifications within Figma.
 
@@ -6,57 +6,77 @@ This document describes the data structures used by the DC Squoosh Designer plug
 
 The plugin stores data in the `sharedPluginData` of Figma components (variants).
 *   **Namespace:** `designcompose`
-*   **Key:** `animations`
-*   **Value:** A stringified JSON object.
+*   **Key:** `squoosh`
+*   **Value:** A stringified JSON object conforming to the Option A Transition Matrix Schema.
 
-## JSON Structure
+## JSON Structure (Option A Transition Matrix)
 
-The root object contains the animation specification for transitioning *to* the variant where the data is stored.
+The root payload defines an explicit array of transition rules (`transitions`) and an optional default specification fallback (`default_spec`).
 
 ```json
 {
-  "spec": {
+  "default_spec": {
     "initial_delay": { "secs": 0, "nanos": 0 },
     "animation": {
       "Smooth": {
         "duration": { "secs": 0, "nanos": 300000000 },
+        "repeat_type": "NoRepeat",
         "easing": "Linear"
       }
     },
     "interrupt_type": "None"
   },
-  "customKeyframeData": {
-    "TIMELINE_ID": "{\"targetEasing\":\"Inherit\",\"keyframes\":[{\"fraction\":0.5,\"value\":{\"Scalar\":1},\"easing\":\"Linear\"}]}"
-    // This field stores stringified JSON data for custom (user-added) property timelines.
-    // Figma's API limits plugin data to strings, so the inner object is JSON-serialized again.
-    // System-generated timelines (e.g., for 'x', 'y' changes between variants)
-    // do not store their keyframe data here, but derive it from variant properties.
-  }
-}
-```
-
-To easily and safely persist complex keyframe sequences, `customKeyframeData` stores serialized property timelines as stringified JSON objects.
-
-### Structured Timeline Format (Decoded)
-
-When decoded, the JSON string mapped to `TIMELINE_ID` has the following structure, aligning with the Protobuf definitions:
-
-```json
-{
-  "targetEasing": "Inherit",
-  "keyframes": [
+  "transitions": [
     {
-      "fraction": 0.2,
-      "value": { "Scalar": 0.4 },
-      "easing": "Linear"
+      "from": "VariantA",
+      "to": "VariantB",
+      "name": "Default",
+      "spec": {
+        "initial_delay": { "secs": 0, "nanos": 0 },
+        "animation": {
+          "Smooth": {
+            "duration": { "secs": 0, "nanos": 500000000 },
+            "repeat_type": "NoRepeat",
+            "easing": "EaseInOut"
+          }
+        },
+        "interrupt_type": "None"
+      },
+      "timelines": {
+        "PRNDState-x": {
+          "targetEasing": "Inherit",
+          "keyframes": [
+            { "fraction": 0.5, "value": { "Scalar": 100.0 }, "easing": "EaseIn" }
+          ]
+        }
+      }
     },
     {
-      "fraction": 0.5,
-      "value": { "Scalar": 0.8 },
-      "easing": "EaseIn"
+      "from": "*",
+      "to": "VariantB",
+      "name": "AlertPop",
+      "spec": {
+        "initial_delay": { "secs": 0, "nanos": 0 },
+        "animation": {
+          "Smooth": {
+            "duration": { "secs": 0, "nanos": 300000000 },
+            "repeat_type": "NoRepeat",
+            "easing": "EaseOut"
+          }
+        },
+        "interrupt_type": "None"
+      },
+      "timelines": {}
     }
   ]
 }
 ```
 
-*Note: All custom timelines enforce this JSON structure within the stringified payload, yielding superior parsing performance and explicit typing for multi-scalar values (like color or gradient arrays).*
+### Transition Matrix Lookup Hierarchy
+
+At runtime (in HAR and DriverUI), transition animation resolution follows a deterministic multi-stage lookup:
+1. `"VariantA->VariantB:AlertPop"` (Exact custom animation name match)
+2. `"VariantA->VariantB:Default"` (Pair default match)
+3. `"*->VariantB:Default"` (Wildcard origin match)
+4. `"VariantB"` (Base target variant fallback)
+

--- a/support-figma/dc_squoosh_designer/DATA_FORMAT.md
+++ b/support-figma/dc_squoosh_designer/DATA_FORMAT.md
@@ -1,4 +1,4 @@
-# Data Format (Option A Transition Matrix Schema)
+# Data Format (Transition Matrix Schema)
 
 This document describes the data structures used by the DC Squoosh Designer plugin to store animation specifications within Figma.
 
@@ -7,9 +7,10 @@ This document describes the data structures used by the DC Squoosh Designer plug
 The plugin stores data in the `sharedPluginData` of Figma components (variants).
 *   **Namespace:** `designcompose`
 *   **Key:** `squoosh`
-*   **Value:** A stringified JSON object conforming to the Option A Transition Matrix Schema.
+*   **Value:** A stringified JSON object conforming to the Transition Matrix Schema.
 
-## JSON Structure (Option A Transition Matrix)
+## JSON Structure (Transition Matrix)
+
 
 The root payload defines an explicit array of transition rules (`transitions`) and an optional default specification fallback (`default_spec`).
 

--- a/support-figma/dc_squoosh_designer/src/code.ts
+++ b/support-figma/dc_squoosh_designer/src/code.ts
@@ -22,8 +22,10 @@
 import { hexToRgb, EPSILON } from "./utils/common";
 import { AnimatedNode, SerializedNode, Variant } from "./timeline/types";
 import { runSandboxTests } from "./timeline/sandbox_tests";
-import { serializeKeyframes, deserializeKeyframes } from "./timeline/serialization";
-
+import {
+  serializeKeyframes,
+  deserializeKeyframes,
+} from "./timeline/serialization";
 
 // Config
 const PERSIST_WINDOW_SIZE = true; // Set to false to disable saving window size
@@ -31,184 +33,345 @@ const PREFERRED_WIDTH = 320;
 const PREFERRED_HEIGHT = 480;
 const MIN_WIDTH = 280;
 const MIN_HEIGHT = 200;
-const MAX_WIDTH = 900;
-const MAX_HEIGHT = 800;
+const MAX_WIDTH = 3000;
+const MAX_HEIGHT = 3000;
 
 import { resolveComponentContext, isDescendantOf } from "./plugin/context";
 import { loadFontsForNode } from "./plugin/fonts";
 import { serializeNode } from "./plugin/serialize";
 import { compareNodes } from "./plugin/compare";
-import { cloneChildren, updateFigmaPreview, tagOriginalNodeId } from "./plugin/preview";
+import {
+  cloneChildren,
+  updateFigmaPreview,
+  tagOriginalNodeId,
+} from "./plugin/preview";
 let hasSavedSize = false;
 let windowSize = { width: PREFERRED_WIDTH, height: PREFERRED_HEIGHT };
 
 let animationNodeId: string | null = null;
+let activeComponentSetId: string | null = null;
 let isSelectingPreviewFrame = false;
 const isUpdatingPreview = false;
 
-async function updateSelection() {
-    if (isSelectingPreviewFrame) {
-      const selection = figma.currentPage.selection;
-      if (selection.length === 1) {
-        animationNodeId = selection[0].id;
-        isSelectingPreviewFrame = false;
-        figma.ui.postMessage({ type: "selection-mode-ended" });
-        figma.ui.postMessage({
-          type: "preview-frame-selected",
-          name: selection[0].name,
-        });
-        figma.notify(`Preview frame set to "${selection[0].name}"`);
-      }
-      return;
-    }
+async function prepareAndPopulatePreviewFrame(): Promise<void> {
+  let componentSet: ComponentSetNode | null = null;
+  let singleComponent: ComponentNode | null = null;
 
+  if (activeComponentSetId) {
+    const activeNode = await figma.getNodeByIdAsync(activeComponentSetId);
+    if (activeNode && activeNode.type === "COMPONENT_SET") {
+      componentSet = activeNode;
+    } else if (activeNode && activeNode.type === "COMPONENT") {
+      singleComponent = activeNode;
+    }
+  }
+
+  if (!componentSet && !singleComponent) {
     const selection = figma.currentPage.selection;
-
-    // Check if selection is inside the preview frame
-    if (animationNodeId && selection.length > 0) {
-        const selectedNode = selection[0];
-        if (isDescendantOf(selectedNode, animationNodeId)) {
-            // Optionally, we could send a message to the UI to highlight the corresponding node in the timeline
-            // But for now, we just prevent deselecting/changing the current component context.
-
-            // If the selected node corresponds to an original node, we might want to notify the UI?
-            if ("getPluginData" in selectedNode) {
-                const originalNodeId = selectedNode.getPluginData("originalNodeId");
-                if (originalNodeId) {
-                     // We can still notify the UI about which node was clicked in the preview
-                     // so it can highlight the corresponding timeline track, WITHOUT resetting the whole timeline view.
-                     figma.ui.postMessage({ type: "preview-node-selected", originalNodeId });
-                }
-            }
-            return;
-        }
+    if (selection.length === 1 && selection[0].id !== animationNodeId) {
+      const res = await resolveComponentContext(selection[0]);
+      componentSet = res.componentSet;
+      singleComponent = res.singleComponent;
+      if (componentSet) activeComponentSetId = componentSet.id;
+      else if (singleComponent) activeComponentSetId = singleComponent.id;
     }
+  }
 
-    // Check if selection is a preview node (old logic, can likely be merged or removed if the above covers it)
-    // keeping it for safety if animationNodeId is somehow lost or managed differently?
-    // Actually, the block above relies on animationNodeId being set.
-    // The old block below relies on `originalNodeId` plugin data being present.
-    if (selection.length === 1) {
-        const node = selection[0];
-        if ("getPluginData" in node) {
-            const originalNodeId = node.getPluginData("originalNodeId");
-            if (originalNodeId) {
-              // If we are here, it means we probably didn't catch it with the ancestor check
-                 // (maybe animationNodeId is unset but the node still has data?)
-                 // In this case, we ALSO want to avoid resetting the timeline.
-                 figma.ui.postMessage({ type: "preview-node-selected", originalNodeId });
-                 return;
-            }
-        }
-    }
+  if (!componentSet && !singleComponent) return;
 
-    if (selection.length !== 1) {
-      const message = "Please select a single layer.";
-      figma.notify(message);
-      figma.ui.postMessage({ type: "clear-timeline" });
-      return;
-    }
+  let primaryTarget: SceneNode | null = null;
+  if (componentSet && componentSet.children.length > 0) {
+    primaryTarget = componentSet.children[0] as SceneNode;
+  } else if (singleComponent) {
+    primaryTarget = singleComponent;
+  }
 
-    const node = selection[0];
-    const { componentSet, singleComponent } = await resolveComponentContext(node);
-    let selectedVariantName: string | null = null;
+  if (primaryTarget) {
+    await loadFontsForNode(primaryTarget);
+  }
 
-    if (componentSet) {
-        if (node.type === "INSTANCE") {
-            const main = await (node as InstanceNode).getMainComponentAsync();
-            selectedVariantName = main ? main.name : null;
-        } else if (node.type === "COMPONENT") {
-            selectedVariantName = node.name;
-        }
-    } else if (singleComponent) {
-        selectedVariantName = singleComponent.name;
-    }
+  let frame: FrameNode | ComponentNode | InstanceNode | null = null;
+  if (animationNodeId) {
+    frame = (await figma.getNodeByIdAsync(animationNodeId)) as
+      | FrameNode
+      | ComponentNode
+      | InstanceNode;
+  }
 
-    if (!componentSet && !singleComponent) {
-      let message = `Selected layer "${node.name}" of type "${node.type}" is not part of a component set with variants.`;
-      if (node.type === "INSTANCE") {
-        message = `Selected instance "${node.name}" is not a variant within a component set.`;
-      } else if (node.type === "COMPONENT") {
-        message = `Selected component "${node.name}" is not a variant within a component set.`;
+  if (!frame) {
+    let defaultFrame = figma.currentPage.findOne(
+      (n) => n.name === "PreviewFrame" && n.type === "FRAME",
+    ) as FrameNode;
+    if (!defaultFrame) {
+      defaultFrame = figma.createFrame();
+      defaultFrame.name = "PreviewFrame";
+      if (primaryTarget && "width" in primaryTarget) {
+        defaultFrame.x = primaryTarget.x + primaryTarget.width + 20;
+        defaultFrame.y = primaryTarget.y;
       }
-      figma.notify(message);
-      figma.ui.postMessage({ type: "clear-timeline" });
-      return;
     }
+    frame = defaultFrame;
+    animationNodeId = frame.id;
+    figma.ui.postMessage({
+      type: "preview-frame-selected",
+      name: frame.name,
+    });
+  }
 
-    const variants: Variant[] = [];
-    const serializedVariants: SerializedNode[] = [];
+  if (!frame || !("children" in frame)) {
+    figma.notify(
+      "The selected preview frame is not a valid container (e.g., a frame or component).",
+    );
+    return;
+  }
 
-    let variantsNodeList: SceneNode[] = [];
-    let componentName = "";
+  if (
+    frame.type === "COMPONENT_SET" ||
+    (frame.parent && frame.parent.type === "COMPONENT_SET") ||
+    (componentSet && frame.id === componentSet.id) ||
+    (singleComponent && frame.id === singleComponent.id)
+  ) {
+    figma.notify(
+      "A component set or variant cannot be used as a preview frame. Please select a separate frame.",
+    );
+    return;
+  }
 
-    if (componentSet) {
-        // Reverse the children array to match Figma's UI order
-        variantsNodeList = [...componentSet.children].reverse();
-        componentName = componentSet.name;
-    } else if (singleComponent) {
-        variantsNodeList = [singleComponent];
-        componentName = singleComponent.name;
-    }
+  frame.children.forEach((child) => child.remove());
 
-    let upgradedVariantsCount = 0;
+  if (primaryTarget && "width" in primaryTarget) {
+    frame.resize(primaryTarget.width, primaryTarget.height);
+  }
 
-    for (const variantNode of variantsNodeList) {
-      if (variantNode.type === "COMPONENT") {
-        const variantName = variantNode.name;
-        const animationDataString = variantNode.getSharedPluginData(
-          "designcompose",
-          "squoosh",
-        );
-        const animationData = animationDataString ? JSON.parse(animationDataString) : null;
-        let upgraded = false;
+  if ("fills" in frame && primaryTarget && "fills" in primaryTarget) {
+    frame.fills = primaryTarget.fills;
+  }
 
-        if (animationData && animationData.customKeyframeData) {
-          for (const [key, value] of Object.entries(animationData.customKeyframeData)) {
-            if (typeof value === "string" && !value.startsWith("{") && value.indexOf("|") !== -1) {
-              const deserialized = deserializeKeyframes(value);
-              animationData.customKeyframeData[key] = serializeKeyframes(
-                deserialized.keyframes,
-                deserialized.targetEasing
-              );
-              upgraded = true;
+  if (componentSet) {
+    const mergeChildren = (
+      source: SceneNode,
+      target: FrameNode | ComponentNode | InstanceNode | GroupNode,
+    ) => {
+      if (!("children" in source) || !("children" in target)) return;
+
+      for (const sourceChild of source.children) {
+        let targetChild = target.findChild((c) => c.name === sourceChild.name);
+
+        if (!targetChild) {
+          if ("clone" in sourceChild) {
+            targetChild = (sourceChild as any).clone();
+            if (targetChild) {
+              tagOriginalNodeId(targetChild, sourceChild);
+              target.appendChild(targetChild);
             }
           }
         }
 
-        if (upgraded) {
-          variantNode.setSharedPluginData(
-            "designcompose",
-            "squoosh",
-            JSON.stringify(animationData)
-          );
-          upgradedVariantsCount++;
-        }
-
-        variants.push({
-          name: variantName,
-          animation: animationData,
-        });
-        serializedVariants.push(serializeNode(variantNode));
-      } else {
-        console.warn(
-          `Skipping unexpected node type in component set children: ${variantNode.type}`,
+        mergeChildren(
+          sourceChild,
+          targetChild as FrameNode | ComponentNode | InstanceNode | GroupNode,
         );
       }
-    }
+    };
 
-    if (upgradedVariantsCount > 0) {
-      figma.notify(`Upgraded legacy animation data to JSON format for ${upgradedVariantsCount} variant(s).`);
+    for (const variant of componentSet.children) {
+      mergeChildren(variant as SceneNode, frame);
     }
-
-    figma.ui.postMessage({
-      type: "update",
-      componentName: componentName,
-      variants: variants,
-      serializedVariants: serializedVariants,
-      selectedVariantName: selectedVariantName,
-    });
+  } else if (singleComponent) {
+    await cloneChildren(singleComponent.children, frame);
   }
+  figma.ui.postMessage({ type: "animation-ready" });
+}
+
+async function updateSelection() {
+  if (isSelectingPreviewFrame) {
+    const selection = figma.currentPage.selection;
+    if (selection.length === 1) {
+      const selected = selection[0];
+      if (
+        selected.type === "COMPONENT_SET" ||
+        (selected.parent && selected.parent.type === "COMPONENT_SET")
+      ) {
+        figma.notify(
+          "Please select a separate preview frame on the canvas (not your component set or variant).",
+        );
+        return;
+      }
+      animationNodeId = selected.id;
+      isSelectingPreviewFrame = false;
+      figma.ui.postMessage({ type: "selection-mode-ended" });
+      figma.ui.postMessage({
+        type: "preview-frame-selected",
+        name: selected.name,
+      });
+      figma.notify(`Preview frame set to "${selected.name}"`);
+      await prepareAndPopulatePreviewFrame();
+    }
+    return;
+  }
+
+  const selection = figma.currentPage.selection;
+
+  // Check if selection is inside the preview frame
+  if (animationNodeId && selection.length > 0) {
+    const selectedNode = selection[0];
+    if (isDescendantOf(selectedNode, animationNodeId)) {
+      // Optionally, we could send a message to the UI to highlight the corresponding node in the timeline
+      // But for now, we just prevent deselecting/changing the current component context.
+
+      // If the selected node corresponds to an original node, we might want to notify the UI?
+      if ("getPluginData" in selectedNode) {
+        const originalNodeId = selectedNode.getPluginData("originalNodeId");
+        if (originalNodeId) {
+          // We can still notify the UI about which node was clicked in the preview
+          // so it can highlight the corresponding timeline track, WITHOUT resetting the whole timeline view.
+          figma.ui.postMessage({
+            type: "preview-node-selected",
+            originalNodeId,
+          });
+        }
+      }
+      return;
+    }
+  }
+
+  // Check if selection is a preview node (old logic, can likely be merged or removed if the above covers it)
+  // keeping it for safety if animationNodeId is somehow lost or managed differently?
+  // Actually, the block above relies on animationNodeId being set.
+  // The old block below relies on `originalNodeId` plugin data being present.
+  if (selection.length === 1) {
+    const node = selection[0];
+    if ("getPluginData" in node) {
+      const originalNodeId = node.getPluginData("originalNodeId");
+      if (originalNodeId) {
+        // If we are here, it means we probably didn't catch it with the ancestor check
+        // (maybe animationNodeId is unset but the node still has data?)
+        // In this case, we ALSO want to avoid resetting the timeline.
+        figma.ui.postMessage({ type: "preview-node-selected", originalNodeId });
+        return;
+      }
+    }
+  }
+
+  if (selection.length !== 1) {
+    const message = "Please select a single layer.";
+    figma.notify(message);
+    figma.ui.postMessage({ type: "clear-timeline" });
+    return;
+  }
+
+  const node = selection[0];
+  const { componentSet, singleComponent } = await resolveComponentContext(node);
+  let selectedVariantName: string | null = null;
+
+  if (componentSet) {
+    activeComponentSetId = componentSet.id;
+    if (node.type === "INSTANCE") {
+      const main = await (node as InstanceNode).getMainComponentAsync();
+      selectedVariantName = main ? main.name : null;
+    } else if (node.type === "COMPONENT") {
+      selectedVariantName = node.name;
+    }
+  } else if (singleComponent) {
+    activeComponentSetId = singleComponent.id;
+    selectedVariantName = singleComponent.name;
+  }
+
+  if (!componentSet && !singleComponent) {
+    let message = `Selected layer "${node.name}" of type "${node.type}" is not part of a component set with variants.`;
+    if (node.type === "INSTANCE") {
+      message = `Selected instance "${node.name}" is not a variant within a component set.`;
+    } else if (node.type === "COMPONENT") {
+      message = `Selected component "${node.name}" is not a variant within a component set.`;
+    }
+    figma.notify(message);
+    figma.ui.postMessage({ type: "clear-timeline" });
+    return;
+  }
+
+  const variants: Variant[] = [];
+  const serializedVariants: SerializedNode[] = [];
+
+  let variantsNodeList: SceneNode[] = [];
+  let componentName = "";
+
+  if (componentSet) {
+    // Reverse the children array to match Figma's UI order
+    variantsNodeList = [...componentSet.children].reverse();
+    componentName = componentSet.name;
+  } else if (singleComponent) {
+    variantsNodeList = [singleComponent];
+    componentName = singleComponent.name;
+  }
+
+  let upgradedVariantsCount = 0;
+
+  for (const variantNode of variantsNodeList) {
+    if (variantNode.type === "COMPONENT") {
+      const variantName = variantNode.name;
+      const animationDataString = variantNode.getSharedPluginData(
+        "designcompose",
+        "squoosh",
+      );
+      const animationData = animationDataString
+        ? JSON.parse(animationDataString)
+        : null;
+      let upgraded = false;
+
+      if (animationData && animationData.customKeyframeData) {
+        for (const [key, value] of Object.entries(
+          animationData.customKeyframeData,
+        )) {
+          if (
+            typeof value === "string" &&
+            !value.startsWith("{") &&
+            value.indexOf("|") !== -1
+          ) {
+            const deserialized = deserializeKeyframes(value);
+            animationData.customKeyframeData[key] = serializeKeyframes(
+              deserialized.keyframes,
+              deserialized.targetEasing,
+            );
+            upgraded = true;
+          }
+        }
+      }
+
+      if (upgraded) {
+        variantNode.setSharedPluginData(
+          "designcompose",
+          "squoosh",
+          JSON.stringify(animationData),
+        );
+        upgradedVariantsCount++;
+      }
+
+      variants.push({
+        name: variantName,
+        animation: animationData,
+      });
+      serializedVariants.push(serializeNode(variantNode));
+    } else {
+      console.warn(
+        `Skipping unexpected node type in component set children: ${variantNode.type}`,
+      );
+    }
+  }
+
+  if (upgradedVariantsCount > 0) {
+    figma.notify(
+      `Upgraded legacy animation data to JSON format for ${upgradedVariantsCount} variant(s).`,
+    );
+  }
+
+  figma.ui.postMessage({
+    type: "update",
+    componentName: componentName,
+    variants: variants,
+    serializedVariants: serializedVariants,
+    selectedVariantName: selectedVariantName,
+  });
+}
 
 (async () => {
   try {
@@ -253,33 +416,40 @@ async function updateSelection() {
 
       if (msg.type === "ping") {
         (async () => {
-            const selection = figma.currentPage.selection;
-            if (selection.length > 0) {
-                const node = selection[0];
-                let componentSet: ComponentSetNode | null = null;
+          const selection = figma.currentPage.selection;
+          if (selection.length > 0) {
+            const node = selection[0];
+            let componentSet: ComponentSetNode | null = null;
 
-                if (node.type === "INSTANCE") {
-                    const main = await node.getMainComponentAsync();
-                    if (main && main.parent && main.parent.type === "COMPONENT_SET") {
-                        componentSet = main.parent;
-                    }
-                } else if (node.type === "COMPONENT" && node.parent && node.parent.type === "COMPONENT_SET") {
-                     componentSet = node.parent;
-                } else if (node.type === "COMPONENT_SET") {
-                    componentSet = node;
-                }
+            if (node.type === "INSTANCE") {
+              const main = await node.getMainComponentAsync();
+              if (main && main.parent && main.parent.type === "COMPONENT_SET") {
+                componentSet = main.parent;
+              }
+            } else if (
+              node.type === "COMPONENT" &&
+              node.parent &&
+              node.parent.type === "COMPONENT_SET"
+            ) {
+              componentSet = node.parent;
+            } else if (node.type === "COMPONENT_SET") {
+              componentSet = node;
+            }
 
-                if (componentSet) {
-                    // Log the first child's data for sampling
-                    const firstVariant = componentSet.children[0];
-                    const data = firstVariant.getSharedPluginData("designcompose", "squoosh");
-                    // Also dump timeline data if available
-                    // We don't have easy access to the 'internal' AnimationData structure here as it's built in UI
-                    // But we can dump the customKeyframeData which is part of the spec.
-                } else {
-                }
+            if (componentSet) {
+              // Log the first child's data for sampling
+              const firstVariant = componentSet.children[0];
+              const data = firstVariant.getSharedPluginData(
+                "designcompose",
+                "squoosh",
+              );
+              // Also dump timeline data if available
+              // We don't have easy access to the 'internal' AnimationData structure here as it's built in UI
+              // But we can dump the customKeyframeData which is part of the spec.
             } else {
             }
+          } else {
+          }
         })();
 
         figma.ui.postMessage({ type: "pong" });
@@ -300,8 +470,8 @@ async function updateSelection() {
 
       if (msg.type === "run-sandbox-tests") {
         (async () => {
-            const results = await runSandboxTests();
-            figma.ui.postMessage({ type: "sandbox-tests-complete", results });
+          const results = await runSandboxTests();
+          figma.ui.postMessage({ type: "sandbox-tests-complete", results });
         })();
       }
 
@@ -323,11 +493,14 @@ async function updateSelection() {
           if (selection.length !== 1) return;
 
           const node = selection[0];
-          const { componentSet, singleComponent } = await resolveComponentContext(node);
+          const { componentSet, singleComponent } =
+            await resolveComponentContext(node);
 
           let variant: SceneNode | undefined;
           if (componentSet) {
-            variant = componentSet.children.find((child) => child.name === frameName);
+            variant = componentSet.children.find(
+              (child) => child.name === frameName,
+            );
           } else if (singleComponent && singleComponent.name === frameName) {
             variant = singleComponent;
           }
@@ -344,12 +517,18 @@ async function updateSelection() {
           if (selection.length !== 1) return;
 
           const node = selection[0];
-          const { componentSet, singleComponent } = await resolveComponentContext(node);
+          const { componentSet, singleComponent } =
+            await resolveComponentContext(node);
 
           let variant: SceneNode | undefined;
           if (componentSet) {
-            variant = componentSet.children.find((child) => child.name === endingVariantName);
-          } else if (singleComponent && singleComponent.name === endingVariantName) {
+            variant = componentSet.children.find(
+              (child) => child.name === endingVariantName,
+            );
+          } else if (
+            singleComponent &&
+            singleComponent.name === endingVariantName
+          ) {
             variant = singleComponent;
           }
 
@@ -372,11 +551,7 @@ async function updateSelection() {
               serializedKeyframes;
 
             const dataToSave = JSON.stringify(animationObject);
-            variant.setSharedPluginData(
-              "designcompose",
-              "squoosh",
-              dataToSave,
-            );
+            variant.setSharedPluginData("designcompose", "squoosh", dataToSave);
           }
         })();
       }
@@ -387,7 +562,8 @@ async function updateSelection() {
           if (selection.length !== 1) return;
 
           const node = selection[0];
-          const { componentSet, singleComponent } = await resolveComponentContext(node);
+          const { componentSet, singleComponent } =
+            await resolveComponentContext(node);
 
           let variants: SceneNode[] = [];
           if (componentSet) {
@@ -462,108 +638,7 @@ async function updateSelection() {
       }
       if (msg.type === "prepare-animation") {
         (async () => {
-          const selection = figma.currentPage.selection;
-          if (selection.length !== 1) return;
-
-          const node = selection[0];
-          const { componentSet, singleComponent } = await resolveComponentContext(node);
-
-          if (!componentSet && !singleComponent) return;
-
-          let primaryTarget: SceneNode | null = null;
-          if (node.type === "INSTANCE" || node.type === "COMPONENT") {
-             primaryTarget = node;
-          } else if (componentSet && componentSet.children.length > 0) {
-             primaryTarget = componentSet.children[0];
-          } else if (singleComponent) {
-             primaryTarget = singleComponent;
-          }
-
-          if (primaryTarget) {
-              await loadFontsForNode(primaryTarget);
-          }
-
-          let frame: FrameNode | ComponentNode | InstanceNode | null = null;
-          if (animationNodeId) {
-            frame = (await figma.getNodeByIdAsync(animationNodeId)) as
-              | FrameNode
-              | ComponentNode
-              | InstanceNode;
-          }
-
-          if (!frame) {
-            let defaultFrame = figma.currentPage.findOne(
-              (n) => n.name === "PreviewFrame" && n.type === "FRAME",
-            ) as FrameNode;
-            if (!defaultFrame) {
-              defaultFrame = figma.createFrame();
-              defaultFrame.name = "PreviewFrame";
-              if (primaryTarget && "width" in primaryTarget) {
-                  defaultFrame.x = primaryTarget.x + primaryTarget.width + 20;
-                  defaultFrame.y = primaryTarget.y;
-              }
-            }
-            frame = defaultFrame;
-            animationNodeId = frame.id;
-            figma.ui.postMessage({
-              type: "preview-frame-selected",
-              name: frame.name,
-            });
-          }
-
-          if (!frame || !("children" in frame)) {
-            figma.notify(
-              "The selected preview frame is not a valid container (e.g., a frame or component).",
-            );
-            return;
-          }
-
-          frame.children.forEach((child) => child.remove());
-
-          if (primaryTarget && "width" in primaryTarget) {
-            frame.resize(primaryTarget.width, primaryTarget.height);
-          }
-
-          if ("fills" in frame && primaryTarget && "fills" in primaryTarget) {
-            frame.fills = primaryTarget.fills;
-          }
-
-          if (componentSet) {
-              const mergeChildren = (source: SceneNode, target: FrameNode | ComponentNode | InstanceNode | GroupNode) => {
-                  if (!("children" in source) || !("children" in target)) return;
-
-                  // We need to iterate source children and see if they exist in target
-                  for (const sourceChild of source.children) {
-                      let targetChild = target.findChild((c) => c.name === sourceChild.name);
-
-                      if (!targetChild) {
-                          // Clone and add if missing
-                          if ("clone" in sourceChild) {
-                              targetChild = (sourceChild as any).clone();
-                              if (targetChild) {
-                                  tagOriginalNodeId(targetChild, sourceChild);
-                                  target.appendChild(targetChild);
-                              }
-                          }
-                      }
-
-                      // Recurse to ensure descendants from other variants are merged into this branch
-                      // (e.g. if targetChild existed or was just cloned, we still check if sourceChild has MORE descendants)
-                      // Note: sourceChild.clone() already brought its current descendants.
-                      // But if a *subsequent* variant has *additional* children inside this structure, we need to merge them in.
-                      // However, 'source' here IS the variant node.
-                      // So we are iterating the variant's structure.
-                      mergeChildren(sourceChild, targetChild as FrameNode | ComponentNode | InstanceNode | GroupNode);
-                  }
-              };
-
-              for (const variant of componentSet.children) {
-                  mergeChildren(variant as SceneNode, frame);
-              }
-          } else if (singleComponent) {
-              await cloneChildren(singleComponent.children, frame);
-          }
-          figma.ui.postMessage({ type: "animation-ready" });
+          await prepareAndPopulatePreviewFrame();
         })();
       }
       if (msg.type === "animate-figma-nodes") {
@@ -632,7 +707,8 @@ async function updateSelection() {
           if (selection.length !== 1) return;
 
           const node = selection[0];
-          const { componentSet, singleComponent } = await resolveComponentContext(node);
+          const { componentSet, singleComponent } =
+            await resolveComponentContext(node);
 
           let variants: SceneNode[] = [];
           if (componentSet) {
@@ -671,10 +747,31 @@ async function updateSelection() {
       if (msg.type === "select-preview-frame") {
         isSelectingPreviewFrame = !isSelectingPreviewFrame;
         if (isSelectingPreviewFrame) {
-          figma.ui.postMessage({ type: "selection-mode-started" });
+          const selection = figma.currentPage.selection;
+          if (
+            selection.length === 1 &&
+            selection[0].type !== "COMPONENT_SET" &&
+            !(
+              selection[0].parent &&
+              selection[0].parent.type === "COMPONENT_SET"
+            )
+          ) {
+            animationNodeId = selection[0].id;
+            isSelectingPreviewFrame = false;
+            figma.ui.postMessage({ type: "selection-mode-ended" });
+            figma.ui.postMessage({
+              type: "preview-frame-selected",
+              name: selection[0].name,
+            });
+            figma.notify(`Preview frame set to "${selection[0].name}"`);
+            (async () => {
+              await prepareAndPopulatePreviewFrame();
+            })();
+          } else {
+            figma.ui.postMessage({ type: "selection-mode-started" });
+          }
         } else {
           figma.ui.postMessage({ type: "selection-mode-ended" });
-          // If selection is cancelled, and we had a node before, tell the UI
           (async () => {
             if (animationNodeId) {
               const node = await figma.getNodeByIdAsync(animationNodeId);
@@ -684,7 +781,6 @@ async function updateSelection() {
                   name: node.name,
                 });
               } else {
-                // The node was deleted, so clear it
                 animationNodeId = null;
                 figma.ui.postMessage({ type: "preview-frame-cleared" });
               }
@@ -701,27 +797,29 @@ async function updateSelection() {
     await figma.loadAllPagesAsync();
 
     figma.on("documentchange", (event) => {
-        if (isUpdatingPreview) return; // Ignore programmatic changes
+      if (isUpdatingPreview) return; // Ignore programmatic changes
 
-        for (const change of event.documentChanges) {
-            if (change.type === "PROPERTY_CHANGE") {
-                const node = change.node;
+      for (const change of event.documentChanges) {
+        if (change.type === "PROPERTY_CHANGE") {
+          const node = change.node;
 
-                // Check if node is selected
-                const isSelected = figma.currentPage.selection.some(n => n.id === node.id);
-                if (!isSelected) continue;
+          // Check if node is selected
+          const isSelected = figma.currentPage.selection.some(
+            (n) => n.id === node.id,
+          );
+          if (!isSelected) continue;
 
-                if ("getPluginData" in node) {
-                    const originalNodeId = node.getPluginData("originalNodeId") || null;
-                    const serialized = serializeNode(node);
-                  figma.ui.postMessage({
-                    type: "preview-node-changed",
-                    originalNodeId,
-                    nodeProps: serialized
-                    });
-                }
-            }
+          if ("getPluginData" in node) {
+            const originalNodeId = node.getPluginData("originalNodeId") || null;
+            const serialized = serializeNode(node);
+            figma.ui.postMessage({
+              type: "preview-node-changed",
+              originalNodeId,
+              nodeProps: serialized,
+            });
+          }
         }
+      }
     });
 
     // Initial update

--- a/support-figma/dc_squoosh_designer/src/services/DataMapper.ts
+++ b/support-figma/dc_squoosh_designer/src/services/DataMapper.ts
@@ -27,9 +27,14 @@ import {
   AnimatedNodeProps,
   DecomposedTransform,
   AnimationNode,
-  AnimatedNode
+  AnimatedNode,
 } from "../timeline/types";
-import { rgbToHex, decomposeMatrix, invertMatrix, multiplyMatrix } from "../utils/common";
+import {
+  rgbToHex,
+  decomposeMatrix,
+  invertMatrix,
+  multiplyMatrix,
+} from "../utils/common";
 import { deserializeKeyframes } from "../timeline/serialization";
 import { getAnimationSegment } from "../timeline/utils";
 // Remove PlaybackController dependency
@@ -42,7 +47,6 @@ export class DataMapper {
   // Using a static instance or injecting the controller if needed for decomposition helper.
   // Alternatively, move decomposeMatrix to a static helper class.
 
-
   /**
    * Calculates the timeline positions for each variant based on animation specs.
    * @param variants The list of variants.
@@ -51,9 +55,9 @@ export class DataMapper {
   static calculateKeyframeData(variants: Variant[]) {
     let currentTime = 0;
     const keyframeTimes: KeyframeTime[] = [];
-    
+
     if (!variants || variants.length === 0) {
-        return { keyframeTimes: [], totalTime: 1 };
+      return { keyframeTimes: [], totalTime: 1 };
     }
 
     variants.forEach((variant, index) => {
@@ -64,29 +68,65 @@ export class DataMapper {
       });
 
       const animSourceVariant =
-        index < variants.length - 1
-          ? variants[index + 1]
-          : variants[0];
+        index < variants.length - 1 ? variants[index + 1] : variants[0];
 
       if (animSourceVariant && variants.length > 1) {
+        let delay = 0;
+        let duration = 0;
         const anim = animSourceVariant.animation;
-        if (anim && anim.spec) {
-          let delay = 0;
-          if (anim.spec.initial_delay) {
-            delay =
-              (anim.spec.initial_delay.secs || 0) +
-              (anim.spec.initial_delay.nanos || 0) / 1e9;
+        if (anim) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let spec = anim.spec;
+          if (!spec && anim.transitions && anim.transitions.length > 0) {
+            const matchingTrans =
+              anim.transitions.find(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (t: any) =>
+                  (t.to === animSourceVariant.name || t.to === "*" || !t.to) &&
+                  (t.from === variant.name || t.from === "*") &&
+                  t.spec,
+              ) ||
+              anim.transitions.find(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (t: any) => t.spec,
+              );
+            if (matchingTrans) {
+              spec = matchingTrans.spec;
+            }
           }
-          let duration = 0;
-          if (anim.spec.animation && anim.spec.animation.Smooth) {
-            const d = anim.spec.animation.Smooth.duration;
-            duration = (d.secs || 0) + (d.nanos || 0) / 1e9;
+          if (!spec && anim.default_spec) {
+            spec = anim.default_spec;
           }
-          currentTime += delay + duration;
+
+          if (spec) {
+            if (spec.initial_delay) {
+              delay =
+                (spec.initial_delay.secs || 0) +
+                (spec.initial_delay.nanos || 0) / 1e9;
+            }
+            if (spec.animation && spec.animation.Smooth) {
+              const d = spec.animation.Smooth.duration;
+              const val = (d.secs || 0) + (d.nanos || 0) / 1e9;
+              if (val > 0) {
+                duration = val;
+              }
+            }
+          }
         }
+        currentTime += delay + duration;
       }
     });
-    const totalTime = currentTime > 0 ? currentTime : 1;
+    let totalTime = currentTime > 0 ? currentTime : 1;
+    const allZero =
+      variants.length > 1 &&
+      keyframeTimes.every((kt) => kt.time === 0) &&
+      currentTime === 0;
+    if (allZero) {
+      keyframeTimes.forEach((kt, idx) => {
+        kt.time = idx * 0.3;
+      });
+      totalTime = variants.length * 0.3;
+    }
     // Always add a loop keyframe, even for single variants, so the timeline has a clear end point.
     // For single variants, this will simply create a loop back to the same (only) variant.
     keyframeTimes.push({
@@ -102,70 +142,70 @@ export class DataMapper {
    * Populates a timeline with locked keyframes derived from variant data.
    */
   private static populateVariantKeyframes(
-      timeline: Timeline,
-      keyframeTimes: KeyframeTime[],
-      values: (number | string | boolean | undefined)[],
-      totalTime: number,
-      nodePresence: boolean[],
-      propName: string,
-      nodeId: string
+    timeline: Timeline,
+    keyframeTimes: KeyframeTime[],
+    values: (number | string | boolean | undefined)[],
+    totalTime: number,
+    nodePresence: boolean[],
+    propName: string,
+    nodeId: string,
   ) {
-      keyframeTimes.forEach((kt: KeyframeTime) => {
-        const vIndex = kt.index;
-        let value = values[vIndex];
-        let isMissing = false;
+    keyframeTimes.forEach((kt: KeyframeTime) => {
+      const vIndex = kt.index;
+      let value = values[vIndex];
+      let isMissing = false;
 
-        if (!nodePresence[vIndex]) {
-            isMissing = true;
-            if (propName === "opacity") {
-                value = 0;
-            } else {
-                // Look ahead for next valid value
-                for (let i = vIndex + 1; i < values.length; i++) {
-                    if (values[i] !== undefined) {
-                        value = values[i];
-                        break;
-                    }
-                }
-                if (value === undefined) {
-                        // Look behind
-                        for (let i = vIndex - 1; i >= 0; i--) {
-                            if (values[i] !== undefined) {
-                                value = values[i];
-                                break;
-                            }
-                        }
-                }
-                if (value === undefined) value = 0; // Fallback
+      if (!nodePresence[vIndex]) {
+        isMissing = true;
+        if (propName === "opacity") {
+          value = 0;
+        } else {
+          // Look ahead for next valid value
+          for (let i = vIndex + 1; i < values.length; i++) {
+            if (values[i] !== undefined) {
+              value = values[i];
+              break;
             }
-        } else if (value === undefined) {
-            // Node present but property undefined (e.g. fill removed).
-            // Default to 0 for numeric properties to ensure continuity (e.g. fade out).
-            if (
-                propName.endsWith("opacity") ||
-                propName.endsWith("Radius") ||
-                propName.endsWith("Weight")
-            ) {
-                value = 0;
+          }
+          if (value === undefined) {
+            // Look behind
+            for (let i = vIndex - 1; i >= 0; i--) {
+              if (values[i] !== undefined) {
+                value = values[i];
+                break;
+              }
             }
+          }
+          if (value === undefined) value = 0; // Fallback
         }
-
-        if (value !== undefined) {
-            const keyframeId = kt.isLoop
-            ? `${nodeId}-${propName}-loop`
-            : `${nodeId}-${propName}-${vIndex}`;
-            const keyframe: Keyframe = {
-            id: keyframeId,
-            position: kt.time / totalTime,
-            value: value,
-            locked: true,
-            isMissing: isMissing,
-            easing: "Inherit",
-            };
-
-            timeline.keyframes.push(keyframe);
+      } else if (value === undefined) {
+        // Node present but property undefined (e.g. fill removed).
+        // Default to 0 for numeric properties to ensure continuity (e.g. fade out).
+        if (
+          propName.endsWith("opacity") ||
+          propName.endsWith("Radius") ||
+          propName.endsWith("Weight")
+        ) {
+          value = 0;
         }
-      });
+      }
+
+      if (value !== undefined) {
+        const keyframeId = kt.isLoop
+          ? `${nodeId}-${propName}-loop`
+          : `${nodeId}-${propName}-${vIndex}`;
+        const keyframe: Keyframe = {
+          id: keyframeId,
+          position: kt.time / totalTime,
+          value: value,
+          locked: true,
+          isMissing: isMissing,
+          easing: "Inherit",
+        };
+
+        timeline.keyframes.push(keyframe);
+      }
+    });
   }
 
   /**
@@ -181,7 +221,9 @@ export class DataMapper {
   ): AnimationData {
     console.log("transformDataToAnimationData inputs:", {
       variantsLength: variants ? variants.length : 0,
-      serializedVariantsLength: serializedVariants ? serializedVariants.length : 0,
+      serializedVariantsLength: serializedVariants
+        ? serializedVariants.length
+        : 0,
     });
 
     if (
@@ -190,7 +232,9 @@ export class DataMapper {
       !serializedVariants ||
       serializedVariants.length === 0
     ) {
-      console.warn("transformDataToAnimationData: variants or serializedVariants is empty.");
+      console.warn(
+        "transformDataToAnimationData: variants or serializedVariants is empty.",
+      );
       return { nodes: [], duration: 1 };
     }
 
@@ -199,47 +243,53 @@ export class DataMapper {
     // Build a superset tree of nodes from ALL variants
     const nodesMap = new Map<string, Node>();
 
-    const getOrCreateNode = (id: string, name: string, figmaId: string): Node => {
-        if (!nodesMap.has(id)) {
-            nodesMap.set(id, {
-                id,
-                figmaId,
-                name,
-                children: [],
-                timelines: [],
-            });
-        }
-        return nodesMap.get(id)!;
+    const getOrCreateNode = (
+      id: string,
+      name: string,
+      figmaId: string,
+    ): Node => {
+      if (!nodesMap.has(id)) {
+        nodesMap.set(id, {
+          id,
+          figmaId,
+          name,
+          children: [],
+          timelines: [],
+        });
+      }
+      return nodesMap.get(id)!;
     };
 
     serializedVariants.forEach((variantRoot) => {
-        const traverse = (node: SerializedNode, parentId: string | null) => {
-            let effectiveId = node.name;
-            if (parentId === null) effectiveId = "__ROOT__";
+      const traverse = (node: SerializedNode, parentId: string | null) => {
+        let effectiveId = node.name;
+        if (parentId === null) effectiveId = "__ROOT__";
 
-            const timelineNode = getOrCreateNode(effectiveId, node.name, node.id);
+        const timelineNode = getOrCreateNode(effectiveId, node.name, node.id);
 
-            if (parentId) {
-                const parentNode = nodesMap.get(parentId);
-                if (parentNode) {
-                    // Check if already added to children to avoid duplicates
-                    if (!parentNode.children.find((c) => c.id === effectiveId)) {
-                        parentNode.children.push(timelineNode);
-                    }
-                }
+        if (parentId) {
+          const parentNode = nodesMap.get(parentId);
+          if (parentNode) {
+            // Check if already added to children to avoid duplicates
+            if (!parentNode.children.find((c) => c.id === effectiveId)) {
+              parentNode.children.push(timelineNode);
             }
+          }
+        }
 
-            if (node.children) {
-                node.children.forEach((child) => traverse(child, effectiveId));
-            }
-        };
-        traverse(variantRoot, null);
+        if (node.children) {
+          node.children.forEach((child) => traverse(child, effectiveId));
+        }
+      };
+      traverse(variantRoot, null);
     });
 
     const figmaVariantRootNode = nodesMap.get("__ROOT__");
     if (!figmaVariantRootNode) {
-         console.warn("transformDataToAnimationData: __ROOT__ node not found in nodesMap.");
-         return { nodes: [], duration: 1 };
+      console.warn(
+        "transformDataToAnimationData: __ROOT__ node not found in nodesMap.",
+      );
+      return { nodes: [], duration: 1 };
     }
 
     const variantChangeTimeline: Timeline = {
@@ -290,7 +340,12 @@ export class DataMapper {
         const variantNodesMap = new Map();
         // SerializedNode is strictly not AnimationNode but structurally similar enough here.
         // We cast to avoid TS errors as we know the structure matches for what collectAnimationNodes needs.
-        this.collectAnimationNodes(variant as unknown as AnimationNode, null, true, variantNodesMap);
+        this.collectAnimationNodes(
+          variant as unknown as AnimationNode,
+          null,
+          true,
+          variantNodesMap,
+        );
         const figmaNode = variantNodesMap.get(node.id);
 
         if (figmaNode) {
@@ -307,11 +362,11 @@ export class DataMapper {
             "bottomLeftRadius",
             "bottomRightRadius",
             "arcData",
-            "strokeWeight"
+            "strokeWeight",
           ];
-          props.forEach(p => {
-              if (!properties[p]) properties[p] = [];
-              properties[p][vIndex] = this.getNodePropertyValue(figmaNode, p); // eslint-disable-line @typescript-eslint/no-explicit-any
+          props.forEach((p) => {
+            if (!properties[p]) properties[p] = [];
+            properties[p][vIndex] = this.getNodePropertyValue(figmaNode, p); // eslint-disable-line @typescript-eslint/no-explicit-any
           });
 
           if (figmaNode.fills && Array.isArray(figmaNode.fills)) {
@@ -319,44 +374,47 @@ export class DataMapper {
             (figmaNode.fills as any[]).forEach((fill: unknown, i: number) => {
               // We need to check all potential properties for fills
               const fillProps = [
-                  `fills.${i}.solid`,
-                  `fills.${i}.solid.opacity`,
-                  `fills.${i}.gradient.positions`,
-                  `fills.${i}.gradient.stops`,
-                  `fills.${i}.gradient.opacity`,
-                  `fills.${i}.opacity`,
-                  `fills.${i}.arc`
+                `fills.${i}.solid`,
+                `fills.${i}.solid.opacity`,
+                `fills.${i}.gradient.positions`,
+                `fills.${i}.gradient.stops`,
+                `fills.${i}.gradient.opacity`,
+                `fills.${i}.opacity`,
+                `fills.${i}.arc`,
               ];
-                            fillProps.forEach(p => {
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const val = this.getNodePropertyValue(figmaNode, p);
-                                if (val !== 0 && val !== undefined) { 
-                                    if (!properties[p]) properties[p] = [];
-                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                    properties[p][vIndex] = val;
-                                }
-                            });            });
+              fillProps.forEach((p) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const val = this.getNodePropertyValue(figmaNode, p);
+                if (val !== 0 && val !== undefined) {
+                  if (!properties[p]) properties[p] = [];
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  properties[p][vIndex] = val;
+                }
+              });
+            });
           }
 
           if (figmaNode.strokes && Array.isArray(figmaNode.strokes)) {
-             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-             (figmaNode.strokes as any[]).forEach((stroke: unknown, i: number) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (figmaNode.strokes as any[]).forEach(
+              (stroke: unknown, i: number) => {
                 const strokeProps = [
-                    `strokes.${i}.solid`,
-                    `strokes.${i}.opacity`,
-                    `strokes.${i}.arc`
+                  `strokes.${i}.solid`,
+                  `strokes.${i}.opacity`,
+                  `strokes.${i}.arc`,
                 ];
-                 strokeProps.forEach(p => {
+                strokeProps.forEach((p) => {
                   const val = this.getNodePropertyValue(figmaNode, p);
                   if (val !== 0 && val !== undefined) {
-                      if (!properties[p]) properties[p] = [];
-                      properties[p][vIndex] = val; // eslint-disable-line @typescript-eslint/no-explicit-any
+                    if (!properties[p]) properties[p] = [];
+                    properties[p][vIndex] = val; // eslint-disable-line @typescript-eslint/no-explicit-any
                   }
-              });
-             });
+                });
+              },
+            );
           }
         } else {
-            nodePresence[vIndex] = false;
+          nodePresence[vIndex] = false;
         }
       });
 
@@ -369,7 +427,15 @@ export class DataMapper {
             keyframes: [],
           };
 
-          this.populateVariantKeyframes(timeline, keyframeTimes, values, totalTime, nodePresence, propName, node.id);
+          this.populateVariantKeyframes(
+            timeline,
+            keyframeTimes,
+            values,
+            totalTime,
+            nodePresence,
+            propName,
+            node.id,
+          );
           node.timelines.push(timeline);
         }
       }
@@ -386,12 +452,20 @@ export class DataMapper {
                   keyframes: [],
                   isCustom: true,
                 };
-                
+
                 const values = properties[propName];
                 if (values) {
-                    this.populateVariantKeyframes(timeline, keyframeTimes, values, totalTime, nodePresence, propName, node.id);
+                  this.populateVariantKeyframes(
+                    timeline,
+                    keyframeTimes,
+                    values,
+                    totalTime,
+                    nodePresence,
+                    propName,
+                    node.id,
+                  );
                 }
-                
+
                 node.timelines.push(timeline);
               }
             }
@@ -414,8 +488,7 @@ export class DataMapper {
           if (!segment) continue;
 
           const animSourceVariantIndex = keyframeTimes[i + 1].index;
-          const animSourceVariant =
-            variants[animSourceVariantIndex];
+          const animSourceVariant = variants[animSourceVariantIndex];
 
           if (
             animSourceVariant?.animation?.customKeyframeData &&
@@ -423,18 +496,19 @@ export class DataMapper {
           ) {
             const serializedCustomKeyframes =
               animSourceVariant.animation.customKeyframeData[timeline.id];
-            const { keyframes: customKeyframes, targetEasing } = deserializeKeyframes(
-              serializedCustomKeyframes,
-            );
+            const { keyframes: customKeyframes, targetEasing } =
+              deserializeKeyframes(serializedCustomKeyframes);
 
             if (targetEasing && targetEasing !== "Inherit") {
-               const endKeyframeTime = keyframeTimes[i + 1].time / totalTime;
-               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-               const endKeyframe = timeline.keyframes.find((kf) => Math.abs(kf.position - endKeyframeTime) < 0.0001);
-               if (endKeyframe) {
-                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                   endKeyframe.easing = targetEasing as any;
-               }
+              const endKeyframeTime = keyframeTimes[i + 1].time / totalTime;
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const endKeyframe = timeline.keyframes.find(
+                (kf) => Math.abs(kf.position - endKeyframeTime) < 0.0001,
+              );
+              if (endKeyframe) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                endKeyframe.easing = targetEasing as any;
+              }
             }
 
             customKeyframes.forEach((customKf) => {
@@ -471,7 +545,7 @@ export class DataMapper {
   public static getNodePropertyValue(
     node: AnimationNode,
     propertyName: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any {
     if (!node) return 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -538,23 +612,26 @@ export class DataMapper {
             } else if (fillProp === "gradient.positions") {
               return fill.gradientHandlePositions;
             } else if (fillProp === "gradient.stops") {
-              return (fill.gradientStops && Array.isArray(fill.gradientStops)) ? fill.gradientStops.map(
-                  (stop: {
-                    position: number;
-                    color: { r: number; g: number; b: number };
-                  }) => {
-                    if (stop.color) {
-                      return {
-                        position: stop.position,
-                        color: rgbToHex(
-                          Math.round(stop.color.r * 255),
-                          Math.round(stop.color.g * 255),
-                          Math.round(stop.color.b * 255),
-                        ),
-                      };
-                    }
-                    return stop;
-                  }) as unknown : undefined;
+              return fill.gradientStops && Array.isArray(fill.gradientStops)
+                ? (fill.gradientStops.map(
+                    (stop: {
+                      position: number;
+                      color: { r: number; g: number; b: number };
+                    }) => {
+                      if (stop.color) {
+                        return {
+                          position: stop.position,
+                          color: rgbToHex(
+                            Math.round(stop.color.r * 255),
+                            Math.round(stop.color.g * 255),
+                            Math.round(stop.color.b * 255),
+                          ),
+                        };
+                      }
+                      return stop;
+                    },
+                  ) as unknown)
+                : undefined;
             } else if (fillProp === "gradient.opacity") {
               return fill.opacity !== undefined ? fill.opacity : 1;
             } else if (fillProp === "arc") {
@@ -602,39 +679,48 @@ export class DataMapper {
   ) {
     if (node.visible === false) return;
 
-    const currentAbsTransform = node.absoluteTransform || [[1, 0, 0], [0, 1, 0]];
+    const currentAbsTransform = node.absoluteTransform || [
+      [1, 0, 0],
+      [0, 1, 0],
+    ];
     let relativeLeft = 0;
     let relativeTop = 0;
     let decomposedLocal: DecomposedTransform;
 
-    if (isRoot || !parentAbsTransform || !parentAbsTransform.absoluteTransform) {
-        const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
-        if (isRoot) {
-            relativeLeft = 0;
-            relativeTop = 0;
-            decomposedLocal = nodeAbsDecomposed;
-        } else {
-            relativeLeft = nodeAbsDecomposed.translateX;
-            relativeTop = nodeAbsDecomposed.translateY;
-            decomposedLocal = nodeAbsDecomposed;
-        }
+    if (
+      isRoot ||
+      !parentAbsTransform ||
+      !parentAbsTransform.absoluteTransform
+    ) {
+      const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
+      if (isRoot) {
+        relativeLeft = 0;
+        relativeTop = 0;
+        decomposedLocal = nodeAbsDecomposed;
+      } else {
+        relativeLeft = nodeAbsDecomposed.translateX;
+        relativeTop = nodeAbsDecomposed.translateY;
+        decomposedLocal = nodeAbsDecomposed;
+      }
     } else {
-        const parentAbs = parentAbsTransform.absoluteTransform;
-        const parentInv = invertMatrix(parentAbs);
-        
-        if (parentInv) {
-            const relMatrix = multiplyMatrix(parentInv, currentAbsTransform);
-            decomposedLocal = decomposeMatrix(relMatrix);
-            relativeLeft = decomposedLocal.translateX;
-            relativeTop = decomposedLocal.translateY;
-        } else {
-            // Fallback for non-invertible parent matrix
-            const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
-            const parentAbsDecomposed = decomposeMatrix(parentAbs);
-            relativeLeft = nodeAbsDecomposed.translateX - parentAbsDecomposed.translateX;
-            relativeTop = nodeAbsDecomposed.translateY - parentAbsDecomposed.translateY;
-            decomposedLocal = nodeAbsDecomposed;
-        }
+      const parentAbs = parentAbsTransform.absoluteTransform;
+      const parentInv = invertMatrix(parentAbs);
+
+      if (parentInv) {
+        const relMatrix = multiplyMatrix(parentInv, currentAbsTransform);
+        decomposedLocal = decomposeMatrix(relMatrix);
+        relativeLeft = decomposedLocal.translateX;
+        relativeTop = decomposedLocal.translateY;
+      } else {
+        // Fallback for non-invertible parent matrix
+        const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
+        const parentAbsDecomposed = decomposeMatrix(parentAbs);
+        relativeLeft =
+          nodeAbsDecomposed.translateX - parentAbsDecomposed.translateX;
+        relativeTop =
+          nodeAbsDecomposed.translateY - parentAbsDecomposed.translateY;
+        decomposedLocal = nodeAbsDecomposed;
+      }
     }
 
     map.set(isRoot ? "__ROOT__" : node.name, {
@@ -643,10 +729,15 @@ export class DataMapper {
       relativeTop,
       decomposedTransform: decomposedLocal,
     });
-    
+
     if (node.children)
       node.children.forEach((child: AnimationNode) =>
-        this.collectAnimationNodes(child, { ...node, absoluteTransform: currentAbsTransform }, false, map),
+        this.collectAnimationNodes(
+          child,
+          { ...node, absoluteTransform: currentAbsTransform },
+          false,
+          map,
+        ),
       );
   }
 
@@ -664,37 +755,46 @@ export class DataMapper {
     animatedNodes: AnimatedNode[],
   ) {
     // Similar logic to collectAnimationNodes for consistent preview
-    const currentAbsTransform = node.absoluteTransform || [[1, 0, 0], [0, 1, 0]];
+    const currentAbsTransform = node.absoluteTransform || [
+      [1, 0, 0],
+      [0, 1, 0],
+    ];
     let relativeLeft = 0;
     let relativeTop = 0;
     let decomposedLocal: DecomposedTransform;
 
-    if (isRoot || !parentAbsTransform || !parentAbsTransform.absoluteTransform) {
-       const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
-       if (isRoot) {
-           relativeLeft = 0;
-           relativeTop = 0;
-           decomposedLocal = nodeAbsDecomposed;
-       } else {
-           relativeLeft = nodeAbsDecomposed.translateX;
-           relativeTop = nodeAbsDecomposed.translateY;
-           decomposedLocal = nodeAbsDecomposed;
-       }
+    if (
+      isRoot ||
+      !parentAbsTransform ||
+      !parentAbsTransform.absoluteTransform
+    ) {
+      const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
+      if (isRoot) {
+        relativeLeft = 0;
+        relativeTop = 0;
+        decomposedLocal = nodeAbsDecomposed;
+      } else {
+        relativeLeft = nodeAbsDecomposed.translateX;
+        relativeTop = nodeAbsDecomposed.translateY;
+        decomposedLocal = nodeAbsDecomposed;
+      }
     } else {
-       const parentAbs = parentAbsTransform.absoluteTransform;
-       const parentInv = invertMatrix(parentAbs);
-       if (parentInv) {
-           const relMatrix = multiplyMatrix(parentInv, currentAbsTransform);
-           decomposedLocal = decomposeMatrix(relMatrix);
-           relativeLeft = decomposedLocal.translateX;
-           relativeTop = decomposedLocal.translateY;
-       } else {
-           const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
-           const parentAbsDecomposed = decomposeMatrix(parentAbs);
-           relativeLeft = nodeAbsDecomposed.translateX - parentAbsDecomposed.translateX;
-           relativeTop = nodeAbsDecomposed.translateY - parentAbsDecomposed.translateY;
-           decomposedLocal = nodeAbsDecomposed;
-       }
+      const parentAbs = parentAbsTransform.absoluteTransform;
+      const parentInv = invertMatrix(parentAbs);
+      if (parentInv) {
+        const relMatrix = multiplyMatrix(parentInv, currentAbsTransform);
+        decomposedLocal = decomposeMatrix(relMatrix);
+        relativeLeft = decomposedLocal.translateX;
+        relativeTop = decomposedLocal.translateY;
+      } else {
+        const nodeAbsDecomposed = decomposeMatrix(currentAbsTransform);
+        const parentAbsDecomposed = decomposeMatrix(parentAbs);
+        relativeLeft =
+          nodeAbsDecomposed.translateX - parentAbsDecomposed.translateX;
+        relativeTop =
+          nodeAbsDecomposed.translateY - parentAbsDecomposed.translateY;
+        decomposedLocal = nodeAbsDecomposed;
+      }
     }
 
     const props: AnimatedNodeProps = {

--- a/support-figma/dc_squoosh_designer/src/services/DataMapper.ts
+++ b/support-figma/dc_squoosh_designer/src/services/DataMapper.ts
@@ -36,7 +36,11 @@ import {
   multiplyMatrix,
 } from "../utils/common";
 import { deserializeKeyframes } from "../timeline/serialization";
-import { getAnimationSegment } from "../timeline/utils";
+import {
+  getAnimationSegment,
+  resolveVariantSpec,
+  resolveVariantCustomKeyframeData,
+} from "../timeline/utils";
 // Remove PlaybackController dependency
 
 /**
@@ -52,7 +56,12 @@ export class DataMapper {
    * @param variants The list of variants.
    * @returns An object containing the keyframe times and the total duration.
    */
-  static calculateKeyframeData(variants: Variant[]) {
+  static calculateKeyframeData(
+    variants: Variant[],
+    activeTransitionsMap?:
+      | { [variantName: string]: number }
+      | Map<string, number>,
+  ) {
     let currentTime = 0;
     const keyframeTimes: KeyframeTime[] = [];
 
@@ -75,28 +84,11 @@ export class DataMapper {
         let duration = 0;
         const anim = animSourceVariant.animation;
         if (anim) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let spec = anim.spec;
-          if (!spec && anim.transitions && anim.transitions.length > 0) {
-            const matchingTrans =
-              anim.transitions.find(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (t: any) =>
-                  (t.to === animSourceVariant.name || t.to === "*" || !t.to) &&
-                  (t.from === variant.name || t.from === "*") &&
-                  t.spec,
-              ) ||
-              anim.transitions.find(
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (t: any) => t.spec,
-              );
-            if (matchingTrans) {
-              spec = matchingTrans.spec;
-            }
-          }
-          if (!spec && anim.default_spec) {
-            spec = anim.default_spec;
-          }
+          const spec = resolveVariantSpec(
+            anim,
+            animSourceVariant.name,
+            activeTransitionsMap,
+          );
 
           if (spec) {
             if (spec.initial_delay) {
@@ -218,6 +210,9 @@ export class DataMapper {
   static transformDataToAnimationData(
     variants: Variant[],
     serializedVariants: SerializedNode[],
+    activeTransitionsMap?:
+      | { [variantName: string]: number }
+      | Map<string, number>,
   ): AnimationData {
     console.log("transformDataToAnimationData inputs:", {
       variantsLength: variants ? variants.length : 0,
@@ -238,7 +233,10 @@ export class DataMapper {
       return { nodes: [], duration: 1 };
     }
 
-    const { keyframeTimes, totalTime } = this.calculateKeyframeData(variants);
+    const { keyframeTimes, totalTime } = this.calculateKeyframeData(
+      variants,
+      activeTransitionsMap,
+    );
 
     // Build a superset tree of nodes from ALL variants
     const nodesMap = new Map<string, Node>();
@@ -441,8 +439,13 @@ export class DataMapper {
       }
 
       variants.forEach((variant) => {
-        if (variant.animation?.customKeyframeData) {
-          for (const timelineId in variant.animation.customKeyframeData) {
+        const kfData = resolveVariantCustomKeyframeData(
+          variant.animation,
+          variant.name,
+          activeTransitionsMap,
+        );
+        if (kfData) {
+          for (const timelineId in kfData) {
             if (timelineId.startsWith(`${node.id}-`)) {
               const propName = timelineId.substring(node.id.length + 1);
               if (!node.timelines.some((t) => t.property === propName)) {
@@ -490,12 +493,13 @@ export class DataMapper {
           const animSourceVariantIndex = keyframeTimes[i + 1].index;
           const animSourceVariant = variants[animSourceVariantIndex];
 
-          if (
-            animSourceVariant?.animation?.customKeyframeData &&
-            animSourceVariant.animation.customKeyframeData[timeline.id]
-          ) {
-            const serializedCustomKeyframes =
-              animSourceVariant.animation.customKeyframeData[timeline.id];
+          const kfData = resolveVariantCustomKeyframeData(
+            animSourceVariant?.animation,
+            animSourceVariant?.name,
+            activeTransitionsMap,
+          );
+          if (kfData && kfData[timeline.id]) {
+            const serializedCustomKeyframes = kfData[timeline.id];
             const { keyframes: customKeyframes, targetEasing } =
               deserializeKeyframes(serializedCustomKeyframes);
 

--- a/support-figma/dc_squoosh_designer/src/timeline/NodeTreeView.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/NodeTreeView.ts
@@ -84,12 +84,12 @@ export class NodeTreeView {
     const nodeId = nodeElement.dataset.nodeId;
 
     if (target.classList.contains("delete-timeline")) {
-        const timelineLi = target.closest("li.property") as HTMLElement;
-        if (timelineLi && timelineLi.dataset.timelineId) {
-            const timelineId = timelineLi.dataset.timelineId;
-            this.eventEmitter.emit("timeline:delete", timelineId);
-        }
-        return;
+      const timelineLi = target.closest("li.property") as HTMLElement;
+      if (timelineLi && timelineLi.dataset.timelineId) {
+        const timelineId = timelineLi.dataset.timelineId;
+        this.eventEmitter.emit("timeline:delete", timelineId);
+      }
+      return;
     }
 
     if (target.classList.contains("add-timeline")) {
@@ -102,14 +102,14 @@ export class NodeTreeView {
       return;
     }
     if (target.classList.contains("node-name")) {
-      const nodeToToggle = target.closest(".has-children");
-      if (nodeToToggle) {
-        nodeToToggle.classList.toggle("collapsed");
+      const liElement = target.closest("li");
+      if (liElement && liElement.classList.contains("has-children")) {
+        liElement.classList.toggle("collapsed");
         if (nodeId) {
           this.eventEmitter.emit(
             "node:toggle",
             nodeId,
-            nodeToToggle.classList.contains("collapsed"),
+            liElement.classList.contains("collapsed"),
           );
         }
       }
@@ -143,6 +143,29 @@ export class NodeTreeView {
     if (input) {
       input.focus();
       input.select();
+    }
+  }
+
+  /**
+   * Updates the displayed name of the root node in the tree.
+   * @param name The new root node name.
+   */
+  public updateRootNodeName(name: string): void {
+    if (this.nodes.length > 0) {
+      this.nodes[0].name = name;
+      const rootLi = this.container.querySelector(
+        'li[data-node-id="__ROOT__"]',
+      );
+      if (rootLi) {
+        const nodeNameSpan = rootLi.querySelector(".node-name");
+        if (nodeNameSpan) {
+          const arrow = nodeNameSpan.querySelector(".toggle-arrow");
+          nodeNameSpan.textContent = ` ${name}`;
+          if (arrow) {
+            nodeNameSpan.prepend(arrow);
+          }
+        }
+      }
     }
   }
 
@@ -234,7 +257,7 @@ export class NodeTreeView {
                     ? `<input type="text" value="${timeline.property}" list="property-options" />`
                     : timeline.property
                 }
-                ${timeline.isCustom ? '<button class="delete-timeline">-</button>' : ''}
+                ${timeline.isCustom ? '<button class="delete-timeline">-</button>' : ""}
               </li>
             `,
               )

--- a/support-figma/dc_squoosh_designer/src/timeline/PlaybackController.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/PlaybackController.ts
@@ -26,6 +26,7 @@ import {
   AnimationNode,
 } from "./types";
 import { EventEmitter } from "./EventEmitter";
+import { resolveVariantSpec } from "./utils";
 import { InterpolationService } from "../utils/InterpolationService";
 import { DataMapper } from "../services/DataMapper";
 
@@ -328,10 +329,11 @@ export class PlaybackController extends EventEmitter {
         toIndex = endKeyframe.index;
         segmentStartTime = startKeyframe.time;
         const anim = this.variants[toIndex].animation;
-        if (anim && anim.spec && anim.spec.initial_delay) {
+        const spec = resolveVariantSpec(anim, this.variants[toIndex].name);
+        if (spec && spec.initial_delay) {
           segmentDelay =
-            (anim.spec.initial_delay.secs || 0) +
-            (anim.spec.initial_delay.nanos || 0) / 1e9;
+            (spec.initial_delay.secs || 0) +
+            (spec.initial_delay.nanos || 0) / 1e9;
         }
         segmentDuration = endKeyframe.time - startKeyframe.time - segmentDelay;
         break;
@@ -372,14 +374,10 @@ export class PlaybackController extends EventEmitter {
     value = Math.max(0, Math.min(1, value));
 
     const animData = this.variants[toIndex].animation;
+    const spec = resolveVariantSpec(animData, this.variants[toIndex].name);
     let nodeEasing: EasingFunction = Easing.easeInOutQuad;
-    if (
-      animData &&
-      animData.spec &&
-      animData.spec.animation &&
-      animData.spec.animation.Smooth
-    ) {
-      const easingStr = animData.spec.animation.Smooth.easing;
+    if (spec && spec.animation && spec.animation.Smooth) {
+      const easingStr = spec.animation.Smooth.easing;
       switch (easingStr) {
         case "Linear":
           nodeEasing = Easing.linear;

--- a/support-figma/dc_squoosh_designer/src/timeline/PlaybackController.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/PlaybackController.ts
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-
-import { AnimationData, Node, Timeline, Keyframe, SerializedNode, Variant, KeyframeTime, AnimatedNode, AnimationNode } from "./types";
+import {
+  AnimationData,
+  Node,
+  Timeline,
+  Keyframe,
+  SerializedNode,
+  Variant,
+  KeyframeTime,
+  AnimatedNode,
+  AnimationNode,
+} from "./types";
 import { EventEmitter } from "./EventEmitter";
 import { InterpolationService } from "../utils/InterpolationService";
 import { DataMapper } from "../services/DataMapper";
@@ -68,13 +77,13 @@ export class PlaybackController extends EventEmitter {
   public setThrottleUpdates(enabled: boolean) {
     this.throttleUpdates = enabled;
     if (!enabled) {
-        // Reset state if disabling
-        this.isFigmaProcessing = false;
-        this.nextUpdateTime = null;
-        if (this.updateTimeout !== null) {
-            clearTimeout(this.updateTimeout);
-            this.updateTimeout = null;
-        }
+      // Reset state if disabling
+      this.isFigmaProcessing = false;
+      this.nextUpdateTime = null;
+      if (this.updateTimeout !== null) {
+        clearTimeout(this.updateTimeout);
+        this.updateTimeout = null;
+      }
     }
   }
 
@@ -85,8 +94,8 @@ export class PlaybackController extends EventEmitter {
   public acknowledgePreviewUpdate() {
     this.isFigmaProcessing = false;
     if (this.throttleUpdates && this.nextUpdateTime !== null) {
-        // Trigger processing of the latest pending time
-        this.updatePreviewAtTime(this.nextUpdateTime);
+      // Trigger processing of the latest pending time
+      this.updatePreviewAtTime(this.nextUpdateTime);
     }
   }
 
@@ -238,7 +247,9 @@ export class PlaybackController extends EventEmitter {
   }
 
   private calculateKeyframeData() {
-    const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.variants);
+    const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
+      this.variants,
+    );
     this.keyframeTimes = keyframeTimes;
     this.totalTime = totalTime;
   }
@@ -275,10 +286,10 @@ export class PlaybackController extends EventEmitter {
           this.updateTimeout = window.setTimeout(() => {
             // Check again if processing
             if (!this.isFigmaProcessing && this.nextUpdateTime !== null) {
-                this.isFigmaProcessing = true;
-                this.performUpdatePreviewAtTime(this.nextUpdateTime);
-                this.lastUpdateTime = Date.now();
-                this.nextUpdateTime = null;
+              this.isFigmaProcessing = true;
+              this.performUpdatePreviewAtTime(this.nextUpdateTime);
+              this.lastUpdateTime = Date.now();
+              this.nextUpdateTime = null;
             }
             this.updateTimeout = null;
           }, 16 - timeSinceLastUpdate);
@@ -290,9 +301,15 @@ export class PlaybackController extends EventEmitter {
   }
 
   private performUpdatePreviewAtTime(time: number) {
-    if (!this.animationData || !this.animationData.nodes || this.animationData.nodes.length === 0) {
-        console.warn("performUpdatePreviewAtTime: No animation data nodes available.");
-        return;
+    if (
+      !this.animationData ||
+      !this.animationData.nodes ||
+      this.animationData.nodes.length === 0
+    ) {
+      console.warn(
+        "performUpdatePreviewAtTime: No animation data nodes available.",
+      );
+      return;
     }
 
     let fromIndex = -1,
@@ -331,9 +348,17 @@ export class PlaybackController extends EventEmitter {
       }
     }
 
-    if (fromIndex !== -1 && fromIndex !== this.currentKeyframeIndex) {
-      this.currentKeyframeIndex = fromIndex;
-      this.emit("keyframe-changed", fromIndex);
+    let emittedIndex = fromIndex;
+    const exact = this.keyframeTimes.find(
+      (kt) => !kt.isLoop && Math.abs(kt.time - time) < 0.001,
+    );
+    if (exact) {
+      emittedIndex = exact.index;
+    }
+
+    if (emittedIndex !== -1 && emittedIndex !== this.currentKeyframeIndex) {
+      this.currentKeyframeIndex = emittedIndex;
+      this.emit("keyframe-changed", emittedIndex);
     }
 
     let value = 0;
@@ -377,10 +402,20 @@ export class PlaybackController extends EventEmitter {
 
     const fromNodes = new Map();
     // Cast to AnimationNode (mostly compatible)
-    DataMapper.collectAnimationNodes(fromVariant as unknown as AnimationNode, null, true, fromNodes);
+    DataMapper.collectAnimationNodes(
+      fromVariant as unknown as AnimationNode,
+      null,
+      true,
+      fromNodes,
+    );
 
     const toNodes = new Map();
-    DataMapper.collectAnimationNodes(toVariant as unknown as AnimationNode, null, true, toNodes);
+    DataMapper.collectAnimationNodes(
+      toVariant as unknown as AnimationNode,
+      null,
+      true,
+      toNodes,
+    );
 
     const allNodeNames = new Set([...fromNodes.keys(), ...toNodes.keys()]);
     const animatedNodes: AnimatedNode[] = [];
@@ -419,7 +454,7 @@ export class PlaybackController extends EventEmitter {
       // Add all fill properties from the timeline
       if (timelineNode) {
         timelineNode.timelines.forEach((t) => {
-           propertiesToAnimate.add(t.property);
+          propertiesToAnimate.add(t.property);
         });
       }
 
@@ -446,7 +481,12 @@ export class PlaybackController extends EventEmitter {
 
           if (fromNode && toNode) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            props[propName] = InterpolationService.interpolate(startValue, endValue, easedValue, propName);
+            props[propName] = InterpolationService.interpolate(
+              startValue,
+              endValue,
+              easedValue,
+              propName,
+            );
           } else if (toNode) {
             const effectiveStart = propName === "opacity" ? 0 : endValue;
             if (
@@ -479,64 +519,100 @@ export class PlaybackController extends EventEmitter {
 
       // Post-process to fix rotation origin if no custom spatial timelines exist
       if (fromNode && toNode) {
-          const spatialProps = ['x', 'y', 'width', 'height', 'rotation'];
-        const hasCustomSpatialTimeline = spatialProps.some(prop =>
-          timelineNode?.timelines.some(t => t.property === prop && t.keyframes.some(kf => !kf.locked))
-          );
+        const spatialProps = ["x", "y", "width", "height", "rotation"];
+        const hasCustomSpatialTimeline = spatialProps.some((prop) =>
+          timelineNode?.timelines.some(
+            (t) => t.property === prop && t.keyframes.some((kf) => !kf.locked),
+          ),
+        );
 
-          if (!hasCustomSpatialTimeline) {
-              const startX = this.getNodePropertyValue(fromNode, 'x') as number;
-              const startY = this.getNodePropertyValue(fromNode, 'y') as number;
-              const startW = this.getNodePropertyValue(fromNode, 'width') as number;
-              const startH = this.getNodePropertyValue(fromNode, 'height') as number;
-              const startRot = this.getNodePropertyValue(fromNode, 'rotation') as number;
+        if (!hasCustomSpatialTimeline) {
+          const startX = this.getNodePropertyValue(fromNode, "x") as number;
+          const startY = this.getNodePropertyValue(fromNode, "y") as number;
+          const startW = this.getNodePropertyValue(fromNode, "width") as number;
+          const startH = this.getNodePropertyValue(
+            fromNode,
+            "height",
+          ) as number;
+          const startRot = this.getNodePropertyValue(
+            fromNode,
+            "rotation",
+          ) as number;
 
-              const endX = this.getNodePropertyValue(toNode, 'x') as number;
-              const endY = this.getNodePropertyValue(toNode, 'y') as number;
-              const endW = this.getNodePropertyValue(toNode, 'width') as number;
-              const endH = this.getNodePropertyValue(toNode, 'height') as number;
-              const endRot = this.getNodePropertyValue(toNode, 'rotation') as number;
+          const endX = this.getNodePropertyValue(toNode, "x") as number;
+          const endY = this.getNodePropertyValue(toNode, "y") as number;
+          const endW = this.getNodePropertyValue(toNode, "width") as number;
+          const endH = this.getNodePropertyValue(toNode, "height") as number;
+          const endRot = this.getNodePropertyValue(
+            toNode,
+            "rotation",
+          ) as number;
 
-              const degreesToRadians = (deg: number) => deg * (Math.PI / 180);
+          const degreesToRadians = (deg: number) => deg * (Math.PI / 180);
 
-              // Calculate Start Center
-              // We negate the angle because updateFigmaPreview applies node.rotation = -props.rotation
-              // implying the visual rotation is inverted relative to the DataMapper value.
-            const startRotRad = degreesToRadians(-startRot);
-              // Center relative to TopLeft(0,0) in local rotated space is (w/2, h/2)
-              // Vector d = (w/2, h/2). Rotate d by rot. Add to TopLeft (x,y).
-              // Standard rotation: x' = x*cos - y*sin, y' = x*sin + y*cos
-              const startCx = startX + (startW / 2) * Math.cos(startRotRad) - (startH / 2) * Math.sin(startRotRad);
-              const startCy = startY + (startW / 2) * Math.sin(startRotRad) + (startH / 2) * Math.cos(startRotRad);
+          // Calculate Start Center
+          // We negate the angle because updateFigmaPreview applies node.rotation = -props.rotation
+          // implying the visual rotation is inverted relative to the DataMapper value.
+          const startRotRad = degreesToRadians(-startRot);
+          // Center relative to TopLeft(0,0) in local rotated space is (w/2, h/2)
+          // Vector d = (w/2, h/2). Rotate d by rot. Add to TopLeft (x,y).
+          // Standard rotation: x' = x*cos - y*sin, y' = x*sin + y*cos
+          const startCx =
+            startX +
+            (startW / 2) * Math.cos(startRotRad) -
+            (startH / 2) * Math.sin(startRotRad);
+          const startCy =
+            startY +
+            (startW / 2) * Math.sin(startRotRad) +
+            (startH / 2) * Math.cos(startRotRad);
 
-              // Calculate End Center
-              const endRotRad = degreesToRadians(-endRot);
-              const endCx = endX + (endW / 2) * Math.cos(endRotRad) - (endH / 2) * Math.sin(endRotRad);
-              const endCy = endY + (endW / 2) * Math.sin(endRotRad) + (endH / 2) * Math.cos(endRotRad);
+          // Calculate End Center
+          const endRotRad = degreesToRadians(-endRot);
+          const endCx =
+            endX +
+            (endW / 2) * Math.cos(endRotRad) -
+            (endH / 2) * Math.sin(endRotRad);
+          const endCy =
+            endY +
+            (endW / 2) * Math.sin(endRotRad) +
+            (endH / 2) * Math.cos(endRotRad);
 
-              // Interpolate Center, Width, Height, Rotation
-              const currentCx = startCx + (endCx - startCx) * easedValue;
-              const currentCy = startCy + (endCy - startCy) * easedValue;
-              const currentW = props.width !== undefined ? props.width : (startW + (endW - startW) * easedValue);
-              const currentH = props.height !== undefined ? props.height : (startH + (endH - startH) * easedValue);
-              const currentRot = props.rotation !== undefined ? props.rotation : (startRot + (endRot - startRot) * easedValue);
+          // Interpolate Center, Width, Height, Rotation
+          const currentCx = startCx + (endCx - startCx) * easedValue;
+          const currentCy = startCy + (endCy - startCy) * easedValue;
+          const currentW =
+            props.width !== undefined
+              ? props.width
+              : startW + (endW - startW) * easedValue;
+          const currentH =
+            props.height !== undefined
+              ? props.height
+              : startH + (endH - startH) * easedValue;
+          const currentRot =
+            props.rotation !== undefined
+              ? props.rotation
+              : startRot + (endRot - startRot) * easedValue;
 
-              // Calculate New TopLeft from Interpolated Center
-              const currentRotRad = degreesToRadians(-currentRot);
-              // To go back from Center to TopLeft: subtract rotated (w/2, h/2)
-              const newX = currentCx - ((currentW / 2) * Math.cos(currentRotRad) - (currentH / 2) * Math.sin(currentRotRad));
-              const newY = currentCy - ((currentW / 2) * Math.sin(currentRotRad) + (currentH / 2) * Math.cos(currentRotRad));
+          // Calculate New TopLeft from Interpolated Center
+          const currentRotRad = degreesToRadians(-currentRot);
+          // To go back from Center to TopLeft: subtract rotated (w/2, h/2)
+          const newX =
+            currentCx -
+            ((currentW / 2) * Math.cos(currentRotRad) -
+              (currentH / 2) * Math.sin(currentRotRad));
+          const newY =
+            currentCy -
+            ((currentW / 2) * Math.sin(currentRotRad) +
+              (currentH / 2) * Math.cos(currentRotRad));
 
-              props.x = newX;
-              props.y = newY;
-              // Ensure width/height/rotation are set if not already (though loop above should have set them)
-              props.width = currentW;
-              props.height = currentH;
-              props.rotation = currentRot;
-          }
+          props.x = newX;
+          props.y = newY;
+          // Ensure width/height/rotation are set if not already (though loop above should have set them)
+          props.width = currentW;
+          props.height = currentH;
+          props.rotation = currentRot;
+        }
       }
-
-
 
       if (nodeName) {
         animatedNodes.push({
@@ -560,7 +636,7 @@ export class PlaybackController extends EventEmitter {
   public getInterpolatedValue(
     timelineId: string,
     time: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any {
     const findResult = this.findKeyframeData(
       this.animationData.nodes,
@@ -576,14 +652,14 @@ export class PlaybackController extends EventEmitter {
       this.keyframeTimes,
       this.serializedVariants,
       this.variants,
-      node
+      node,
     );
   }
 
   public getNodePropertyValue(
     node: AnimationNode,
     propertyName: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): any {
     return DataMapper.getNodePropertyValue(node, propertyName);
   }

--- a/support-figma/dc_squoosh_designer/src/timeline/TimelineEditor.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/TimelineEditor.ts
@@ -249,6 +249,16 @@ export class TimelineEditor {
   }
 
   /**
+   * Updates the displayed name of the root node in the tree.
+   * @param name The new root node name.
+   */
+  public updateRootNodeName(name: string): void {
+    if (this.nodeTreeView) {
+      this.nodeTreeView.updateRootNodeName(name);
+    }
+  }
+
+  /**
    * Registers an event listener.
    * @param eventName The name of the event to listen for.
    * @param callback The callback function to execute when the event is triggered.
@@ -473,7 +483,7 @@ export class TimelineEditor {
                     newKeyframeId,
                   );
                   // Emit event to save the new keyframe data
-                  this.emit("keyframe:saved", timeline.id, newKeyframeId); 
+                  this.emit("keyframe:saved", timeline.id, newKeyframeId);
                 }
                 return true;
               }

--- a/support-figma/dc_squoosh_designer/src/timeline/styles.css
+++ b/support-figma/dc_squoosh_designer/src/timeline/styles.css
@@ -1,16 +1,18 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 .delay-bar {
   position: absolute;
@@ -232,7 +234,7 @@
 
 /* Standard Selected */
 .keyframe.selected {
-  background-color: #2196F3;
+  background-color: #2196f3;
   border: 2px solid #fff;
   box-shadow: 0 0 0 1px #000;
   z-index: 2;
@@ -240,8 +242,8 @@
 
 /* Locked Normal */
 .keyframe.locked {
-  background-color: #9E9E9E;
-  border-color: #9E9E9E;
+  background-color: #9e9e9e;
+  border-color: #9e9e9e;
 }
 
 /* Locked Selected */
@@ -254,12 +256,12 @@
 /* Missing Normal */
 .keyframe.missing {
   background-color: #fff;
-  border: 2px solid #FF9800;
+  border: 2px solid #ff9800;
 }
 
 /* Missing Selected */
 .keyframe.missing.selected {
-  background-color: #E65100;
+  background-color: #e65100;
   border: 2px solid #fff;
   box-shadow: 0 0 0 1px #000;
 }
@@ -271,14 +273,14 @@
   top: 0;
   height: 100%;
   background-color: rgba(33, 150, 243, 0.15);
-  border: 1px solid #2196F3;
+  border: 1px solid #2196f3;
   z-index: 0;
   pointer-events: none;
 }
 
 .selection.dragging {
   background-color: rgba(33, 150, 243, 0.4);
-  border: 1px solid #2196F3;
+  border: 1px solid #2196f3;
 }
 
 .timeline-node.collapsed > .timeline,

--- a/support-figma/dc_squoosh_designer/src/timeline/types.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/types.ts
@@ -294,6 +294,7 @@ export interface TransitionSpec {
   name: string;
   spec?: VariantAnimationSpec;
   timelines?: { [key: string]: unknown };
+  customKeyframeData?: { [key: string]: string };
 }
 
 /**

--- a/support-figma/dc_squoosh_designer/src/timeline/types.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/types.ts
@@ -271,27 +271,41 @@ export interface SerializedNode {
   children?: SerializedNode[];
 }
 
+export interface VariantAnimationSpec {
+  initial_delay?: {
+    secs?: number;
+    nanos?: number;
+  };
+  animation?: {
+    Smooth?: {
+      duration: {
+        secs?: number;
+        nanos?: number;
+      };
+      easing: string;
+    };
+  };
+  interrupt_type?: string;
+}
+
+export interface TransitionSpec {
+  from: string;
+  to: string;
+  name: string;
+  spec?: VariantAnimationSpec;
+  timelines?: { [key: string]: unknown };
+}
+
 /**
  * Represents the animation data stored in a Figma variant's plugin data.
  */
 export interface VariantAnimation {
+  /** Global default animation spec fallback across all transitions. */
+  default_spec?: VariantAnimationSpec;
+  /** Array of explicit transition specifications. */
+  transitions?: TransitionSpec[];
   /** The specification for the animation, including delay, duration, and easing. */
-  spec?: {
-    initial_delay?: {
-      secs?: number;
-      nanos?: number;
-    };
-    animation?: {
-      Smooth?: {
-        duration: {
-          secs?: number;
-          nanos?: number;
-        };
-        easing: string;
-      };
-    };
-    interrupt_type?: string;
-  };
+  spec?: VariantAnimationSpec;
   /** A map of timeline IDs to serialized custom keyframe data. */
   customKeyframeData?: { [key: string]: string };
 }

--- a/support-figma/dc_squoosh_designer/src/timeline/utils.ts
+++ b/support-figma/dc_squoosh_designer/src/timeline/utils.ts
@@ -96,14 +96,18 @@ export function getAnimationSegment(
   const animSourceVariant = variants[animSourceVariantIndex];
 
   let delay = 0;
-  if (animSourceVariant?.animation?.spec?.initial_delay) {
-    const d = animSourceVariant.animation.spec.initial_delay;
+  let duration = 0;
+  const spec = resolveVariantSpec(
+    animSourceVariant?.animation,
+    animSourceVariant?.name,
+  );
+  if (spec?.initial_delay) {
+    const d = spec.initial_delay;
     delay = (d.secs || 0) + (d.nanos || 0) / 1e9;
   }
 
-  let duration = 0;
-  if (animSourceVariant?.animation?.spec?.animation?.Smooth) {
-    const d = animSourceVariant.animation.spec.animation.Smooth.duration;
+  if (spec?.animation?.Smooth) {
+    const d = spec.animation.Smooth.duration;
     duration = (d.secs || 0) + (d.nanos || 0) / 1e9;
   }
 
@@ -155,4 +159,128 @@ export function findNextKeyframe(
   }
 
   return bestKeyframe;
+}
+
+let globalActiveTransitionsMap:
+  | { [variantName: string]: number }
+  | Map<string, number>
+  | undefined = undefined;
+
+export function setGlobalActiveTransitions(
+  map?: { [variantName: string]: number } | Map<string, number>,
+): void {
+  globalActiveTransitionsMap = map;
+}
+
+export function getGlobalActiveTransitions():
+  | { [variantName: string]: number }
+  | Map<string, number>
+  | undefined {
+  return globalActiveTransitionsMap;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function resolveVariantSpec(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  anim: any,
+  variantName?: string,
+  activeTransitionsMap?:
+    | { [variantName: string]: number }
+    | Map<string, number>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+  if (!anim) return undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let spec: any = undefined;
+  const mapToUse = activeTransitionsMap || globalActiveTransitionsMap;
+
+  if (anim.transitions && anim.transitions.length > 0) {
+    let selectedIdx: number | undefined = undefined;
+    if (mapToUse && variantName) {
+      if (mapToUse instanceof Map) {
+        selectedIdx = mapToUse.get(variantName);
+      } else {
+        selectedIdx = mapToUse[variantName];
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let matchingTrans: any = undefined;
+    if (
+      typeof selectedIdx === "number" &&
+      selectedIdx >= 0 &&
+      selectedIdx < anim.transitions.length
+    ) {
+      matchingTrans = anim.transitions[selectedIdx];
+    } else {
+      matchingTrans =
+        anim.transitions.find(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (t: any) => (t.to === variantName || t.to === "*" || !t.to) && t.spec,
+        ) ||
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        anim.transitions.find((t: any) => t.spec);
+    }
+    if (matchingTrans && matchingTrans.spec) {
+      spec = matchingTrans.spec;
+    }
+  }
+
+  if (!spec && anim.spec) {
+    spec = anim.spec;
+  }
+  if (!spec && anim.default_spec) {
+    spec = anim.default_spec;
+  }
+
+  return spec;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function resolveVariantCustomKeyframeData(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  anim: any,
+  variantName?: string,
+  activeTransitionsMap?:
+    | { [variantName: string]: number }
+    | Map<string, number>,
+): { [key: string]: string } | undefined {
+  if (!anim) return undefined;
+
+  const mapToUse = activeTransitionsMap || globalActiveTransitionsMap;
+
+  if (anim.transitions && anim.transitions.length > 0) {
+    let selectedIdx: number | undefined = undefined;
+    if (mapToUse && variantName) {
+      if (mapToUse instanceof Map) {
+        selectedIdx = mapToUse.get(variantName);
+      } else {
+        selectedIdx = mapToUse[variantName];
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let matchingTrans: any = undefined;
+    if (
+      typeof selectedIdx === "number" &&
+      selectedIdx >= 0 &&
+      selectedIdx < anim.transitions.length
+    ) {
+      matchingTrans = anim.transitions[selectedIdx];
+    } else {
+      matchingTrans =
+        anim.transitions.find(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (t: any) =>
+            (t.to === variantName || t.to === "*" || !t.to) &&
+            t.customKeyframeData,
+        ) || anim.transitions[0];
+    }
+    if (matchingTrans && matchingTrans.customKeyframeData) {
+      return matchingTrans.customKeyframeData;
+    }
+  }
+
+  return anim.customKeyframeData;
 }

--- a/support-figma/dc_squoosh_designer/src/ui.html
+++ b/support-figma/dc_squoosh_designer/src/ui.html
@@ -160,8 +160,16 @@
         <h3>Animation Properties</h3>
         <p style="font-size: 0.8em; color: var(--figma-color-text-secondary); margin-top: -8px; margin-bottom: 16px;">Declares the animation settings to squoosh into this state. This means the duration and easing defined here apply to the transition *leading up to* this keyframe, not after it.</p>
         <div class="form-grid">
-            <label class="figma-label">Variant</label>
+            <label for="from-variant" class="figma-label">From State</label>
+            <select id="from-variant">
+                <option value="*">* (Any Origin)</option>
+            </select>
+
+            <label class="figma-label">To State</label>
             <span id="variant-name-display"></span>
+
+            <label for="animation-name" class="figma-label">Animation Name</label>
+            <input type="text" id="animation-name" value="Default" placeholder="Default">
 
             <label for="initial-delay" class="figma-label">Initial Delay (s)</label>
             <input type="number" id="initial-delay" step="0.1" value="0">

--- a/support-figma/dc_squoosh_designer/src/ui.html
+++ b/support-figma/dc_squoosh_designer/src/ui.html
@@ -14,234 +14,374 @@
  limitations under the License.
 -->
 
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    :root {
-      color-scheme: light dark;
-      --size-4: 8px;
-      --size-6: 16px;
-      --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      --resizer-size: 20px;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      padding: 0;
-      font-family: var(--font-family);
-      background-color: var(--figma-color-bg);
-      color: var(--figma-color-text);
-      position: relative;
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-    }
-    .resize-handle {
-      position: fixed;
-      bottom: 0;
-      right: 0;
-      width: var(--resizer-size);
-      height: var(--resizer-size);
-      cursor: se-resize;
-      z-index: 1000;
-    }
-    #timeline-container, #controls, #editor {
-      flex-shrink: 0;
-      position: relative;
-      border-bottom: 1px solid var(--figma-color-border);
-      padding: var(--size-4);
-    }
-    #controls {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 8px;
-    }
-    #controls > div {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    #controls > div button {
-      white-space: nowrap;
-    }
-    #timeline-container {
-      padding: 0;
-      overflow: hidden;
-      height: 290px;
-      display: flex;
-      flex-direction: column;
-    }
-    #timeline-resizer {
-      height: 8px;
-      cursor: ns-resize;
-      background-color: var(--figma-color-border);
-      flex-shrink: 0;
-    }
-    #timeline-resizer:hover {
-      background-color: var(--figma-color-border-strong);
-    }
-    #editor {
-      flex-grow: 1;
-      overflow-y: auto;
-    }
-    .form-grid {
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --size-4: 8px;
+        --size-6: 16px;
+        --font-family:
+          "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --resizer-size: 20px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: var(--font-family);
+        background-color: var(--figma-color-bg);
+        color: var(--figma-color-text);
+        position: relative;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      .resize-handle {
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        width: var(--resizer-size);
+        height: var(--resizer-size);
+        cursor: se-resize;
+        z-index: 1000;
+      }
+      #timeline-container,
+      #controls,
+      #editor {
+        flex-shrink: 0;
+        position: relative;
+        border-bottom: 1px solid var(--figma-color-border);
+        padding: var(--size-4);
+      }
+      #controls {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+      }
+      #controls > div {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      #controls > div button {
+        white-space: nowrap;
+      }
+      #timeline-container {
+        padding: 0;
+        overflow: hidden;
+        height: 290px;
+        display: flex;
+        flex-direction: column;
+      }
+      #timeline-resizer {
+        height: 8px;
+        cursor: ns-resize;
+        background-color: var(--figma-color-border);
+        flex-shrink: 0;
+      }
+      #timeline-resizer:hover {
+        background-color: var(--figma-color-border-strong);
+      }
+      #main-scroll-container {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      #editor {
+        flex-shrink: 0;
+        overflow: visible;
+      }
+      .form-grid {
         display: grid;
         grid-template-columns: 120px 1fr;
         gap: 8px;
         align-items: start;
-    }
-    label { font-weight: bold; }
-    .figma-label {
+      }
+      label {
+        font-weight: bold;
+      }
+      .figma-label {
         font-size: var(--figma-font-size-small);
         color: var(--figma-color-text);
         font-weight: var(--figma-font-weight-medium);
-    }
-    .figma-secondary-label {
+      }
+      .figma-secondary-label {
         font-size: var(--figma-font-size-xsmall);
         color: var(--figma-color-text-secondary);
         font-weight: var(--figma-font-weight-normal);
-    }
-    input, select {
+      }
+      input,
+      select {
         width: 100%;
         background-color: var(--figma-color-bg-secondary);
         color: var(--figma-color-text);
         border: 1px solid var(--figma-color-border);
         border-radius: 4px;
         padding: 4px;
-    }
-    .form-grid input[type="checkbox"] {
+      }
+      .form-grid input[type="checkbox"] {
         width: auto;
         justify-self: start;
-    }
-    .clickable {
-      cursor: pointer;
-      text-decoration: underline;
-      color: var(--figma-color-text-brand);
-    }
-    .clickable:hover {
-      color: var(--figma-color-text-brand-secondary);
-    }
-  </style>
-</head>
-<body>
-  <div id="controls">
+      }
+      .clickable {
+        cursor: pointer;
+        text-decoration: underline;
+        color: var(--figma-color-text-brand);
+      }
+      .clickable:hover {
+        color: var(--figma-color-text-brand-secondary);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="controls">
       <div>
         <button id="play-button">Play</button>
         <button id="ping-button">Ping Main Thread</button>
         <button id="clear-preview-button">Clear Preview</button>
         <button id="export-button">Export</button>
+        <button id="import-button">Import</button>
+        <input
+          type="file"
+          id="import-file-input"
+          accept=".json,application/json"
+          style="display: none;"
+        />
         <button id="reset-button">Reset</button>
         <button id="select-preview-frame-button">Select Preview Frame</button>
-        <input type="checkbox" id="continue-checkbox" checked>
+        <input type="checkbox" id="continue-checkbox" checked />
         <label for="continue-checkbox" class="figma-label">Continue</label>
-        <input type="checkbox" id="throttle-updates-checkbox" checked>
-        <label for="throttle-updates-checkbox" class="figma-label">Throttle</label>
-        <button id="run-tests-button" style="background-color: var(--figma-color-bg-brand); color: white;">Run Tests</button>
+        <input type="checkbox" id="throttle-updates-checkbox" checked />
+        <label for="throttle-updates-checkbox" class="figma-label"
+          >Throttle</label
+        >
+        <button
+          id="run-tests-button"
+          style="background-color: var(--figma-color-bg-brand); color: white"
+        >
+          Run Tests
+        </button>
+        <span
+          id="playhead-time-display"
+          style="
+            font-family: monospace;
+            font-size: 12px;
+            font-weight: bold;
+            margin-left: 12px;
+            background: var(--figma-color-bg-secondary);
+            padding: 4px 8px;
+            border-radius: 4px;
+            border: 1px solid var(--figma-color-border);
+            white-space: nowrap;
+            display: inline-flex;
+            align-items: center;
+          "
+          >Time: 0.00s / 0.00s</span
+        >
       </div>
       <select id="keyframe-select"></select>
-  </div>
-  <div id="test-runner-container" style="display: none; padding: var(--size-4); border-bottom: 1px solid var(--figma-color-border); max-height: 150px; overflow-y: auto; background: var(--figma-color-bg-secondary);">
-    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-      <h4 style="margin: 0;">Test Results</h4>
-      <button id="close-tests-button">Close</button>
     </div>
-    <div id="test-logs"></div>
-  </div>
-  <div id="timeline-container">
-  </div>
-  <div id="timeline-resizer"></div>
-  <div id="editor">
-    <div id="editor-content">
-      <div class="panel" id="animation-properties">
-        <h3>Animation Properties</h3>
-        <p style="font-size: 0.8em; color: var(--figma-color-text-secondary); margin-top: -8px; margin-bottom: 16px;">Declares the animation settings to squoosh into this state. This means the duration and easing defined here apply to the transition *leading up to* this keyframe, not after it.</p>
-        <div class="form-grid">
+    <div id="main-scroll-container">
+    <div
+      id="test-runner-container"
+      style="
+        display: none;
+        padding: var(--size-4);
+        border-bottom: 1px solid var(--figma-color-border);
+        max-height: 150px;
+        overflow-y: auto;
+        background: var(--figma-color-bg-secondary);
+      "
+    >
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 8px;
+        "
+      >
+        <h4 style="margin: 0">Test Results</h4>
+        <button id="close-tests-button">Close</button>
+      </div>
+      <div id="test-logs"></div>
+    </div>
+    <div id="timeline-container"></div>
+    <div id="timeline-resizer"></div>
+    <div id="editor">
+      <div id="editor-content">
+        <div class="panel" id="animation-properties">
+          <h3>Animation Properties</h3>
+          <p
+            style="
+              font-size: 0.8em;
+              color: var(--figma-color-text-secondary);
+              margin-top: -8px;
+              margin-bottom: 16px;
+            "
+          >
+            Declares the animation settings to squoosh into this state. This
+            means the duration and easing defined here apply to the transition
+            *leading up to* this keyframe, not after it.
+          </p>
+          <div class="form-grid">
+            <label for="transition-select" class="figma-label"
+              >Transition</label
+            >
+            <select id="transition-select">
+              <option value="0">Default</option>
+            </select>
+
             <label for="from-variant" class="figma-label">From State</label>
             <select id="from-variant">
-                <option value="*">* (Any Origin)</option>
+              <option value="*">* (Any Origin)</option>
             </select>
 
             <label class="figma-label">To State</label>
             <span id="variant-name-display"></span>
 
-            <label for="animation-name" class="figma-label">Animation Name</label>
-            <input type="text" id="animation-name" value="Default" placeholder="Default">
+            <label for="animation-name" class="figma-label"
+              >Animation Name</label
+            >
+            <input
+              type="text"
+              id="animation-name"
+              value="Default"
+              placeholder="Default"
+            />
 
-            <label for="initial-delay" class="figma-label">Initial Delay (s)</label>
-            <input type="number" id="initial-delay" step="0.1" value="0">
+            <label for="initial-delay" class="figma-label"
+              >Initial Delay (s)</label
+            >
+            <input type="number" id="initial-delay" step="0.1" value="0" />
 
             <label for="duration" class="figma-label">Duration (s)</label>
-            <input type="number" id="duration" step="0.1" value="0.3">
+            <input type="number" id="duration" step="0.1" value="0.3" />
 
             <!-- Hidden until other animation types are supported -->
-            <div style="display: none;">
-                <label for="repeat-type" class="figma-label">Repeat</label>
-                <select id="repeat-type">
-                    <option value="NoRepeat">No Repeat</option>
-                    <option value="LoopForever">Loop Forever</option>
-                </select>
+            <div style="display: none">
+              <label for="repeat-type" class="figma-label">Repeat</label>
+              <select id="repeat-type">
+                <option value="NoRepeat">No Repeat</option>
+                <option value="LoopForever">Loop Forever</option>
+              </select>
             </div>
 
             <label for="easing" class="figma-label">Easing</label>
             <select id="easing">
-                <option value="Linear">Linear</option>
-                <option value="EaseInOut">Ease In Out</option>
-                <option value="EaseIn">Ease In</option>
-                <option value="EaseOut">Ease Out</option>
-                <option value="EaseInCubic">Ease In Cubic</option>
-                <option value="EaseOutCubic">Ease Out Cubic</option>
-                <option value="EaseInOutCubic">Ease In Out Cubic</option>
+              <option value="Linear">Linear</option>
+              <option value="EaseInOut">Ease In Out</option>
+              <option value="EaseIn">Ease In</option>
+              <option value="EaseOut">Ease Out</option>
+              <option value="EaseInCubic">Ease In Cubic</option>
+              <option value="EaseOutCubic">Ease Out Cubic</option>
+              <option value="EaseInOutCubic">Ease In Out Cubic</option>
             </select>
 
             <label for="interrupt-type" class="figma-label">Interrupt</label>
             <select id="interrupt-type">
-                <option value="None">None</option>
-                <option value="ResetToStart">Reset To Start</option>
-                <option value="Complete">Complete</option>
-                <option value="Stop">Stop</option>
+              <option value="None">None</option>
+              <option value="ResetToStart">Reset To Start</option>
+              <option value="Complete">Complete</option>
+              <option value="Stop">Stop</option>
             </select>
+          </div>
+          <button id="save-button" style="margin-top: 16px">
+            Save Properties
+          </button>
+          <button id="discard-button" style="margin-top: 16px">
+            Discard Changes
+          </button>
+          <button id="delete-transition-button" style="margin-top: 16px; margin-left: 8px; color: #f24822;">
+            Delete Transition
+          </button>
         </div>
-        <button id="save-button" style="margin-top: 16px;">Save Properties</button>
-        <button id="discard-button" style="margin-top: 16px;">Discard Changes</button>
-      </div>
-      <div class="panel" id="keyframe-properties">
-        <h3 id="keyframe-panel-title">Keyframe Properties</h3>
-        <div id="single-keyframe-properties">
+        <div class="panel" id="keyframe-properties">
+          <h3 id="keyframe-panel-title">Keyframe Properties</h3>
+          <div id="single-keyframe-properties">
             <div class="form-grid">
               <label for="keyframe-node-name" class="figma-label">Node:</label>
               <span id="keyframe-node-name" class="clickable"></span>
               <label for="keyframe-id" class="figma-label">ID:</label>
               <span id="keyframe-id"></span>
-              <label for="keyframe-time-input" class="figma-label">Time (s)</label>
+              <label for="keyframe-time-input" class="figma-label"
+                >Time (s)</label
+              >
               <input type="number" id="keyframe-time-input" step="0.01" />
 
-              <label for="keyframe-fraction-input" class="figma-label">Fraction</label>
-              <input type="number" id="keyframe-fraction-input" step="0.001" min="0" max="1" />
-              <label for="keyframe-variant-name" class="figma-label">Variant:</label>
+              <label for="keyframe-fraction-input" class="figma-label"
+                >Fraction</label
+              >
+              <input
+                type="number"
+                id="keyframe-fraction-input"
+                step="0.001"
+                min="0"
+                max="1"
+              />
+              <label for="keyframe-variant-name" class="figma-label"
+                >Variant:</label
+              >
               <span id="keyframe-variant-name"></span>
-              <label for="keyframe-property-name" class="figma-label">Property:</label>
+              <label for="keyframe-property-name" class="figma-label"
+                >Property:</label
+              >
               <span id="keyframe-property-name"></span>
 
               <label class="figma-label">Value</label>
               <div>
                 <input type="number" id="keyframe-property-value" step="0.1" />
-                <input type="color" id="keyframe-property-color-value" style="display: none;" />
-                <div id="keyframe-property-gradient-editor" style="display: none;"></div>
-                <div id="keyframe-property-arc-editor" style="display: none;"></div>
-                <div id="keyframe-property-corner-radius-editor" style="display: none;">
-                  <div class="form-grid" style="grid-template-columns: 60px 1fr;">
+                <input
+                  type="color"
+                  id="keyframe-property-color-value"
+                  style="display: none"
+                />
+                <div
+                  id="keyframe-property-gradient-editor"
+                  style="display: none"
+                ></div>
+                <div
+                  id="keyframe-property-arc-editor"
+                  style="display: none"
+                ></div>
+                <div
+                  id="keyframe-property-corner-radius-editor"
+                  style="display: none"
+                >
+                  <div
+                    class="form-grid"
+                    style="grid-template-columns: 60px 1fr"
+                  >
                     <label for="corner-radius-top-left">TL</label>
                     <input type="number" id="corner-radius-top-left" step="1" />
                     <label for="corner-radius-top-right">TR</label>
-                    <input type="number" id="corner-radius-top-right" step="1" />
+                    <input
+                      type="number"
+                      id="corner-radius-top-right"
+                      step="1"
+                    />
                     <label for="corner-radius-bottom-right">BR</label>
-                    <input type="number" id="corner-radius-bottom-right" step="1" />
+                    <input
+                      type="number"
+                      id="corner-radius-bottom-right"
+                      step="1"
+                    />
                     <label for="corner-radius-bottom-left">BL</label>
-                    <input type="number" id="corner-radius-bottom-left" step="1" />
+                    <input
+                      type="number"
+                      id="corner-radius-bottom-left"
+                      step="1"
+                    />
                   </div>
                 </div>
               </div>
@@ -249,46 +389,64 @@
               <label class="figma-label">Locked</label>
               <input type="checkbox" id="keyframe-locked-status" disabled />
             </div>
-            <button id="remove-keyframe-button" style="margin-top: 16px;">Remove Keyframe</button>
-        </div>
-        <div id="multi-keyframes-list" style="display: none;">
+            <button id="remove-keyframe-button" style="margin-top: 16px">
+              Remove Keyframe
+            </button>
+          </div>
+          <div id="multi-keyframes-list" style="display: none">
             <!-- Keyframe list will be populated here -->
+          </div>
+          <button
+            id="remove-all-keyframes-button"
+            style="margin-top: 16px; display: none"
+          >
+            Remove All
+          </button>
         </div>
-        <button id="remove-all-keyframes-button" style="margin-top: 16px; display: none;">Remove All</button>
-      </div>
-      <div class="panel" id="animation-section-properties" style="display: none;">
-        <h3>Animation Section Properties</h3>
-        <div class="form-grid">
+        <div
+          class="panel"
+          id="animation-section-properties"
+          style="display: none"
+        >
+          <h3>Animation Section Properties</h3>
+          <div class="form-grid">
             <label class="figma-label">Type</label>
             <span id="section-type"></span>
 
             <label class="figma-label">Time</label>
-            <div><span id="section-start-time"></span> - <span id="section-end-time"></span></div>
+            <div>
+              <span id="section-start-time"></span> -
+              <span id="section-end-time"></span>
+            </div>
 
             <label class="figma-label">Duration</label>
             <span id="section-duration"></span>
 
             <label class="figma-label">Value</label>
-            <div><span id="section-start-value"></span> - <span id="section-end-value"></span></div>
+            <div>
+              <span id="section-start-value"></span> -
+              <span id="section-end-value"></span>
+            </div>
 
             <label for="section-easing" class="figma-label">Easing</label>
             <select id="section-easing">
-            <option value="Inherit">Inherit</option>
-            <option value="Linear">Linear</option>
-            <option value="Instant">Instant</option>
-            <option value="EaseIn">EaseIn</option>
-            <option value="EaseOut">EaseOut</option>
-            <option value="EaseInOut">EaseInOut</option>
-            <option value="EaseInCubic">EaseInCubic</option>
-            <option value="EaseOutCubic">EaseOutCubic</option>
-            <option value="EaseInOutCubic">EaseInOutCubic</option>
+              <option value="Inherit">Inherit</option>
+              <option value="Linear">Linear</option>
+              <option value="Instant">Instant</option>
+              <option value="EaseIn">EaseIn</option>
+              <option value="EaseOut">EaseOut</option>
+              <option value="EaseInOut">EaseInOut</option>
+              <option value="EaseInCubic">EaseInCubic</option>
+              <option value="EaseOutCubic">EaseOutCubic</option>
+              <option value="EaseInOutCubic">EaseInOutCubic</option>
             </select>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="resize-handle" id="resizeHandle" tabindex="0"></div>
+    </div>
+    <div class="resize-handle" id="resizeHandle" tabindex="0"></div>
 
-  <script src="ui.ts"></script>
-</body>
+    <script src="ui.ts"></script>
+  </body>
 </html>

--- a/support-figma/dc_squoosh_designer/src/ui.ts
+++ b/support-figma/dc_squoosh_designer/src/ui.ts
@@ -98,7 +98,7 @@ class AnimationUI {
     this.controlPanel.on("frame-changed", (index: number) => {
         if (index !== this.currentFrameIndex) {
             this.currentFrameIndex = index;
-            this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex]);
+            this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
 
             const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.currentVariants);
             const selectedKeyframe = keyframeTimes.find((kf) => kf.index === index);
@@ -145,7 +145,7 @@ class AnimationUI {
 
         if (newFrameIndex !== -1 && newFrameIndex !== this.currentFrameIndex) {
           this.currentFrameIndex = newFrameIndex;
-          this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex]);
+          this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
           this.controlPanel.setSelectedFrame(this.currentFrameIndex);
         }
       }
@@ -153,7 +153,7 @@ class AnimationUI {
 
     this.playbackController.on("keyframe-changed", (index: number) => {
       this.currentFrameIndex = index;
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex]);
+      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
       this.controlPanel.setSelectedFrame(this.currentFrameIndex);
     });
 
@@ -172,9 +172,8 @@ class AnimationUI {
 
   private handleSave(settings: AnimationSettings) {
       const existingAnimation = this.currentVariants[this.currentFrameIndex].animation || {};
-      const newAnimationData = {
-        ...existingAnimation,
-        spec: {
+      
+      const newSpec = {
           initial_delay: { secs: Math.floor(settings.initialDelay), nanos: (settings.initialDelay % 1) * 1e9 },
           animation: {
             Smooth: {
@@ -187,8 +186,38 @@ class AnimationUI {
             },
           },
           interrupt_type: settings.interruptType,
-        },
       };
+
+      const newAnimationData = { ...existingAnimation };
+      
+      if (!newAnimationData.transitions) {
+          newAnimationData.transitions = [];
+      }
+
+      const toVariantName = this.currentVariants[this.currentFrameIndex].name;
+
+      if (settings.fromVariant === "*" && settings.animationName === "Default") {
+          newAnimationData.default_spec = newSpec;
+      } else {
+          const targetTransitionIndex = newAnimationData.transitions.findIndex(
+              (t: any) => t.from === settings.fromVariant && t.name === settings.animationName && t.to === toVariantName
+          );
+
+          if (targetTransitionIndex >= 0) {
+              newAnimationData.transitions[targetTransitionIndex].spec = newSpec;
+          } else {
+              newAnimationData.transitions.push({
+                  from: settings.fromVariant,
+                  to: toVariantName,
+                  name: settings.animationName,
+                  spec: newSpec,
+                  timelines: {} 
+              });
+          }
+      }
+
+      // Preserve legacy spec temporarily to prevent older UI code from crashing
+      newAnimationData.spec = newSpec;
 
       this.currentVariants[this.currentFrameIndex].animation = newAnimationData;
 
@@ -213,11 +242,11 @@ class AnimationUI {
 
       this.timelineManager.editor.setData(newAnimationDataObject);
 
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex]); // Updates initial properties
+      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants); // Updates initial properties
   }
 
   private handleDiscard() {
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex]);
+      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
   }
 
   private handleExport() {
@@ -322,7 +351,7 @@ class AnimationUI {
           this.currentFrameIndex = startIndex;
 
           this.controlPanel.updateKeyframeSelector(variants, startIndex);
-          this.controlPanel.setVariant(variants[startIndex]);
+          this.controlPanel.setVariant(variants[startIndex], variants);
 
           const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.currentVariants);
           const selectedKeyframe = keyframeTimes.find((kf) => kf.index === startIndex);

--- a/support-figma/dc_squoosh_designer/src/ui.ts
+++ b/support-figma/dc_squoosh_designer/src/ui.ts
@@ -17,7 +17,10 @@
 import { Variant, SerializedNode } from "./timeline/types";
 import { PlaybackController } from "./timeline/PlaybackController";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { getAnimationSegment } from "./timeline/utils";
+import {
+  getAnimationSegment,
+  setGlobalActiveTransitions,
+} from "./timeline/utils";
 import { DataMapper } from "./services/DataMapper";
 import { PropertiesPanel } from "./ui/PropertiesPanel";
 import { ControlPanel, AnimationSettings } from "./ui/ControlPanel";
@@ -43,6 +46,7 @@ class AnimationUI {
   private isAnimationReady: boolean = false;
   private playAfterReady: boolean = false;
   private isSeekingFromDropdown: boolean = false;
+  private selectedTransitionsMap: { [variantName: string]: number } = {};
 
   constructor() {
     this.timelineContainer = document.getElementById("timeline-container")!;
@@ -93,6 +97,9 @@ class AnimationUI {
     this.controlPanel.on("discard", () => this.handleDiscard());
     this.controlPanel.on("delete-transition", (index: number) =>
       this.handleDeleteTransition(index),
+    );
+    this.controlPanel.on("transition-selected", (index: number) =>
+      this.handleTransitionSelected(index),
     );
     this.controlPanel.on("export", () => this.handleExport());
     this.controlPanel.on("import", (file: File) => this.handleImport(file));
@@ -200,15 +207,18 @@ class AnimationUI {
           newFrameIndex !== this.currentFrameIndex
         ) {
           this.currentFrameIndex = newFrameIndex;
+          const targetVariant = this.currentVariants[this.currentFrameIndex];
+          const savedIndex = targetVariant
+            ? (this.selectedTransitionsMap[targetVariant.name] ?? 0)
+            : 0;
           this.controlPanel.setVariant(
-            this.currentVariants[this.currentFrameIndex],
+            targetVariant,
             this.currentVariants,
+            savedIndex,
           );
           this.controlPanel.setSelectedFrame(this.currentFrameIndex);
-          if (this.currentVariants[this.currentFrameIndex]) {
-            this.timelineManager.updateRootNodeName(
-              this.currentVariants[this.currentFrameIndex].name,
-            );
+          if (targetVariant) {
+            this.timelineManager.updateRootNodeName(targetVariant.name);
           }
         }
       }
@@ -217,9 +227,14 @@ class AnimationUI {
     this.playbackController.on("keyframe-changed", (index: number) => {
       if (!this.isSeekingFromDropdown && index !== this.currentFrameIndex) {
         this.currentFrameIndex = index;
+        const targetVariant = this.currentVariants[this.currentFrameIndex];
+        const savedIndex = targetVariant
+          ? (this.selectedTransitionsMap[targetVariant.name] ?? 0)
+          : 0;
         this.controlPanel.setVariant(
-          this.currentVariants[this.currentFrameIndex],
+          targetVariant,
           this.currentVariants,
+          savedIndex,
         );
         this.controlPanel.setSelectedFrame(this.currentFrameIndex);
       }
@@ -312,9 +327,17 @@ class AnimationUI {
       "*",
     );
 
+    const savedIndex = Math.max(0, targetTransitionIndex || 0);
+    const targetVariant = this.currentVariants[this.currentFrameIndex];
+    if (targetVariant) {
+      this.selectedTransitionsMap[targetVariant.name] = savedIndex;
+    }
+    setGlobalActiveTransitions(this.selectedTransitionsMap);
+
     const newAnimationDataObject = DataMapper.transformDataToAnimationData(
       this.currentVariants,
       this.currentSerializedVariants,
+      this.selectedTransitionsMap,
     );
 
     this.playbackController.updateData({
@@ -325,7 +348,6 @@ class AnimationUI {
 
     this.timelineManager.editor.setData(newAnimationDataObject);
 
-    const savedIndex = Math.max(0, targetTransitionIndex || 0);
     this.controlPanel.setVariant(
       this.currentVariants[this.currentFrameIndex],
       this.currentVariants,
@@ -334,10 +356,14 @@ class AnimationUI {
   }
 
   private handleDiscard() {
+    const targetVariant = this.currentVariants[this.currentFrameIndex];
+    const savedIndex = targetVariant
+      ? (this.selectedTransitionsMap[targetVariant.name] ?? 0)
+      : 0;
     this.controlPanel.setVariant(
-      this.currentVariants[this.currentFrameIndex],
+      targetVariant,
       this.currentVariants,
-      this.controlPanel.getSelectedTransitionIndex(),
+      savedIndex,
     );
   }
 
@@ -367,9 +393,16 @@ class AnimationUI {
       "*",
     );
 
+    const targetVariant = this.currentVariants[this.currentFrameIndex];
+    if (targetVariant) {
+      this.selectedTransitionsMap[targetVariant.name] = 0;
+    }
+    setGlobalActiveTransitions(this.selectedTransitionsMap);
+
     const newAnimationDataObject = DataMapper.transformDataToAnimationData(
       this.currentVariants,
       this.currentSerializedVariants,
+      this.selectedTransitionsMap,
     );
 
     this.playbackController.updateData({
@@ -387,6 +420,36 @@ class AnimationUI {
     );
   }
 
+  private handleTransitionSelected(index: number) {
+    const currentVariant = this.currentVariants[this.currentFrameIndex];
+    if (currentVariant) {
+      this.selectedTransitionsMap[currentVariant.name] = Math.max(0, index);
+    }
+    setGlobalActiveTransitions(this.selectedTransitionsMap);
+
+    const newAnimationDataObject = DataMapper.transformDataToAnimationData(
+      this.currentVariants,
+      this.currentSerializedVariants,
+      this.selectedTransitionsMap,
+    );
+
+    this.playbackController.updateData({
+      animationData: newAnimationDataObject,
+      serializedVariants: this.currentSerializedVariants,
+      variants: this.currentVariants,
+    });
+
+    this.timelineManager.editor.setData(newAnimationDataObject);
+
+    if (currentVariant) {
+      this.controlPanel.setVariant(
+        currentVariant,
+        this.currentVariants,
+        Math.max(0, index),
+      );
+    }
+  }
+
   private handleExport() {
     const dataToExport = {
       variants: this.currentVariants,
@@ -394,6 +457,7 @@ class AnimationUI {
       animationData: DataMapper.transformDataToAnimationData(
         this.currentVariants,
         this.currentSerializedVariants,
+        this.selectedTransitionsMap,
       ),
     };
     const dataStr =
@@ -439,9 +503,11 @@ class AnimationUI {
           }
         });
 
+        setGlobalActiveTransitions(this.selectedTransitionsMap);
         const newAnimationData = DataMapper.transformDataToAnimationData(
           this.currentVariants,
           this.currentSerializedVariants,
+          this.selectedTransitionsMap,
         );
 
         this.playbackController.updateData({
@@ -455,18 +521,22 @@ class AnimationUI {
           this.currentVariants,
           this.currentFrameIndex,
         );
+        const targetVariant = this.currentVariants[this.currentFrameIndex];
+        const savedIndex = targetVariant
+          ? (this.selectedTransitionsMap[targetVariant.name] ?? 0)
+          : 0;
         this.controlPanel.setVariant(
-          this.currentVariants[this.currentFrameIndex],
+          targetVariant,
           this.currentVariants,
+          savedIndex,
         );
-        if (this.currentVariants[this.currentFrameIndex]) {
-          this.timelineManager.updateRootNodeName(
-            this.currentVariants[this.currentFrameIndex].name,
-          );
+        if (targetVariant) {
+          this.timelineManager.updateRootNodeName(targetVariant.name);
         }
 
         const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
           this.currentVariants,
+          this.selectedTransitionsMap,
         );
         const selectedKeyframe = keyframeTimes.find(
           (kf) => kf.index === this.currentFrameIndex,
@@ -558,9 +628,11 @@ class AnimationUI {
         this.currentVariants = variants;
         this.propertiesPanel.setCurrentVariants(variants);
 
+        setGlobalActiveTransitions(this.selectedTransitionsMap);
         const animationData = DataMapper.transformDataToAnimationData(
           variants,
           serializedVariants,
+          this.selectedTransitionsMap,
         );
         this.timelineManager.editor.setData(animationData);
         this.playbackController.updateData({
@@ -579,13 +651,18 @@ class AnimationUI {
         this.currentFrameIndex = startIndex;
 
         this.controlPanel.updateKeyframeSelector(variants, startIndex);
-        this.controlPanel.setVariant(variants[startIndex], variants);
-        if (variants[startIndex]) {
-          this.timelineManager.updateRootNodeName(variants[startIndex].name);
+        const targetVariant = variants[startIndex];
+        const savedIndex = targetVariant
+          ? (this.selectedTransitionsMap[targetVariant.name] ?? 0)
+          : 0;
+        this.controlPanel.setVariant(targetVariant, variants, savedIndex);
+        if (targetVariant) {
+          this.timelineManager.updateRootNodeName(targetVariant.name);
         }
 
         const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
           this.currentVariants,
+          this.selectedTransitionsMap,
         );
         const selectedKeyframe = keyframeTimes.find(
           (kf) => kf.index === startIndex,

--- a/support-figma/dc_squoosh_designer/src/ui.ts
+++ b/support-figma/dc_squoosh_designer/src/ui.ts
@@ -42,6 +42,7 @@ class AnimationUI {
   private currentFrameIndex: number = 0;
   private isAnimationReady: boolean = false;
   private playAfterReady: boolean = false;
+  private isSeekingFromDropdown: boolean = false;
 
   constructor() {
     this.timelineContainer = document.getElementById("timeline-container")!;
@@ -55,112 +56,178 @@ class AnimationUI {
     this.controlPanel = new ControlPanel(this.playbackController);
 
     this.timelineManager = new TimelineManager(
-        this.timelineContainer,
-        this.playbackController,
+      this.timelineContainer,
+      this.playbackController,
       null,
-        () => this.currentVariants,
-        () => this.currentSerializedVariants
+      () => this.currentVariants,
+      () => this.currentSerializedVariants,
     );
 
-    this.propertiesPanel = new PropertiesPanel(this.timelineManager.editor, this.playbackController);
+    this.propertiesPanel = new PropertiesPanel(
+      this.timelineManager.editor,
+      this.playbackController,
+    );
     this.timelineManager.setPropertiesPanel(this.propertiesPanel);
 
     this.resizeManager = new ResizeManager(
-        document.getElementById("resizeHandle")!,
-        document.getElementById("timeline-resizer")!,
-        this.timelineContainer
+      document.getElementById("resizeHandle")!,
+      document.getElementById("timeline-resizer")!,
+      this.timelineContainer,
     );
 
-    this.testRunner = new SimpleTestRunner('test-logs');
-    registerUITests(this.testRunner, this.controlPanel, this.timelineManager, this.propertiesPanel);
+    this.testRunner = new SimpleTestRunner("test-logs");
+    registerUITests(
+      this.testRunner,
+      this.controlPanel,
+      this.timelineManager,
+      this.propertiesPanel,
+    );
 
     this.setupEventListeners();
   }
   private setupEventListeners() {
     // Wiring ControlPanel events
-    this.controlPanel.on("save", (settings: AnimationSettings) => this.handleSave(settings));
+    this.controlPanel.on("save", (settings: AnimationSettings) =>
+      this.handleSave(settings),
+    );
     this.controlPanel.on("discard", () => this.handleDiscard());
+    this.controlPanel.on("delete-transition", (index: number) =>
+      this.handleDeleteTransition(index),
+    );
     this.controlPanel.on("export", () => this.handleExport());
-    this.controlPanel.on("reset", () => parent.postMessage({ pluginMessage: { type: "reset-data" } }, "*"));
+    this.controlPanel.on("import", (file: File) => this.handleImport(file));
+    this.controlPanel.on("reset", () =>
+      parent.postMessage({ pluginMessage: { type: "reset-data" } }, "*"),
+    );
     this.controlPanel.on("ping", () => {
-        parent.postMessage({ pluginMessage: { type: "ping" } }, "*");
+      parent.postMessage({ pluginMessage: { type: "ping" } }, "*");
     });
-    this.controlPanel.on("clear-preview", () => parent.postMessage({ pluginMessage: { type: "clear-preview" } }, "*"));
+    this.controlPanel.on("clear-preview", () =>
+      parent.postMessage({ pluginMessage: { type: "clear-preview" } }, "*"),
+    );
     this.controlPanel.on("select-preview", (isSelecting: boolean) => {
-        if (isSelecting) {
-             parent.postMessage({ pluginMessage: { type: "select-preview-frame" } }, "*");
-        } else {
-             this.controlPanel.setSelectingPreview(true);
-             parent.postMessage({ pluginMessage: { type: "select-preview-frame" } }, "*");
-        }
+      if (isSelecting) {
+        parent.postMessage(
+          { pluginMessage: { type: "select-preview-frame" } },
+          "*",
+        );
+      } else {
+        this.controlPanel.setSelectingPreview(true);
+        parent.postMessage(
+          { pluginMessage: { type: "select-preview-frame" } },
+          "*",
+        );
+      }
     });
 
     this.controlPanel.on("frame-changed", (index: number) => {
-        if (index !== this.currentFrameIndex) {
-            this.currentFrameIndex = index;
-            this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
-
-            const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.currentVariants);
-            const selectedKeyframe = keyframeTimes.find((kf) => kf.index === index);
-            if (selectedKeyframe && totalTime > 0) {
-                this.playbackController.seek(selectedKeyframe.time);
-            }
-            this.updateFigmaPreview();
+      if (index !== this.currentFrameIndex) {
+        this.currentFrameIndex = index;
+        this.controlPanel.setVariant(
+          this.currentVariants[this.currentFrameIndex],
+          this.currentVariants,
+        );
+        if (this.currentVariants[this.currentFrameIndex]) {
+          this.timelineManager.updateRootNodeName(
+            this.currentVariants[this.currentFrameIndex].name,
+          );
         }
+
+        const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
+          this.currentVariants,
+        );
+        const selectedKeyframe = keyframeTimes.find((kf) => kf.index === index);
+        if (selectedKeyframe && totalTime > 0) {
+          this.isSeekingFromDropdown = true;
+          this.playbackController.seek(selectedKeyframe.time);
+          this.isSeekingFromDropdown = false;
+        }
+        this.updateFigmaPreview();
+      }
     });
 
     // Test Runner Events
-    const runTestsButton = document.getElementById('run-tests-button');
-    const closeTestsButton = document.getElementById('close-tests-button');
-    const testContainer = document.getElementById('test-runner-container');
+    const runTestsButton = document.getElementById("run-tests-button");
+    const closeTestsButton = document.getElementById("close-tests-button");
+    const testContainer = document.getElementById("test-runner-container");
 
     if (runTestsButton && testContainer && closeTestsButton) {
-        runTestsButton.onclick = () => {
-            testContainer.style.display = 'block';
-            this.testRunner.run();
-        };
-        closeTestsButton.onclick = () => {
-            testContainer.style.display = 'none';
-        };
+      runTestsButton.onclick = () => {
+        testContainer.style.display = "block";
+        this.testRunner.run();
+      };
+      closeTestsButton.onclick = () => {
+        testContainer.style.display = "none";
+      };
     }
 
     // Playback Controller Events
     this.playbackController.on("timeupdate", (time: number) => {
-      const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.currentVariants);
+      const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
+        this.currentVariants,
+      );
       if (totalTime > 0) {
         this.timelineManager.editor.setPlayheadPosition(time / totalTime);
 
         let newFrameIndex = -1;
-        const exactKeyframe = keyframeTimes.find((kt) => Math.abs(kt.time - time) < 0.0001);
+        const exactKeyframe = keyframeTimes.find(
+          (kt) => Math.abs(kt.time - time) < 0.001,
+        );
         if (exactKeyframe) {
-            newFrameIndex = exactKeyframe.index;
+          newFrameIndex = exactKeyframe.index;
         } else {
-            const segment = getAnimationSegment(time / totalTime, keyframeTimes, totalTime, this.currentVariants);
-            if (segment) {
-                newFrameIndex = keyframeTimes[segment.endIndex].index;
-            } else if (time >= totalTime && keyframeTimes.length > 0) {
-                newFrameIndex = keyframeTimes[0].index;
-            }
+          const segment = getAnimationSegment(
+            time / totalTime,
+            keyframeTimes,
+            totalTime,
+            this.currentVariants,
+          );
+          if (segment) {
+            newFrameIndex = keyframeTimes[segment.endIndex].index;
+          } else if (time >= totalTime && keyframeTimes.length > 0) {
+            newFrameIndex = keyframeTimes[0].index;
+          }
         }
 
-        if (newFrameIndex !== -1 && newFrameIndex !== this.currentFrameIndex) {
+        const timeDisplay = document.getElementById("playhead-time-display");
+        if (timeDisplay) {
+          timeDisplay.textContent = `Time: ${time.toFixed(2)}s / ${totalTime.toFixed(2)}s`;
+        }
+
+        if (
+          !this.isSeekingFromDropdown &&
+          newFrameIndex !== -1 &&
+          newFrameIndex !== this.currentFrameIndex
+        ) {
           this.currentFrameIndex = newFrameIndex;
-          this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
+          this.controlPanel.setVariant(
+            this.currentVariants[this.currentFrameIndex],
+            this.currentVariants,
+          );
           this.controlPanel.setSelectedFrame(this.currentFrameIndex);
+          if (this.currentVariants[this.currentFrameIndex]) {
+            this.timelineManager.updateRootNodeName(
+              this.currentVariants[this.currentFrameIndex].name,
+            );
+          }
         }
       }
     });
 
     this.playbackController.on("keyframe-changed", (index: number) => {
-      this.currentFrameIndex = index;
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
-      this.controlPanel.setSelectedFrame(this.currentFrameIndex);
+      if (!this.isSeekingFromDropdown && index !== this.currentFrameIndex) {
+        this.currentFrameIndex = index;
+        this.controlPanel.setVariant(
+          this.currentVariants[this.currentFrameIndex],
+          this.currentVariants,
+        );
+        this.controlPanel.setSelectedFrame(this.currentFrameIndex);
+      }
     });
 
     // Global Events
     window.addEventListener("mouseup", () => {
-
-        document.body.classList.remove("no-select");
+      document.body.classList.remove("no-select");
     });
 
     window.addEventListener("load", () =>
@@ -171,220 +238,396 @@ class AnimationUI {
   }
 
   private handleSave(settings: AnimationSettings) {
-      const existingAnimation = this.currentVariants[this.currentFrameIndex].animation || {};
-      
-      const newSpec = {
-          initial_delay: { secs: Math.floor(settings.initialDelay), nanos: (settings.initialDelay % 1) * 1e9 },
-          animation: {
-            Smooth: {
-              duration: {
-                secs: Math.floor(settings.duration),
-                nanos: (settings.duration % 1) * 1e9,
-              },
-              repeat_type: "NoRepeat",
-              easing: settings.easing,
-            },
+    const existingAnimation =
+      this.currentVariants[this.currentFrameIndex].animation || {};
+
+    const newSpec = {
+      initial_delay: {
+        secs: Math.floor(settings.initialDelay),
+        nanos: Math.round((settings.initialDelay % 1) * 1e9),
+      },
+      animation: {
+        Smooth: {
+          duration: {
+            secs: Math.floor(settings.duration),
+            nanos: Math.round((settings.duration % 1) * 1e9),
           },
-          interrupt_type: settings.interruptType,
-      };
+          repeat_type: "NoRepeat",
+          easing: settings.easing,
+        },
+      },
+      interrupt_type: settings.interruptType,
+    };
 
-      const newAnimationData = { ...existingAnimation };
-      
-      if (!newAnimationData.transitions) {
-          newAnimationData.transitions = [];
-      }
+    const newAnimationData = { ...existingAnimation };
 
-      const toVariantName = this.currentVariants[this.currentFrameIndex].name;
+    if (!newAnimationData.transitions) {
+      newAnimationData.transitions = [];
+    }
 
-      if (settings.fromVariant === "*" && settings.animationName === "Default") {
-          newAnimationData.default_spec = newSpec;
-      } else {
-          const targetTransitionIndex = newAnimationData.transitions.findIndex(
-              (t: any) => t.from === settings.fromVariant && t.name === settings.animationName && t.to === toVariantName
-          );
+    const toVariantName = this.currentVariants[this.currentFrameIndex].name;
 
-          if (targetTransitionIndex >= 0) {
-              newAnimationData.transitions[targetTransitionIndex].spec = newSpec;
-          } else {
-              newAnimationData.transitions.push({
-                  from: settings.fromVariant,
-                  to: toVariantName,
-                  name: settings.animationName,
-                  spec: newSpec,
-                  timelines: {} 
-              });
-          }
-      }
-
-      // Preserve legacy spec temporarily to prevent older UI code from crashing
-      newAnimationData.spec = newSpec;
-
-      this.currentVariants[this.currentFrameIndex].animation = newAnimationData;
-
-      parent.postMessage({
-          pluginMessage: {
-            type: "save-data",
-            frameName: this.currentVariants[this.currentFrameIndex].name,
-            data: JSON.stringify(newAnimationData),
-          },
-      }, "*");
-
-      const newAnimationDataObject = DataMapper.transformDataToAnimationData(
-        this.currentVariants,
-        this.currentSerializedVariants,
+    if (
+      settings.fromVariant === "*" &&
+      settings.animationName === "Default" &&
+      (toVariantName === "*" || !toVariantName)
+    ) {
+      newAnimationData.default_spec = newSpec;
+    } else {
+      let targetTransitionIndex = newAnimationData.transitions.findIndex(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (t: any) =>
+          t.from === settings.fromVariant &&
+          t.name === settings.animationName &&
+          (t.to === toVariantName || (!t.to && !toVariantName)),
       );
 
-      this.playbackController.updateData({
-        animationData: newAnimationDataObject,
-        serializedVariants: this.currentSerializedVariants,
-        variants: this.currentVariants,
-      });
+      if (targetTransitionIndex >= 0) {
+        newAnimationData.transitions[targetTransitionIndex].spec = newSpec;
+      } else {
+        newAnimationData.transitions.push({
+          from: settings.fromVariant,
+          to: toVariantName,
+          name: settings.animationName,
+          spec: newSpec,
+          timelines: {},
+        });
+        targetTransitionIndex = newAnimationData.transitions.length - 1;
+      }
+    }
 
-      this.timelineManager.editor.setData(newAnimationDataObject);
+    // Preserve legacy spec temporarily to prevent older UI code from crashing
+    newAnimationData.spec = newSpec;
 
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants); // Updates initial properties
+    this.currentVariants[this.currentFrameIndex].animation = newAnimationData;
+
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "save-data",
+          frameName: this.currentVariants[this.currentFrameIndex].name,
+          data: JSON.stringify(newAnimationData),
+        },
+      },
+      "*",
+    );
+
+    const newAnimationDataObject = DataMapper.transformDataToAnimationData(
+      this.currentVariants,
+      this.currentSerializedVariants,
+    );
+
+    this.playbackController.updateData({
+      animationData: newAnimationDataObject,
+      serializedVariants: this.currentSerializedVariants,
+      variants: this.currentVariants,
+    });
+
+    this.timelineManager.editor.setData(newAnimationDataObject);
+
+    const savedIndex = Math.max(0, targetTransitionIndex || 0);
+    this.controlPanel.setVariant(
+      this.currentVariants[this.currentFrameIndex],
+      this.currentVariants,
+      savedIndex,
+    );
   }
 
   private handleDiscard() {
-      this.controlPanel.setVariant(this.currentVariants[this.currentFrameIndex], this.currentVariants);
+    this.controlPanel.setVariant(
+      this.currentVariants[this.currentFrameIndex],
+      this.currentVariants,
+      this.controlPanel.getSelectedTransitionIndex(),
+    );
+  }
+
+  private handleDeleteTransition(index: number) {
+    const existingAnimation =
+      this.currentVariants[this.currentFrameIndex].animation || {};
+
+    if (
+      existingAnimation.transitions &&
+      index >= 0 &&
+      index < existingAnimation.transitions.length &&
+      existingAnimation.transitions.length > 1
+    ) {
+      existingAnimation.transitions.splice(index, 1);
+    }
+
+    this.currentVariants[this.currentFrameIndex].animation = existingAnimation;
+
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "save-data",
+          frameName: this.currentVariants[this.currentFrameIndex].name,
+          data: JSON.stringify(existingAnimation),
+        },
+      },
+      "*",
+    );
+
+    const newAnimationDataObject = DataMapper.transformDataToAnimationData(
+      this.currentVariants,
+      this.currentSerializedVariants,
+    );
+
+    this.playbackController.updateData({
+      animationData: newAnimationDataObject,
+      serializedVariants: this.currentSerializedVariants,
+      variants: this.currentVariants,
+    });
+
+    this.timelineManager.editor.setData(newAnimationDataObject);
+
+    this.controlPanel.setVariant(
+      this.currentVariants[this.currentFrameIndex],
+      this.currentVariants,
+      0,
+    );
   }
 
   private handleExport() {
-      console.info("Exporting DCF Animation Matrix with variants: ", this.currentVariants.map(v => v.name).join(", "));
-      const dataToExport = {
-        variants: this.currentVariants,
-        serializedVariants: this.currentSerializedVariants,
-        animationData: DataMapper.transformDataToAnimationData(
+    const dataToExport = {
+      variants: this.currentVariants,
+      serializedVariants: this.currentSerializedVariants,
+      animationData: DataMapper.transformDataToAnimationData(
+        this.currentVariants,
+        this.currentSerializedVariants,
+      ),
+    };
+    const dataStr =
+      "data:text/json;charset=utf-8," +
+      encodeURIComponent(JSON.stringify(dataToExport, null, 2));
+    const downloadAnchorNode = document.createElement("a");
+    downloadAnchorNode.setAttribute("href", dataStr);
+    downloadAnchorNode.setAttribute("download", "animation_data.json");
+    document.body.appendChild(downloadAnchorNode);
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  }
+
+  private handleImport(file: File) {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string;
+        if (!content) return;
+        const imported = JSON.parse(content);
+        if (!imported.variants || !Array.isArray(imported.variants)) {
+          alert("Invalid animation_data.json file: missing variants array.");
+          return;
+        }
+
+        imported.variants.forEach((importedVariant: Variant) => {
+          const targetVariant = this.currentVariants.find(
+            (v) => v.name === importedVariant.name,
+          );
+          if (targetVariant && importedVariant.animation) {
+            targetVariant.animation = importedVariant.animation;
+
+            parent.postMessage(
+              {
+                pluginMessage: {
+                  type: "save-data",
+                  frameName: targetVariant.name,
+                  data: JSON.stringify(importedVariant.animation),
+                },
+              },
+              "*",
+            );
+          }
+        });
+
+        const newAnimationData = DataMapper.transformDataToAnimationData(
           this.currentVariants,
           this.currentSerializedVariants,
-        ),
-      };
-      const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(dataToExport, null, 2));
-      const downloadAnchorNode = document.createElement("a");
-      downloadAnchorNode.setAttribute("href", dataStr);
-      downloadAnchorNode.setAttribute("download", "animation_data.json");
-      document.body.appendChild(downloadAnchorNode);
-      downloadAnchorNode.click();
-      downloadAnchorNode.remove();
+        );
+
+        this.playbackController.updateData({
+          animationData: newAnimationData,
+          serializedVariants: this.currentSerializedVariants,
+          variants: this.currentVariants,
+        });
+
+        this.timelineManager.editor.setData(newAnimationData);
+        this.controlPanel.updateKeyframeSelector(
+          this.currentVariants,
+          this.currentFrameIndex,
+        );
+        this.controlPanel.setVariant(
+          this.currentVariants[this.currentFrameIndex],
+          this.currentVariants,
+        );
+        if (this.currentVariants[this.currentFrameIndex]) {
+          this.timelineManager.updateRootNodeName(
+            this.currentVariants[this.currentFrameIndex].name,
+          );
+        }
+
+        const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
+          this.currentVariants,
+        );
+        const selectedKeyframe = keyframeTimes.find(
+          (kf) => kf.index === this.currentFrameIndex,
+        );
+        if (selectedKeyframe && totalTime > 0) {
+          this.isSeekingFromDropdown = true;
+          this.playbackController.seek(selectedKeyframe.time);
+          this.isSeekingFromDropdown = false;
+        }
+
+        alert("Successfully imported and saved animation data to Figma!");
+      } catch (err) {
+        console.error("Error importing file:", err);
+        alert("Failed to parse imported JSON file.");
+      }
+    };
+    reader.readAsText(file);
   }
 
   private updateFigmaPreview() {
-        const animatedNodes: SerializedNode[] = [];
-        const variantNode = this.currentSerializedVariants[this.currentFrameIndex];
-        DataMapper.collectNodesForPreview(variantNode, null, true, animatedNodes);
-        parent.postMessage({
-            pluginMessage: {
-              type: "update-figma-preview",
-              animatedNodes: animatedNodes,
-            },
-        }, "*");
+    const animatedNodes: SerializedNode[] = [];
+    const variantNode = this.currentSerializedVariants[this.currentFrameIndex];
+    DataMapper.collectNodesForPreview(variantNode, null, true, animatedNodes);
+    parent.postMessage(
+      {
+        pluginMessage: {
+          type: "update-figma-preview",
+          animatedNodes: animatedNodes,
+        },
+      },
+      "*",
+    );
   }
 
   private handleMessage(event: MessageEvent) {
-      const pluginMessage = event.data.pluginMessage;
-      if (!pluginMessage) return;
+    const pluginMessage = event.data.pluginMessage;
+    if (!pluginMessage) return;
 
-      switch (pluginMessage.type) {
-        case "animation-ready": {
-          this.isAnimationReady = true;
-          this.updateFigmaPreview(); // Ensure properties and metadata are synced
-          if (this.playAfterReady) {
-            this.playAfterReady = false;
-            this.playbackController.play();
-          }
-          break;
+    switch (pluginMessage.type) {
+      case "animation-ready": {
+        this.isAnimationReady = true;
+        this.updateFigmaPreview(); // Ensure properties and metadata are synced
+        if (this.playAfterReady) {
+          this.playAfterReady = false;
+          this.playbackController.play();
         }
-        case "pong": {
-          break;
-        }
-        case "selection-mode-started": {
-          this.controlPanel.setSelectingPreview(true);
-          break;
-        }
-        case "selection-mode-ended": {
-          this.controlPanel.setSelectingPreview(false);
-          break;
-        }
-        case "preview-frame-selected": {
-          this.controlPanel.setSelectingPreview(false, pluginMessage.name);
-          break;
-        }
-        case "preview-frame-cleared": {
-          this.controlPanel.setSelectingPreview(false);
-          break;
-        }
-        case "clear-timeline": {
-          this.currentSerializedVariants = [];
-          this.currentVariants = [];
-          this.currentFrameIndex = 0;
-          // Do not destroy/recreate the editor, just clear its data to preserve references
-          this.timelineManager.editor.setData({ nodes: [], duration: 1 });
-          break;
-        }
-        case "clear": {
-          document.getElementById("editor")!.style.display = "none";
-          this.currentSerializedVariants = [];
-          this.currentVariants = [];
-          this.currentFrameIndex = 0;
-          break;
-        }
-        case "update": {
-          this.isAnimationReady = false;
-          document.getElementById("editor")!.style.display = "block";
-          const { variants, serializedVariants, selectedVariantName } = pluginMessage;
-          this.currentSerializedVariants = serializedVariants;
-          this.currentVariants = variants;
-          this.propertiesPanel.setCurrentVariants(variants);
-
-          const animationData = DataMapper.transformDataToAnimationData(variants, serializedVariants);
-          this.timelineManager.editor.setData(animationData);
-          this.playbackController.updateData({
-            animationData: animationData,
-            serializedVariants: this.currentSerializedVariants,
-            variants: this.currentVariants,
-          });
-
-          let startIndex = 0;
-          if (selectedVariantName) {
-            const index = variants.findIndex((v: Variant) => v.name === selectedVariantName);
-            if (index !== -1) startIndex = index;
-          }
-          this.currentFrameIndex = startIndex;
-
-          this.controlPanel.updateKeyframeSelector(variants, startIndex);
-          this.controlPanel.setVariant(variants[startIndex], variants);
-
-          const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(this.currentVariants);
-          const selectedKeyframe = keyframeTimes.find((kf) => kf.index === startIndex);
-          if (selectedKeyframe && totalTime > 0) {
-            this.playbackController.seek(selectedKeyframe.time);
-          }
-
-          parent.postMessage({ pluginMessage: { type: "prepare-animation" } }, "*");
-          break;
-        }
-        case "preview-node-changed": {
-          const { originalNodeId, nodeProps } = pluginMessage;
-          compareAndPrintChanges(
-            originalNodeId,
-            nodeProps,
-            this.currentSerializedVariants,
-            this.currentFrameIndex,
-            this.timelineManager,
-            this.playbackController
-          );
-          break;
-        }
-        case "preview-node-selected": {
-           break;
-        }
-        case "preview-update-complete": {
-           this.playbackController.acknowledgePreviewUpdate();
-           break;
-        }
+        break;
       }
-  }
+      case "pong": {
+        break;
+      }
+      case "selection-mode-started": {
+        this.controlPanel.setSelectingPreview(true);
+        break;
+      }
+      case "selection-mode-ended": {
+        this.controlPanel.setSelectingPreview(false);
+        break;
+      }
+      case "preview-frame-selected": {
+        this.controlPanel.setSelectingPreview(false, pluginMessage.name);
+        break;
+      }
+      case "preview-frame-cleared": {
+        this.controlPanel.setSelectingPreview(false);
+        break;
+      }
+      case "clear-timeline": {
+        this.currentSerializedVariants = [];
+        this.currentVariants = [];
+        this.currentFrameIndex = 0;
+        // Do not destroy/recreate the editor, just clear its data to preserve references
+        this.timelineManager.editor.setData({ nodes: [], duration: 1 });
+        break;
+      }
+      case "clear": {
+        document.getElementById("editor")!.style.display = "none";
+        this.currentSerializedVariants = [];
+        this.currentVariants = [];
+        this.currentFrameIndex = 0;
+        break;
+      }
+      case "update": {
+        this.isAnimationReady = false;
+        document.getElementById("editor")!.style.display = "block";
+        const { variants, serializedVariants, selectedVariantName } =
+          pluginMessage;
+        this.currentSerializedVariants = serializedVariants;
+        this.currentVariants = variants;
+        this.propertiesPanel.setCurrentVariants(variants);
 
+        const animationData = DataMapper.transformDataToAnimationData(
+          variants,
+          serializedVariants,
+        );
+        this.timelineManager.editor.setData(animationData);
+        this.playbackController.updateData({
+          animationData: animationData,
+          serializedVariants: this.currentSerializedVariants,
+          variants: this.currentVariants,
+        });
+
+        let startIndex = 0;
+        if (selectedVariantName) {
+          const index = variants.findIndex(
+            (v: Variant) => v.name === selectedVariantName,
+          );
+          if (index !== -1) startIndex = index;
+        }
+        this.currentFrameIndex = startIndex;
+
+        this.controlPanel.updateKeyframeSelector(variants, startIndex);
+        this.controlPanel.setVariant(variants[startIndex], variants);
+        if (variants[startIndex]) {
+          this.timelineManager.updateRootNodeName(variants[startIndex].name);
+        }
+
+        const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
+          this.currentVariants,
+        );
+        const selectedKeyframe = keyframeTimes.find(
+          (kf) => kf.index === startIndex,
+        );
+        if (selectedKeyframe && totalTime > 0) {
+          this.isSeekingFromDropdown = true;
+          this.playbackController.seek(selectedKeyframe.time);
+          this.isSeekingFromDropdown = false;
+        }
+        const timeDisplay = document.getElementById("playhead-time-display");
+        if (timeDisplay) {
+          const initialTime = selectedKeyframe ? selectedKeyframe.time : 0;
+          timeDisplay.textContent = `Time: ${initialTime.toFixed(2)}s / ${totalTime.toFixed(2)}s`;
+        }
+
+        parent.postMessage(
+          { pluginMessage: { type: "prepare-animation" } },
+          "*",
+        );
+        break;
+      }
+      case "preview-node-changed": {
+        const { originalNodeId, nodeProps } = pluginMessage;
+        compareAndPrintChanges(
+          originalNodeId,
+          nodeProps,
+          this.currentSerializedVariants,
+          this.currentFrameIndex,
+          this.timelineManager,
+          this.playbackController,
+        );
+        break;
+      }
+      case "preview-node-selected": {
+        break;
+      }
+      case "preview-update-complete": {
+        this.playbackController.acknowledgePreviewUpdate();
+        break;
+      }
+    }
+  }
 }
 
 new AnimationUI();

--- a/support-figma/dc_squoosh_designer/src/ui.ts
+++ b/support-figma/dc_squoosh_designer/src/ui.ts
@@ -250,6 +250,7 @@ class AnimationUI {
   }
 
   private handleExport() {
+      console.info("Exporting DCF Animation Matrix with variants: ", this.currentVariants.map(v => v.name).join(", "));
       const dataToExport = {
         variants: this.currentVariants,
         serializedVariants: this.currentSerializedVariants,

--- a/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
+++ b/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
@@ -23,6 +23,8 @@ import { DataMapper } from "../services/DataMapper";
  * Settings for the animation configuration.
  */
 export interface AnimationSettings {
+  fromVariant: string;
+  animationName: string;
   initialDelay: number;
   duration: number;
   easing: string;
@@ -45,6 +47,8 @@ export class ControlPanel extends EventEmitter {
   private resetButton: HTMLButtonElement;
   private selectPreviewFrameButton: HTMLButtonElement;
   private keyframeSelect: HTMLSelectElement;
+  private fromVariantSelect: HTMLSelectElement;
+  private animationNameInput: HTMLInputElement;
   private initialDelayInput: HTMLInputElement;
   private durationInput: HTMLInputElement;
   private easingSelect: HTMLSelectElement;
@@ -54,6 +58,8 @@ export class ControlPanel extends EventEmitter {
   private variantNameDisplay: HTMLElement;
 
   private initialSettings: AnimationSettings = {
+    fromVariant: "*",
+    animationName: "Default",
     initialDelay: 0,
     duration: 0.3,
     easing: "Linear",
@@ -73,6 +79,8 @@ export class ControlPanel extends EventEmitter {
     this.resetButton = document.getElementById("reset-button") as HTMLButtonElement;
     this.selectPreviewFrameButton = document.getElementById("select-preview-frame-button") as HTMLButtonElement;
     this.keyframeSelect = document.getElementById("keyframe-select") as HTMLSelectElement;
+    this.fromVariantSelect = document.getElementById("from-variant") as HTMLSelectElement;
+    this.animationNameInput = document.getElementById("animation-name") as HTMLInputElement;
     this.initialDelayInput = document.getElementById("initial-delay") as HTMLInputElement;
     this.durationInput = document.getElementById("duration") as HTMLInputElement;
     this.easingSelect = document.getElementById("easing") as HTMLSelectElement;
@@ -123,6 +131,8 @@ export class ControlPanel extends EventEmitter {
     });
 
     const checkChange = () => this.checkPropertiesChanged();
+    this.fromVariantSelect.addEventListener("change", checkChange);
+    this.animationNameInput.addEventListener("input", checkChange);
     this.initialDelayInput.addEventListener("input", checkChange);
     this.durationInput.addEventListener("input", checkChange);
     this.easingSelect.addEventListener("change", checkChange);
@@ -154,11 +164,21 @@ export class ControlPanel extends EventEmitter {
    * Disables save/discard buttons initially.
    * @param variant The variant to display settings for.
    */
-  public setVariant(variant: Variant | undefined) {
+  public setVariant(variant: Variant | undefined, allVariants: Variant[] = []) {
     this.variantNameDisplay.textContent = variant ? variant.name : "N/A";
 
+    this.fromVariantSelect.innerHTML = '<option value="*">* (Any Origin)</option>';
+    allVariants.forEach(v => {
+        if (v.name !== (variant ? variant.name : "")) {
+            const option = document.createElement("option");
+            option.value = v.name;
+            option.textContent = v.name;
+            this.fromVariantSelect.appendChild(option);
+        }
+    });
+
     if (!variant || !variant.animation || !variant.animation.spec) {
-      this.initialSettings = { initialDelay: 0, duration: 0.3, easing: "Linear", interruptType: "None" };
+      this.initialSettings = { fromVariant: "*", animationName: "Default", initialDelay: 0, duration: 0.3, easing: "Linear", interruptType: "None" };
       this.updateInputs(this.initialSettings);
       this.saveButton.disabled = true;
       this.discardButton.disabled = true;
@@ -178,8 +198,14 @@ export class ControlPanel extends EventEmitter {
     }
     
     const interruptType = spec.interrupt_type || "None";
+    
+    // Default matrix schema values for now until we parse full matrix
+    let fromVariant = "*";
+    let animationName = "Default";
 
     this.initialSettings = {
+      fromVariant: fromVariant,
+      animationName: animationName,
       initialDelay: delay,
       duration: duration,
       easing: easing,
@@ -196,6 +222,8 @@ export class ControlPanel extends EventEmitter {
    * @param settings The animation settings to display.
    */
   public updateInputs(settings: AnimationSettings) {
+    this.fromVariantSelect.value = settings.fromVariant;
+    this.animationNameInput.value = settings.animationName;
     this.initialDelayInput.value = settings.initialDelay.toFixed(2);
     this.durationInput.value = settings.duration.toFixed(2);
     this.easingSelect.value = settings.easing;
@@ -208,6 +236,8 @@ export class ControlPanel extends EventEmitter {
    */
   public getCurrentSettings(): AnimationSettings {
     return {
+      fromVariant: this.fromVariantSelect.value,
+      animationName: this.animationNameInput.value,
       initialDelay: parseFloat(this.initialDelayInput.value),
       duration: parseFloat(this.durationInput.value),
       easing: this.easingSelect.value,
@@ -223,6 +253,8 @@ export class ControlPanel extends EventEmitter {
     const initial = this.initialSettings;
 
     const changed = 
+        current.fromVariant !== initial.fromVariant ||
+        current.animationName !== initial.animationName ||
         Math.abs(current.initialDelay - initial.initialDelay) > 0.0001 ||
         Math.abs(current.duration - initial.duration) > 0.0001 ||
         current.easing !== initial.easing ||

--- a/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
+++ b/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
@@ -200,8 +200,8 @@ export class ControlPanel extends EventEmitter {
     const interruptType = spec.interrupt_type || "None";
     
     // Default matrix schema values for now until we parse full matrix
-    let fromVariant = "*";
-    let animationName = "Default";
+    const fromVariant = "*";
+    const animationName = "Default";
 
     this.initialSettings = {
       fromVariant: fromVariant,

--- a/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
+++ b/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
@@ -441,6 +441,7 @@ export class ControlPanel extends EventEmitter {
       const idx = parseInt(this.transitionSelect.value, 10);
       this.selectedTransitionIndex = idx;
       this.loadTransitionAtIndex(idx);
+      this.emit("transition-selected", idx);
     }
   }
 

--- a/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
+++ b/support-figma/dc_squoosh_designer/src/ui/ControlPanel.ts
@@ -44,6 +44,8 @@ export class ControlPanel extends EventEmitter {
   private pingButton: HTMLButtonElement;
   private clearPreviewButton: HTMLButtonElement;
   private exportButton: HTMLButtonElement;
+  private importButton: HTMLButtonElement;
+  private importFileInput: HTMLInputElement;
   private resetButton: HTMLButtonElement;
   private selectPreviewFrameButton: HTMLButtonElement;
   private keyframeSelect: HTMLSelectElement;
@@ -55,6 +57,11 @@ export class ControlPanel extends EventEmitter {
   private interruptTypeSelect: HTMLSelectElement;
   private continueCheckbox: HTMLInputElement;
   private throttleUpdatesCheckbox: HTMLInputElement;
+  private transitionSelect?: HTMLSelectElement;
+  private deleteTransitionButton?: HTMLButtonElement;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private currentTransitions: any[] = [];
+  private selectedTransitionIndex: number = 0;
   private variantNameDisplay: HTMLElement;
 
   private initialSettings: AnimationSettings = {
@@ -70,31 +77,80 @@ export class ControlPanel extends EventEmitter {
     super();
     this.playbackController = playbackController;
 
-    this.playButton = document.getElementById("play-button") as HTMLButtonElement;
-    this.saveButton = document.getElementById("save-button") as HTMLButtonElement;
-    this.discardButton = document.getElementById("discard-button") as HTMLButtonElement;
-    this.pingButton = document.getElementById("ping-button") as HTMLButtonElement;
-    this.clearPreviewButton = document.getElementById("clear-preview-button") as HTMLButtonElement;
-    this.exportButton = document.getElementById("export-button") as HTMLButtonElement;
-    this.resetButton = document.getElementById("reset-button") as HTMLButtonElement;
-    this.selectPreviewFrameButton = document.getElementById("select-preview-frame-button") as HTMLButtonElement;
-    this.keyframeSelect = document.getElementById("keyframe-select") as HTMLSelectElement;
-    this.fromVariantSelect = document.getElementById("from-variant") as HTMLSelectElement;
-    this.animationNameInput = document.getElementById("animation-name") as HTMLInputElement;
-    this.initialDelayInput = document.getElementById("initial-delay") as HTMLInputElement;
-    this.durationInput = document.getElementById("duration") as HTMLInputElement;
+    this.playButton = document.getElementById(
+      "play-button",
+    ) as HTMLButtonElement;
+    this.saveButton = document.getElementById(
+      "save-button",
+    ) as HTMLButtonElement;
+    this.discardButton = document.getElementById(
+      "discard-button",
+    ) as HTMLButtonElement;
+    this.pingButton = document.getElementById(
+      "ping-button",
+    ) as HTMLButtonElement;
+    this.clearPreviewButton = document.getElementById(
+      "clear-preview-button",
+    ) as HTMLButtonElement;
+    this.exportButton = document.getElementById(
+      "export-button",
+    ) as HTMLButtonElement;
+    this.importButton = document.getElementById(
+      "import-button",
+    ) as HTMLButtonElement;
+    this.importFileInput = document.getElementById(
+      "import-file-input",
+    ) as HTMLInputElement;
+    this.resetButton = document.getElementById(
+      "reset-button",
+    ) as HTMLButtonElement;
+    this.selectPreviewFrameButton = document.getElementById(
+      "select-preview-frame-button",
+    ) as HTMLButtonElement;
+    this.keyframeSelect = document.getElementById(
+      "keyframe-select",
+    ) as HTMLSelectElement;
+    this.fromVariantSelect = document.getElementById(
+      "from-variant",
+    ) as HTMLSelectElement;
+    this.animationNameInput = document.getElementById(
+      "animation-name",
+    ) as HTMLInputElement;
+    this.initialDelayInput = document.getElementById(
+      "initial-delay",
+    ) as HTMLInputElement;
+    this.durationInput = document.getElementById(
+      "duration",
+    ) as HTMLInputElement;
     this.easingSelect = document.getElementById("easing") as HTMLSelectElement;
-    this.interruptTypeSelect = document.getElementById("interrupt-type") as HTMLSelectElement;
-    this.continueCheckbox = document.getElementById("continue-checkbox") as HTMLInputElement;
-    this.throttleUpdatesCheckbox = document.getElementById("throttle-updates-checkbox") as HTMLInputElement;
-    this.variantNameDisplay = document.getElementById("variant-name-display") as HTMLElement;
+    this.interruptTypeSelect = document.getElementById(
+      "interrupt-type",
+    ) as HTMLSelectElement;
+    this.continueCheckbox = document.getElementById(
+      "continue-checkbox",
+    ) as HTMLInputElement;
+    this.throttleUpdatesCheckbox = document.getElementById(
+      "throttle-updates-checkbox",
+    ) as HTMLInputElement;
+    this.variantNameDisplay = document.getElementById(
+      "variant-name-display",
+    ) as HTMLElement;
+    this.transitionSelect =
+      (document.getElementById("transition-select") as HTMLSelectElement) ||
+      undefined;
+    this.deleteTransitionButton =
+      (document.getElementById(
+        "delete-transition-button",
+      ) as HTMLButtonElement) || undefined;
 
     this.setupEventListeners();
     this.setupPlaybackListeners();
 
     // Initialize controller state
     this.playbackController.setContinue(this.continueCheckbox.checked);
-    this.playbackController.setThrottleUpdates(this.throttleUpdatesCheckbox.checked);
+    this.playbackController.setThrottleUpdates(
+      this.throttleUpdatesCheckbox.checked,
+    );
   }
 
   private setupEventListeners() {
@@ -106,24 +162,69 @@ export class ControlPanel extends EventEmitter {
       }
     };
 
+    window.addEventListener("keydown", (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.code === "Space" || e.key === " ") {
+        e.preventDefault();
+        if (this.playbackController.isPlaying) {
+          this.playbackController.pause();
+        } else {
+          this.playbackController.play();
+        }
+      }
+    });
+
     this.continueCheckbox.onchange = () => {
       this.playbackController.setContinue(this.continueCheckbox.checked);
     };
 
     this.throttleUpdatesCheckbox.onchange = () => {
-      this.playbackController.setThrottleUpdates(this.throttleUpdatesCheckbox.checked);
+      this.playbackController.setThrottleUpdates(
+        this.throttleUpdatesCheckbox.checked,
+      );
     };
 
-    this.saveButton.onclick = () => this.emit("save", this.getCurrentSettings());
+    this.saveButton.onclick = () =>
+      this.emit("save", this.getCurrentSettings());
     this.discardButton.onclick = () => this.emit("discard");
+    if (this.deleteTransitionButton) {
+      this.deleteTransitionButton.onclick = () =>
+        this.emit("delete-transition", this.selectedTransitionIndex);
+    }
     this.exportButton.onclick = () => this.emit("export");
+    this.importButton.onclick = () => {
+      this.importFileInput.click();
+    };
+    this.importFileInput.onchange = () => {
+      const files = this.importFileInput.files;
+      if (files && files[0]) {
+        this.emit("import", files[0]);
+        this.importFileInput.value = "";
+      }
+    };
     this.resetButton.onclick = () => this.emit("reset");
     this.pingButton.onclick = () => this.emit("ping");
     this.clearPreviewButton.onclick = () => this.emit("clear-preview");
-    
+
+    if (this.transitionSelect) {
+      this.transitionSelect.addEventListener("change", () =>
+        this.handleTransitionSelectChange(),
+      );
+    }
+
     this.selectPreviewFrameButton.onclick = () => {
-       const isSelecting = this.selectPreviewFrameButton.classList.contains("selecting");
-       this.emit("select-preview", isSelecting);
+      const isSelecting =
+        this.selectPreviewFrameButton.classList.contains("selecting");
+      this.emit("select-preview", isSelecting);
     };
 
     this.keyframeSelect.addEventListener("change", () => {
@@ -164,44 +265,141 @@ export class ControlPanel extends EventEmitter {
    * Disables save/discard buttons initially.
    * @param variant The variant to display settings for.
    */
-  public setVariant(variant: Variant | undefined, allVariants: Variant[] = []) {
+  public setVariant(
+    variant: Variant | undefined,
+    allVariants: Variant[] = [],
+    selectedTransitionIndex: number | string = 0,
+  ) {
     this.variantNameDisplay.textContent = variant ? variant.name : "N/A";
 
-    this.fromVariantSelect.innerHTML = '<option value="*">* (Any Origin)</option>';
-    allVariants.forEach(v => {
-        if (v.name !== (variant ? variant.name : "")) {
-            const option = document.createElement("option");
-            option.value = v.name;
-            option.textContent = v.name;
-            this.fromVariantSelect.appendChild(option);
-        }
+    this.fromVariantSelect.innerHTML =
+      '<option value="*">* (Any Origin)</option>';
+    allVariants.forEach((v) => {
+      if (v.name !== (variant ? variant.name : "")) {
+        const option = document.createElement("option");
+        option.value = v.name;
+        option.textContent = v.name;
+        this.fromVariantSelect.appendChild(option);
+      }
     });
 
-    if (!variant || !variant.animation || !variant.animation.spec) {
-      this.initialSettings = { fromVariant: "*", animationName: "Default", initialDelay: 0, duration: 0.3, easing: "Linear", interruptType: "None" };
+    if (
+      !variant ||
+      !variant.animation ||
+      (!variant.animation.spec &&
+        !variant.animation.default_spec &&
+        (!variant.animation.transitions ||
+          variant.animation.transitions.length === 0))
+    ) {
+      this.currentTransitions = [];
+      if (this.transitionSelect) {
+        this.transitionSelect.innerHTML = "";
+      }
+      if (this.deleteTransitionButton) {
+        this.deleteTransitionButton.disabled = true;
+      }
+      this.initialSettings = {
+        fromVariant: "*",
+        animationName: "Default",
+        initialDelay: 0,
+        duration: 0.3,
+        easing: "Linear",
+        interruptType: "None",
+      };
       this.updateInputs(this.initialSettings);
       this.saveButton.disabled = true;
       this.discardButton.disabled = true;
       return;
     }
 
-    const spec = variant.animation.spec;
-    const delay = (spec.initial_delay?.secs || 0) + (spec.initial_delay?.nanos || 0) / 1e9;
-    
+    if (
+      variant.animation.transitions &&
+      variant.animation.transitions.length > 0
+    ) {
+      this.currentTransitions = variant.animation.transitions;
+    } else {
+      this.currentTransitions = [
+        {
+          from: "*",
+          to: variant.name,
+          name: "Default",
+          spec: variant.animation.spec || variant.animation.default_spec,
+          timelines: {},
+        },
+      ];
+    }
+
+    const transitionSelect = this.transitionSelect;
+    if (transitionSelect) {
+      transitionSelect.innerHTML = "";
+      this.currentTransitions.forEach((t, idx) => {
+        const option = document.createElement("option");
+        option.value = String(idx);
+        const fromStr = t.from || "*";
+        const nameStr = t.name || "Default";
+        option.textContent = `${fromStr} → ${variant.name} : ${nameStr}`;
+        transitionSelect.appendChild(option);
+      });
+      const newOption = document.createElement("option");
+      newOption.value = "NEW";
+      newOption.textContent = "+ Create New Transition...";
+      transitionSelect.appendChild(newOption);
+
+      let targetIdx = 0;
+      if (typeof selectedTransitionIndex === "number") {
+        if (
+          selectedTransitionIndex >= 0 &&
+          selectedTransitionIndex < this.currentTransitions.length
+        ) {
+          targetIdx = selectedTransitionIndex;
+        }
+        this.selectedTransitionIndex = targetIdx;
+        transitionSelect.value = String(targetIdx);
+        this.loadTransitionAtIndex(targetIdx);
+      } else if (selectedTransitionIndex === "NEW") {
+        transitionSelect.value = "NEW";
+        this.handleTransitionSelectChange();
+      }
+    } else {
+      this.loadTransitionAtIndex(
+        typeof selectedTransitionIndex === "number" &&
+          selectedTransitionIndex >= 0 &&
+          selectedTransitionIndex < this.currentTransitions.length
+          ? selectedTransitionIndex
+          : 0,
+      );
+    }
+  }
+
+  private loadTransitionAtIndex(idx: number) {
+    const matchingTrans = this.currentTransitions[idx];
+    let fromVariant = "*";
+    let animationName = "Default";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let specToUse: any = undefined;
+
+    if (matchingTrans) {
+      fromVariant = matchingTrans.from || "*";
+      animationName = matchingTrans.name || "Default";
+      specToUse = matchingTrans.spec;
+    }
+
+    let delay = 0;
     let duration = 0;
     let easing = "Linear";
-    
-    if (spec.animation && spec.animation.Smooth) {
-        const d = spec.animation.Smooth.duration;
+    let interruptType = "None";
+
+    if (specToUse) {
+      delay =
+        (specToUse.initial_delay?.secs || 0) +
+        (specToUse.initial_delay?.nanos || 0) / 1e9;
+      if (specToUse.animation && specToUse.animation.Smooth) {
+        const d = specToUse.animation.Smooth.duration;
         duration = (d.secs || 0) + (d.nanos || 0) / 1e9;
-        easing = spec.animation.Smooth.easing;
+        easing = specToUse.animation.Smooth.easing;
+      }
+      interruptType = specToUse.interrupt_type || "None";
     }
-    
-    const interruptType = spec.interrupt_type || "None";
-    
-    // Default matrix schema values for now until we parse full matrix
-    const fromVariant = "*";
-    const animationName = "Default";
 
     this.initialSettings = {
       fromVariant: fromVariant,
@@ -209,12 +407,45 @@ export class ControlPanel extends EventEmitter {
       initialDelay: delay,
       duration: duration,
       easing: easing,
-      interruptType: interruptType
+      interruptType: interruptType,
     };
 
     this.updateInputs(this.initialSettings);
     this.saveButton.disabled = true;
     this.discardButton.disabled = true;
+    if (this.deleteTransitionButton) {
+      this.deleteTransitionButton.disabled =
+        this.currentTransitions.length <= 1;
+    }
+  }
+
+  private handleTransitionSelectChange() {
+    if (!this.transitionSelect) return;
+    if (this.transitionSelect.value === "NEW") {
+      this.selectedTransitionIndex = -1;
+      this.initialSettings = {
+        fromVariant: "*",
+        animationName: "NewTransition",
+        initialDelay: 0,
+        duration: 0.3,
+        easing: "Linear",
+        interruptType: "None",
+      };
+      this.updateInputs(this.initialSettings);
+      this.saveButton.disabled = false;
+      this.discardButton.disabled = false;
+      if (this.deleteTransitionButton) {
+        this.deleteTransitionButton.disabled = true;
+      }
+    } else {
+      const idx = parseInt(this.transitionSelect.value, 10);
+      this.selectedTransitionIndex = idx;
+      this.loadTransitionAtIndex(idx);
+    }
+  }
+
+  public getSelectedTransitionIndex(): number {
+    return this.selectedTransitionIndex;
   }
 
   /**
@@ -241,7 +472,7 @@ export class ControlPanel extends EventEmitter {
       initialDelay: parseFloat(this.initialDelayInput.value),
       duration: parseFloat(this.durationInput.value),
       easing: this.easingSelect.value,
-      interruptType: this.interruptTypeSelect.value
+      interruptType: this.interruptTypeSelect.value,
     };
   }
 
@@ -252,13 +483,13 @@ export class ControlPanel extends EventEmitter {
     const current = this.getCurrentSettings();
     const initial = this.initialSettings;
 
-    const changed = 
-        current.fromVariant !== initial.fromVariant ||
-        current.animationName !== initial.animationName ||
-        Math.abs(current.initialDelay - initial.initialDelay) > 0.0001 ||
-        Math.abs(current.duration - initial.duration) > 0.0001 ||
-        current.easing !== initial.easing ||
-        current.interruptType !== initial.interruptType;
+    const changed =
+      current.fromVariant !== initial.fromVariant ||
+      current.animationName !== initial.animationName ||
+      Math.abs(current.initialDelay - initial.initialDelay) > 0.0001 ||
+      Math.abs(current.duration - initial.duration) > 0.0001 ||
+      current.easing !== initial.easing ||
+      current.interruptType !== initial.interruptType;
 
     this.saveButton.disabled = !changed;
     this.discardButton.disabled = !changed;
@@ -288,26 +519,26 @@ export class ControlPanel extends EventEmitter {
    * @param name Optional name of the selected preview frame to display.
    */
   public setSelectingPreview(isSelecting: boolean, name?: string) {
-      if (isSelecting) {
-          this.selectPreviewFrameButton.classList.add("selecting");
-          this.selectPreviewFrameButton.textContent = "Selecting Preview Frame...";
+    if (isSelecting) {
+      this.selectPreviewFrameButton.classList.add("selecting");
+      this.selectPreviewFrameButton.textContent = "Selecting Preview Frame...";
+    } else {
+      this.selectPreviewFrameButton.classList.remove("selecting");
+      if (name) {
+        this.selectPreviewFrameButton.textContent = `Preview: ${name}`;
       } else {
-          this.selectPreviewFrameButton.classList.remove("selecting");
-          if (name) {
-            this.selectPreviewFrameButton.textContent = `Preview: ${name}`;
-          } else {
-             this.selectPreviewFrameButton.textContent = "Select Preview Frame";
-          }
+        this.selectPreviewFrameButton.textContent = "Select Preview Frame";
       }
+    }
   }
-  
+
   /**
    * Sets the state of the 'Continue' (loop) checkbox.
    * @param checked Whether playback should continue looping.
    */
   public setContinue(checked: boolean) {
-      this.continueCheckbox.checked = checked;
-      this.playbackController.setContinue(checked);
+    this.continueCheckbox.checked = checked;
+    this.playbackController.setContinue(checked);
   }
 
   /**
@@ -315,6 +546,6 @@ export class ControlPanel extends EventEmitter {
    * @param index The index of the frame to select.
    */
   public setSelectedFrame(index: number) {
-      this.keyframeSelect.value = String(index);
+    this.keyframeSelect.value = String(index);
   }
 }

--- a/support-figma/dc_squoosh_designer/src/ui/TimelineManager.ts
+++ b/support-figma/dc_squoosh_designer/src/ui/TimelineManager.ts
@@ -19,7 +19,15 @@ import { TimelineEditor } from "../timeline/TimelineEditor";
 import { PlaybackController } from "../timeline/PlaybackController";
 import { PropertiesPanel } from "./PropertiesPanel";
 import { DataMapper } from "../services/DataMapper";
-import { Keyframe, Node, Timeline, KeyframeTime, Variant, SerializedNode, AnimationNode } from "../timeline/types";
+import {
+  Keyframe,
+  Node,
+  Timeline,
+  KeyframeTime,
+  Variant,
+  SerializedNode,
+  AnimationNode,
+} from "../timeline/types";
 
 /**
  * Manages the interaction between the timeline editor, playback controller, and properties panel.
@@ -37,7 +45,7 @@ export class TimelineManager {
     playbackController: PlaybackController,
     propertiesPanel: PropertiesPanel | null,
     getCurrentVariants: () => Variant[],
-    getCurrentSerializedVariants: () => SerializedNode[]
+    getCurrentSerializedVariants: () => SerializedNode[],
   ) {
     this.playbackController = playbackController;
     this.propertiesPanel = propertiesPanel;
@@ -53,50 +61,72 @@ export class TimelineManager {
    * @param propertiesPanel The properties panel to use.
    */
   public setPropertiesPanel(propertiesPanel: PropertiesPanel) {
-      this.propertiesPanel = propertiesPanel;
+    this.propertiesPanel = propertiesPanel;
   }
-  
-    private getValueFromVariant(variantIndex: number, nodeId: string, propertyName: string): any {
-      const serializedVariants = this.getCurrentSerializedVariants();
-      const variantRoot = serializedVariants[variantIndex];
-      if (!variantRoot) return undefined;
-      
-      const nodesMap = new Map<string, AnimationNode>();
-      // We need to cast SerializedNode to AnimationNode structure for DataMapper
-      // This is safe because the structures are compatible for what collectAnimationNodes needs
-      DataMapper.collectAnimationNodes(variantRoot as unknown as AnimationNode, null, true, nodesMap);
-      
-      // DataMapper uses the node name as the ID in the map
-      // The nodeId passed here is from the Node structure, which is the node name (or __ROOT__)
-      const targetNode = nodesMap.get(nodeId);
-      
-      if (!targetNode) return undefined;
-      
-      return DataMapper.getNodePropertyValue(targetNode, propertyName);
-    }
-    
-    private isNodeMissingInVariant(variantIndex: number, nodeId: string): boolean {
-      const serializedVariants = this.getCurrentSerializedVariants();
-      const variantRoot = serializedVariants[variantIndex];
-      if (!variantRoot) return true;
-      
-      if (nodeId === "__ROOT__") return false; // Root always exists
-  
-      const findNode = (root: SerializedNode, id: string): boolean => {
-          if (root.name === id) return true; // Match by Name
-          if (root.children) {
-              for (const child of root.children) {
-                  if (findNode(child, id)) return true;
-              }
-          }
-          return false;
-      };
-      
-      return !findNode(variantRoot, nodeId);
-    }
+
+  /**
+   * Updates the displayed name of the root node in the tree.
+   * @param name The new root node name.
+   */
+  public updateRootNodeName(name: string) {
+    this.editor.updateRootNodeName(name);
+  }
+
+  private getValueFromVariant(
+    variantIndex: number,
+    nodeId: string,
+    propertyName: string,
+  ): any {
+    const serializedVariants = this.getCurrentSerializedVariants();
+    const variantRoot = serializedVariants[variantIndex];
+    if (!variantRoot) return undefined;
+
+    const nodesMap = new Map<string, AnimationNode>();
+    // We need to cast SerializedNode to AnimationNode structure for DataMapper
+    // This is safe because the structures are compatible for what collectAnimationNodes needs
+    DataMapper.collectAnimationNodes(
+      variantRoot as unknown as AnimationNode,
+      null,
+      true,
+      nodesMap,
+    );
+
+    // DataMapper uses the node name as the ID in the map
+    // The nodeId passed here is from the Node structure, which is the node name (or __ROOT__)
+    const targetNode = nodesMap.get(nodeId);
+
+    if (!targetNode) return undefined;
+
+    return DataMapper.getNodePropertyValue(targetNode, propertyName);
+  }
+
+  private isNodeMissingInVariant(
+    variantIndex: number,
+    nodeId: string,
+  ): boolean {
+    const serializedVariants = this.getCurrentSerializedVariants();
+    const variantRoot = serializedVariants[variantIndex];
+    if (!variantRoot) return true;
+
+    if (nodeId === "__ROOT__") return false; // Root always exists
+
+    const findNode = (root: SerializedNode, id: string): boolean => {
+      if (root.name === id) return true; // Match by Name
+      if (root.children) {
+        for (const child of root.children) {
+          if (findNode(child, id)) return true;
+        }
+      }
+      return false;
+    };
+
+    return !findNode(variantRoot, nodeId);
+  }
   private setupEventListeners() {
     this.editor.on("playhead:set", (position: number) => {
-      const { totalTime } = DataMapper.calculateKeyframeData(this.getCurrentVariants());
+      const { totalTime } = DataMapper.calculateKeyframeData(
+        this.getCurrentVariants(),
+      );
       const time = position * totalTime;
       this.playbackController.seek(time);
     });
@@ -155,7 +185,10 @@ export class TimelineManager {
         if (findResult) {
           findResult.keyframe.position = finalPosition;
           this.editor.setData(data);
-          this.propertiesPanel?.saveCustomKeyframeData(findResult.timeline.id, keyframeId);
+          this.propertiesPanel?.saveCustomKeyframeData(
+            findResult.timeline.id,
+            keyframeId,
+          );
         }
       },
     );
@@ -167,126 +200,131 @@ export class TimelineManager {
     this.editor.on(
       "section:selected",
       (timelineId: string, start: number, end: number) => {
-        this.propertiesPanel?.updateAnimationSectionProperties(timelineId, start, end);
+        this.propertiesPanel?.updateAnimationSectionProperties(
+          timelineId,
+          start,
+          end,
+        );
       },
     );
 
-    this.editor.on(
-      "timeline:rename",
-      (timelineId: string, newName: string) => {
-        const data = this.editor.getData();
-        if (!data) return;
+    this.editor.on("timeline:rename", (timelineId: string, newName: string) => {
+      const data = this.editor.getData();
+      if (!data) return;
 
-        let parentNode: Node | null = null;
-        const find = (nodes: Node[]): Timeline | null => {
-          for (const node of nodes) {
-            const timeline = node.timelines.find((t) => t.id === timelineId);
-            if (timeline) {
-              parentNode = node;
-              return timeline;
-            }
-            if (node.children && node.children.length > 0) {
-              const found = find(node.children);
-              if (found) return found;
-            }
+      let parentNode: Node | null = null;
+      const find = (nodes: Node[]): Timeline | null => {
+        for (const node of nodes) {
+          const timeline = node.timelines.find((t) => t.id === timelineId);
+          if (timeline) {
+            parentNode = node;
+            return timeline;
           }
-          return null;
-        };
-        const timeline = find(data.nodes);
-
-        if (timeline && parentNode) {
-          if (
-            (parentNode as Node).timelines.some(
-              (t) => t.property === newName && t.id !== timelineId,
-            )
-          ) {
-            alert(`Property "${newName}" already exists on this node.`);
-            (parentNode as Node).timelines = (parentNode as Node).timelines.filter(
-              (t) => t.id !== timelineId,
-            );
-            this.editor.setData(data);
-            return;
+          if (node.children && node.children.length > 0) {
+            const found = find(node.children);
+            if (found) return found;
           }
-
-          timeline.property = newName;
-          timeline.id = `${(parentNode as Node).id}-${newName}`;
-
-          // Clear existing dummy keyframes and populate with actual data from variants
-          timeline.keyframes = [];
-          this.populateNewTimeline(timeline, parentNode as Node, newName);
-          
-          // If no data found (e.g. invalid property name), restore dummy keyframes
-          if (timeline.keyframes.length === 0) {
-              timeline.keyframes = [
-                  {
-                    id: `kf-${Date.now()}-1`,
-                    position: 0,
-                    value: 0,
-                    locked: false,
-                    easing: "Linear",
-                  },
-                  {
-                    id: `kf-${Date.now()}-2`,
-                    position: 1,
-                    value: 0,
-                    locked: false,
-                    easing: "Linear",
-                  },
-              ];
-          } else {
-              timeline.keyframes.sort((a, b) => a.position - b.position);
-          }
-
-          this.editor.setData(data);
         }
-      },
-    );
+        return null;
+      };
+      const timeline = find(data.nodes);
+
+      if (timeline && parentNode) {
+        if (
+          (parentNode as Node).timelines.some(
+            (t) => t.property === newName && t.id !== timelineId,
+          )
+        ) {
+          alert(`Property "${newName}" already exists on this node.`);
+          (parentNode as Node).timelines = (
+            parentNode as Node
+          ).timelines.filter((t) => t.id !== timelineId);
+          this.editor.setData(data);
+          return;
+        }
+
+        timeline.property = newName;
+        timeline.id = `${(parentNode as Node).id}-${newName}`;
+
+        // Clear existing dummy keyframes and populate with actual data from variants
+        timeline.keyframes = [];
+        this.populateNewTimeline(timeline, parentNode as Node, newName);
+
+        // If no data found (e.g. invalid property name), restore dummy keyframes
+        if (timeline.keyframes.length === 0) {
+          timeline.keyframes = [
+            {
+              id: `kf-${Date.now()}-1`,
+              position: 0,
+              value: 0,
+              locked: false,
+              easing: "Linear",
+            },
+            {
+              id: `kf-${Date.now()}-2`,
+              position: 1,
+              value: 0,
+              locked: false,
+              easing: "Linear",
+            },
+          ];
+        } else {
+          timeline.keyframes.sort((a, b) => a.position - b.position);
+        }
+
+        this.editor.setData(data);
+      }
+    });
 
     this.editor.on(
       "keyframe:saved",
       (timelineId: string, keyframeId: string) => {
-         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-         this.propertiesPanel?.saveCustomKeyframeData(timelineId, keyframeId);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.propertiesPanel?.saveCustomKeyframeData(timelineId, keyframeId);
       },
     );
 
     this.editor.on(
       "keyframe:save-on-remove",
       (timelineId: string, keyframePosition: number) => {
-         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-         this.propertiesPanel?.saveCustomKeyframeData(timelineId, undefined, keyframePosition);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.propertiesPanel?.saveCustomKeyframeData(
+          timelineId,
+          undefined,
+          keyframePosition,
+        );
       },
     );
 
-    this.editor.on(
-      "timeline:delete",
-      (timelineId: string) => {
-          const data = this.editor.getData();
-          if (!data) return;
-          
-          const remove = (nodes: Node[]): boolean => {
-              for (const node of nodes) {
-                  const index = node.timelines.findIndex((t) => t.id === timelineId);
-                  if (index !== -1) {
-                      node.timelines.splice(index, 1);
-                      return true;
-                  }
-                  if (node.children && remove(node.children)) return true;
-              }
-              return false;
-          };
-          
-          if (remove(data.nodes)) {
-              this.editor.setData(data);
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (this.propertiesPanel as any)?.deleteCustomTimeline(timelineId);
+    this.editor.on("timeline:delete", (timelineId: string) => {
+      const data = this.editor.getData();
+      if (!data) return;
+
+      const remove = (nodes: Node[]): boolean => {
+        for (const node of nodes) {
+          const index = node.timelines.findIndex((t) => t.id === timelineId);
+          if (index !== -1) {
+            node.timelines.splice(index, 1);
+            return true;
           }
-      },
-    );
+          if (node.children && remove(node.children)) return true;
+        }
+        return false;
+      };
 
+      if (remove(data.nodes)) {
+        this.editor.setData(data);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.propertiesPanel as any)?.deleteCustomTimeline(timelineId);
+      }
+    });
   }
 
-  private populateNewTimeline(timeline: Timeline, parentNode: Node, newName: string) {
+  private populateNewTimeline(
+    timeline: Timeline,
+    parentNode: Node,
+    newName: string,
+  ) {
     const { keyframeTimes, totalTime } = DataMapper.calculateKeyframeData(
       this.getCurrentVariants(),
     );
@@ -295,31 +333,31 @@ export class TimelineManager {
 
     // Helper to find next valid value for a property
     const findNextValidValue = (startIndex: number, prop: string): any => {
-        for (let i = startIndex; i < variants.length; i++) {
-             const val = this.getValueFromVariant(i, parentNode.id, prop);
-             if (val !== undefined) return val;
-        }
-        return 0; // Default if no future value found
+      for (let i = startIndex; i < variants.length; i++) {
+        const val = this.getValueFromVariant(i, parentNode.id, prop);
+        if (val !== undefined) return val;
+      }
+      return 0; // Default if no future value found
     };
 
     keyframeTimes.forEach((kt: KeyframeTime) => {
       // Removed: if (kt.isLoop) return;
       let value = this.getValueFromVariant(kt.index, parentNode.id, newName);
       let isMissing = false;
-      
+
       const nodeMissing = this.isNodeMissingInVariant(kt.index, parentNode.id);
 
       if (nodeMissing) {
-          isMissing = true;
-          // Look ahead for next valid value
-          if (newName === 'opacity') {
-              value = 0;
-          } else {
-              value = findNextValidValue(kt.index + 1, newName);
-          }
+        isMissing = true;
+        // Look ahead for next valid value
+        if (newName === "opacity") {
+          value = 0;
+        } else {
+          value = findNextValidValue(kt.index + 1, newName);
+        }
       } else if (value === undefined) {
-          // Node present, but property missing. Skip.
-          return;
+        // Node present, but property missing. Skip.
+        return;
       }
 
       if (value !== undefined || isMissing) {
@@ -334,8 +372,8 @@ export class TimelineManager {
 
         // Side effect: If node is missing (implied by isMissing=true for property 'x' etc?), ensure opacity is 0.
         // BUT only if we are NOT currently populating 'opacity' (to avoid recursion loops or redundant work).
-        if (isMissing && newName !== 'opacity') {
-             this.ensureOpacityTimeline(parentNode, kt.time / totalTime, variants);
+        if (isMissing && newName !== "opacity") {
+          this.ensureOpacityTimeline(parentNode, kt.time / totalTime, variants);
         }
       }
     });
@@ -346,42 +384,44 @@ export class TimelineManager {
   }
 
   private ensureOpacityTimeline(node: Node, position: number, variants: any[]) {
-      let opacityTimeline = node.timelines.find(t => t.property === 'opacity');
-      if (!opacityTimeline) {
-          // Create it
-          opacityTimeline = {
-              id: `${node.id}-opacity`,
-              property: 'opacity',
-              keyframes: [],
-              isCustom: false // It's auto-generated/system
-          };
-          node.timelines.push(opacityTimeline);
-          
-          // Populate it fully first?
-          // If we create it, we should populate it with variant data first.
-          this.populateNewTimeline(opacityTimeline, node, 'opacity');
+    let opacityTimeline = node.timelines.find((t) => t.property === "opacity");
+    if (!opacityTimeline) {
+      // Create it
+      opacityTimeline = {
+        id: `${node.id}-opacity`,
+        property: "opacity",
+        keyframes: [],
+        isCustom: false, // It's auto-generated/system
+      };
+      node.timelines.push(opacityTimeline);
+
+      // Populate it fully first?
+      // If we create it, we should populate it with variant data first.
+      this.populateNewTimeline(opacityTimeline, node, "opacity");
+    }
+
+    // Now ensure the specific keyframe at 'position' is set to 0 and marked missing
+    // populateNewTimeline('opacity') should have already handled this if logic is correct!
+    // In populateNewTimeline('opacity'):
+    // If value is undefined -> isMissing=true, value=0.
+    // So we just need to call populateNewTimeline if we created it.
+    // If it already existed, it should already have the correct data?
+    // Maybe not if it was created before this 'missing' logic was implemented?
+    // But we assume consistent state.
+
+    // However, explicitly forcing 0 at this missing point is safe.
+    const existingKf = opacityTimeline.keyframes.find(
+      (kf) => Math.abs(kf.position - position) < 0.0001,
+    );
+    if (existingKf) {
+      if (existingKf.value !== 0) {
+        // If it exists but isn't 0 (maybe interpolated?), force it?
+        // If the node is missing, opacity MUST be 0.
+        // But populateNewTimeline logic says: if undefined, value=0.
+        // So it should be 0.
       }
-      
-      // Now ensure the specific keyframe at 'position' is set to 0 and marked missing
-      // populateNewTimeline('opacity') should have already handled this if logic is correct!
-      // In populateNewTimeline('opacity'):
-      // If value is undefined -> isMissing=true, value=0.
-      // So we just need to call populateNewTimeline if we created it.
-      // If it already existed, it should already have the correct data?
-      // Maybe not if it was created before this 'missing' logic was implemented?
-      // But we assume consistent state.
-      
-      // However, explicitly forcing 0 at this missing point is safe.
-      const existingKf = opacityTimeline.keyframes.find(kf => Math.abs(kf.position - position) < 0.0001);
-      if (existingKf) {
-          if (existingKf.value !== 0) {
-              // If it exists but isn't 0 (maybe interpolated?), force it?
-              // If the node is missing, opacity MUST be 0.
-              // But populateNewTimeline logic says: if undefined, value=0.
-              // So it should be 0.
-          }
-      } else {
-           // Should have been added by populateNewTimeline.
-      }
+    } else {
+      // Should have been added by populateNewTimeline.
+    }
   }
 }

--- a/support-figma/dc_squoosh_designer/test/services/DataMapper.test.ts
+++ b/support-figma/dc_squoosh_designer/test/services/DataMapper.test.ts
@@ -14,46 +14,46 @@
  * limitations under the License.
  */
 
-import { DataMapper } from '../../src/services/DataMapper';
-import { Variant } from '../../src/timeline/types';
+import { DataMapper } from "../../src/services/DataMapper";
+import { Variant } from "../../src/timeline/types";
 
-describe('DataMapper', () => {
-  describe('calculateKeyframeData', () => {
-    it('should calculate keyframe times correctly for multiple variants with delays and durations', () => {
+describe("DataMapper", () => {
+  describe("calculateKeyframeData", () => {
+    it("should calculate keyframe times correctly for multiple variants with delays and durations", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const variants: Variant[] = [
         {
-          name: 'State 1',
+          name: "State 1",
           animation: {
             spec: {
               initial_delay: { secs: 1, nanos: 0 }, // 1s
               animation: {
                 Smooth: {
                   duration: { secs: 2, nanos: 0 }, // 2s
-                  easing: 'Linear'
-                }
-              }
-            }
-          } as any
+                  easing: "Linear",
+                },
+              },
+            },
+          } as any,
         },
         {
-          name: 'State 2',
+          name: "State 2",
           animation: {
             spec: {
               initial_delay: { secs: 0, nanos: 500000000 }, // 0.5s
               animation: {
                 Smooth: {
                   duration: { secs: 1, nanos: 0 }, // 1s
-                  easing: 'EaseIn'
-                }
-              }
-            }
-          } as any
+                  easing: "EaseIn",
+                },
+              },
+            },
+          } as any,
         },
         {
-          name: 'State 3',
-          animation: null
-        }
+          name: "State 3",
+          animation: null,
+        },
       ];
 
       const result = DataMapper.calculateKeyframeData(variants);
@@ -61,28 +61,40 @@ describe('DataMapper', () => {
       // Loop 1: Index 0 -> 1. Delay 1s, Duration 2s. Time increases by 3.
       // Loop 2: Index 1 -> 2. Delay 0.5s, Duration 1s. Time increases by 1.5.
       // Total time should be 4.5.
-      
+
       expect(result.keyframeTimes).toHaveLength(4); // 3 variants + loop back
       expect(result.keyframeTimes[0].time).toBe(0);
       expect(result.keyframeTimes[1].time).toBe(1.5);
-      expect(result.keyframeTimes[2].time).toBe(1.5); // Because State 3 has no animation spec to move from State 2? No, State 2 defines transition TO State 3? 
-      // Actually, the logic uses `animSourceVariant` which is `variants[index+1]`.
-      // The animation spec is ON the target variant usually in Figma (smart animate).
-      // So to go 1 -> 2, we look at 2's spec. 
-      
+      expect(result.keyframeTimes[2].time).toBe(1.5);
       expect(result.totalTime).toBe(4.5);
       expect(result.keyframeTimes[3].time).toBe(4.5);
       expect(result.keyframeTimes[3].isLoop).toBe(true);
     });
 
-    it('should handle single variant', () => {
-      const variants: Variant[] = [{ name: 'Single', animation: null }];
+    it("should assign default 0.3s duration for each variant in a sequence without animation specs", () => {
+      const variants: Variant[] = [
+        { name: "P", animation: null },
+        { name: "R", animation: null },
+        { name: "N", animation: null },
+        { name: "D", animation: null },
+      ];
+      const result = DataMapper.calculateKeyframeData(variants);
+      expect(result.keyframeTimes).toHaveLength(5);
+      expect(result.keyframeTimes[0].time).toBeCloseTo(0);
+      expect(result.keyframeTimes[1].time).toBeCloseTo(0.3);
+      expect(result.keyframeTimes[2].time).toBeCloseTo(0.6);
+      expect(result.keyframeTimes[3].time).toBeCloseTo(0.9);
+      expect(result.totalTime).toBeCloseTo(1.2);
+    });
+
+    it("should handle single variant", () => {
+      const variants: Variant[] = [{ name: "Single", animation: null }];
       const result = DataMapper.calculateKeyframeData(variants);
       expect(result.keyframeTimes).toHaveLength(2);
-      expect(result.keyframeTimes[0].name).toBe('Single');
+      expect(result.keyframeTimes[0].name).toBe("Single");
       expect(result.keyframeTimes[0].time).toBe(0);
       expect(result.keyframeTimes[0].index).toBe(0);
-      expect(result.keyframeTimes[1].name).toBe('Single');
+      expect(result.keyframeTimes[1].name).toBe("Single");
       expect(result.keyframeTimes[1].time).toBe(1); // Defaults to 1
       expect(result.keyframeTimes[1].index).toBe(0);
       expect(result.keyframeTimes[1].isLoop).toBe(true);

--- a/support-figma/dc_squoosh_designer/test/services/DataMapper.test.ts
+++ b/support-figma/dc_squoosh_designer/test/services/DataMapper.test.ts
@@ -16,6 +16,7 @@
 
 import { DataMapper } from "../../src/services/DataMapper";
 import { Variant } from "../../src/timeline/types";
+import { resolveVariantCustomKeyframeData } from "../../src/timeline/utils";
 
 describe("DataMapper", () => {
   describe("calculateKeyframeData", () => {
@@ -99,6 +100,153 @@ describe("DataMapper", () => {
       expect(result.keyframeTimes[1].index).toBe(0);
       expect(result.keyframeTimes[1].isLoop).toBe(true);
       expect(result.totalTime).toBe(1); // Defaults to 1
+    });
+
+    it("should respect activeTransitionsMap when selecting custom transition spec", () => {
+      const variants: Variant[] = [
+        {
+          name: "State A",
+          animation: {
+            transitions: [
+              {
+                from: "*",
+                to: "State A",
+                name: "Default",
+                spec: {
+                  animation: {
+                    Smooth: {
+                      duration: { secs: 0, nanos: 300000000 },
+                      easing: "Linear",
+                    },
+                  },
+                },
+              },
+              {
+                from: "*",
+                to: "State A",
+                name: "SportMode",
+                spec: {
+                  animation: {
+                    Smooth: {
+                      duration: { secs: 1, nanos: 500000000 },
+                      easing: "EaseOut",
+                    },
+                  },
+                },
+              },
+            ],
+          } as any,
+        },
+        {
+          name: "State B",
+          animation: null,
+        },
+      ];
+
+      const defaultResult = DataMapper.calculateKeyframeData(variants, {
+        "State A": 0,
+      });
+      const customResult = DataMapper.calculateKeyframeData(variants, {
+        "State A": 1,
+      });
+
+      expect(defaultResult.totalTime).toBeCloseTo(0.3); // 0.3s default
+      expect(customResult.totalTime).toBeCloseTo(1.5); // 1.5s custom
+    });
+
+    it("should override anim.spec when anim.transitions is present and custom transition is selected", () => {
+      const variants: Variant[] = [
+        {
+          name: "State A",
+          animation: {
+            spec: {
+              animation: {
+                Smooth: {
+                  duration: { secs: 0, nanos: 300000000 },
+                  easing: "Linear",
+                },
+              },
+            },
+            transitions: [
+              {
+                from: "*",
+                to: "State A",
+                name: "Default",
+                spec: {
+                  animation: {
+                    Smooth: {
+                      duration: { secs: 0, nanos: 300000000 },
+                      easing: "Linear",
+                    },
+                  },
+                },
+              },
+              {
+                from: "*",
+                to: "State A",
+                name: "SportMode",
+                spec: {
+                  animation: {
+                    Smooth: {
+                      duration: { secs: 1, nanos: 500000000 },
+                      easing: "EaseOut",
+                    },
+                  },
+                },
+              },
+            ],
+          } as any,
+        },
+        {
+          name: "State B",
+          animation: null,
+        },
+      ];
+
+      const customResult = DataMapper.calculateKeyframeData(variants, {
+        "State A": 1,
+      });
+      expect(customResult.totalTime).toBeCloseTo(1.5);
+    });
+
+    it("should resolve per-transition customKeyframeData when specified on transition", () => {
+      const variants: Variant[] = [
+        {
+          name: "State A",
+          animation: {
+            customKeyframeData: { "node1-x": "0:0;1:100" },
+            transitions: [
+              {
+                from: "*",
+                to: "State A",
+                name: "Default",
+                customKeyframeData: { "node1-x": "0:0;1:100" },
+              },
+              {
+                from: "*",
+                to: "State A",
+                name: "SportMode",
+                customKeyframeData: { "node1-y": "0:50;1:200" },
+              },
+            ],
+          } as any,
+        },
+        { name: "State B", animation: null },
+      ];
+
+      const kfDefault = resolveVariantCustomKeyframeData(
+        variants[0].animation,
+        "State A",
+        { "State A": 0 },
+      );
+      const kfSport = resolveVariantCustomKeyframeData(
+        variants[0].animation,
+        "State A",
+        { "State A": 1 },
+      );
+
+      expect(kfDefault).toEqual({ "node1-x": "0:0;1:100" });
+      expect(kfSport).toEqual({ "node1-y": "0:50;1:200" });
     });
   });
 });

--- a/support-figma/dc_squoosh_designer/test/ui/ControlPanel.test.ts
+++ b/support-figma/dc_squoosh_designer/test/ui/ControlPanel.test.ts
@@ -37,6 +37,8 @@ describe('ControlPanel', () => {
       'reset-button': document.createElement('button'),
       'select-preview-frame-button': document.createElement('button'),
       'keyframe-select': document.createElement('select'),
+      'from-variant': document.createElement('select'),
+      'animation-name': document.createElement('input'),
       'initial-delay': document.createElement('input'),
       'duration': document.createElement('input'),
       'easing': document.createElement('select'),
@@ -117,7 +119,9 @@ describe('ControlPanel', () => {
       initialDelay: 1.5,
       duration: 2.0,
       easing: 'EaseIn',
-      interruptType: 'Immediate'
+      interruptType: 'Immediate',
+      fromVariant: '',
+      animationName: ''
     });
   });
 

--- a/support-figma/dc_squoosh_designer/test/ui/ControlPanel.test.ts
+++ b/support-figma/dc_squoosh_designer/test/ui/ControlPanel.test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { ControlPanel } from '../../src/ui/ControlPanel';
-import { PlaybackController } from '../../src/timeline/PlaybackController';
+import { ControlPanel } from "../../src/ui/ControlPanel";
+import { PlaybackController } from "../../src/timeline/PlaybackController";
 
 // Mock PlaybackController
-jest.mock('../../src/timeline/PlaybackController');
+jest.mock("../../src/timeline/PlaybackController");
 
-describe('ControlPanel', () => {
+describe("ControlPanel", () => {
   let controlPanel: ControlPanel;
   let playbackController: PlaybackController;
   let mockElements: { [key: string]: HTMLElement };
@@ -28,53 +28,65 @@ describe('ControlPanel', () => {
   beforeEach(() => {
     // Setup DOM mocks
     mockElements = {
-      'play-button': document.createElement('button'),
-      'save-button': document.createElement('button'),
-      'discard-button': document.createElement('button'),
-      'ping-button': document.createElement('button'),
-      'clear-preview-button': document.createElement('button'),
-      'export-button': document.createElement('button'),
-      'reset-button': document.createElement('button'),
-      'select-preview-frame-button': document.createElement('button'),
-      'keyframe-select': document.createElement('select'),
-      'from-variant': document.createElement('select'),
-      'animation-name': document.createElement('input'),
-      'initial-delay': document.createElement('input'),
-      'duration': document.createElement('input'),
-      'easing': document.createElement('select'),
-      'interrupt-type': document.createElement('select'),
-      'continue-checkbox': document.createElement('input'),
-      'variant-name-display': document.createElement('div'),
-      'throttle-updates-checkbox': document.createElement('input'),
+      "play-button": document.createElement("button"),
+      "save-button": document.createElement("button"),
+      "discard-button": document.createElement("button"),
+      "ping-button": document.createElement("button"),
+      "clear-preview-button": document.createElement("button"),
+      "export-button": document.createElement("button"),
+      "import-button": document.createElement("button"),
+      "import-file-input": document.createElement("input"),
+      "reset-button": document.createElement("button"),
+      "select-preview-frame-button": document.createElement("button"),
+      "keyframe-select": document.createElement("select"),
+      "from-variant": document.createElement("select"),
+      "animation-name": document.createElement("input"),
+      "initial-delay": document.createElement("input"),
+      duration: document.createElement("input"),
+      easing: document.createElement("select"),
+      "interrupt-type": document.createElement("select"),
+      "continue-checkbox": document.createElement("input"),
+      "variant-name-display": document.createElement("div"),
+      "throttle-updates-checkbox": document.createElement("input"),
+      "transition-select": document.createElement("select"),
+      "delete-transition-button": document.createElement("button"),
     };
 
     // Setup specific checkbox
-    (mockElements['throttle-updates-checkbox'] as HTMLInputElement).type = 'checkbox';
+    (mockElements["throttle-updates-checkbox"] as HTMLInputElement).type =
+      "checkbox";
 
     // Populate select options for jsdom to handle value property
-    ['Linear', 'EaseIn', 'EaseOut'].forEach(val => {
-        const opt = document.createElement('option');
-        opt.value = val;
-        mockElements['easing'].appendChild(opt);
+    const optStar = document.createElement("option");
+    optStar.value = "*";
+    optStar.textContent = "*";
+    mockElements["from-variant"].appendChild(optStar);
+
+    ["Linear", "EaseIn", "EaseOut"].forEach((val) => {
+      const opt = document.createElement("option");
+      opt.value = val;
+      mockElements["easing"].appendChild(opt);
     });
-    ['None', 'Immediate', 'Finish'].forEach(val => {
-        const opt = document.createElement('option');
-        opt.value = val;
-        mockElements['interrupt-type'].appendChild(opt);
+    ["None", "Immediate", "Finish"].forEach((val) => {
+      const opt = document.createElement("option");
+      opt.value = val;
+      mockElements["interrupt-type"].appendChild(opt);
     });
 
-    jest.spyOn(document, 'getElementById').mockImplementation((id: string) => {
+    jest.spyOn(document, "getElementById").mockImplementation((id: string) => {
       return mockElements[id] || null;
     });
 
     // Manually mock methods needed in constructor
-    const MockPlaybackController = PlaybackController as jest.MockedClass<typeof PlaybackController>;
+    const MockPlaybackController = PlaybackController as jest.MockedClass<
+      typeof PlaybackController
+    >;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     playbackController = new MockPlaybackController({} as any);
-    
+
     // Ensure 'on' method is mockable
     playbackController.on = jest.fn();
-    
+
     controlPanel = new ControlPanel(playbackController);
   });
 
@@ -82,15 +94,21 @@ describe('ControlPanel', () => {
     jest.clearAllMocks();
   });
 
-  it('should initialize properly', () => {
+  it("should initialize properly", () => {
     expect(controlPanel).toBeDefined();
-    expect(playbackController.on).toHaveBeenCalledWith('play', expect.any(Function));
-    expect(playbackController.on).toHaveBeenCalledWith('pause', expect.any(Function));
+    expect(playbackController.on).toHaveBeenCalledWith(
+      "play",
+      expect.any(Function),
+    );
+    expect(playbackController.on).toHaveBeenCalledWith(
+      "pause",
+      expect.any(Function),
+    );
   });
 
-  it('should toggle play/pause on button click', () => {
-    const playBtn = mockElements['play-button'] as HTMLButtonElement;
-    
+  it("should toggle play/pause on button click", () => {
+    const playBtn = mockElements["play-button"] as HTMLButtonElement;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (playbackController as any).isPlaying = false;
     playBtn.click();
@@ -102,82 +120,277 @@ describe('ControlPanel', () => {
     expect(playbackController.pause).toHaveBeenCalled();
   });
 
-  it('should emit save event with settings', () => {
-    const saveBtn = mockElements['save-button'] as HTMLButtonElement;
+  it("should emit save event with settings", () => {
+    const saveBtn = mockElements["save-button"] as HTMLButtonElement;
     const saveSpy = jest.fn();
-    controlPanel.on('save', saveSpy);
+    controlPanel.on("save", saveSpy);
 
     // Set inputs
-    (mockElements['initial-delay'] as HTMLInputElement).value = '1.5';
-    (mockElements['duration'] as HTMLInputElement).value = '2.0';
-    (mockElements['easing'] as HTMLSelectElement).value = 'EaseIn';
-    (mockElements['interrupt-type'] as HTMLSelectElement).value = 'Immediate';
+    (mockElements["initial-delay"] as HTMLInputElement).value = "1.5";
+    (mockElements["duration"] as HTMLInputElement).value = "2.0";
+    (mockElements["easing"] as HTMLSelectElement).value = "EaseIn";
+    (mockElements["interrupt-type"] as HTMLSelectElement).value = "Immediate";
 
     saveBtn.click();
 
     expect(saveSpy).toHaveBeenCalledWith({
       initialDelay: 1.5,
       duration: 2.0,
-      easing: 'EaseIn',
-      interruptType: 'Immediate',
-      fromVariant: '',
-      animationName: ''
+      easing: "EaseIn",
+      interruptType: "Immediate",
+      fromVariant: "*",
+      animationName: "",
     });
   });
 
-  it('should update inputs when setVariant is called', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const variant: any = {
-          name: 'Test Variant',
+  it("should update inputs when setVariant is called", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "Test Variant",
+      animation: {
+        spec: {
+          initial_delay: { secs: 1, nanos: 500000000 }, // 1.5s
           animation: {
-              spec: {
-                  initial_delay: { secs: 1, nanos: 500000000 }, // 1.5s
-                  animation: {
-                      Smooth: {
-                          duration: { secs: 0, nanos: 500000000 }, // 0.5s
-                          easing: 'EaseOut'
-                      }
-                  },
-                  interrupt_type: 'Finish'
-              }
-          }
-      };
+            Smooth: {
+              duration: { secs: 0, nanos: 500000000 }, // 0.5s
+              easing: "EaseOut",
+            },
+          },
+          interrupt_type: "Finish",
+        },
+      },
+    };
 
-      controlPanel.setVariant(variant);
+    controlPanel.setVariant(variant);
 
-      expect((mockElements['initial-delay'] as HTMLInputElement).value).toBe('1.50');
-      expect((mockElements['duration'] as HTMLInputElement).value).toBe('0.50');
-      expect((mockElements['easing'] as HTMLSelectElement).value).toBe('EaseOut');
-      expect((mockElements['interrupt-type'] as HTMLSelectElement).value).toBe('Finish');
-      expect(mockElements['variant-name-display'].textContent).toBe('Test Variant');
+    expect((mockElements["initial-delay"] as HTMLInputElement).value).toBe(
+      "1.50",
+    );
+    expect((mockElements["duration"] as HTMLInputElement).value).toBe("0.50");
+    expect((mockElements["easing"] as HTMLSelectElement).value).toBe("EaseOut");
+    expect((mockElements["interrupt-type"] as HTMLSelectElement).value).toBe(
+      "Finish",
+    );
+    expect(mockElements["variant-name-display"].textContent).toBe(
+      "Test Variant",
+    );
   });
 
-  it('should disable save button initially when variant set', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const variant: any = {
-        name: 'Test Variant',
-        animation: { spec: {} }
-      };
-      controlPanel.setVariant(variant);
-      expect((mockElements['save-button'] as HTMLButtonElement).disabled).toBe(true);
+  it("should disable save button initially when variant set", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "Test Variant",
+      animation: { spec: {} },
+    };
+    controlPanel.setVariant(variant);
+    expect((mockElements["save-button"] as HTMLButtonElement).disabled).toBe(
+      true,
+    );
   });
 
-  it('should enable save button when properties change', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const variant: any = {
-        name: 'Test Variant',
-        animation: { spec: {
-            initial_delay: { secs: 0, nanos: 0 },
-            animation: { Smooth: { duration: { secs: 0, nanos: 300000000 }, easing: 'Linear' } }
-        } }
-      };
-      controlPanel.setVariant(variant);
-      
-      // Change duration
-      (mockElements['duration'] as HTMLInputElement).value = '0.5';
-      // Trigger input event
-      (mockElements['duration'] as HTMLInputElement).dispatchEvent(new Event('input'));
+  it("should enable save button when properties change", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "Test Variant",
+      animation: {
+        spec: {
+          initial_delay: { secs: 0, nanos: 0 },
+          animation: {
+            Smooth: {
+              duration: { secs: 0, nanos: 300000000 },
+              easing: "Linear",
+            },
+          },
+        },
+      },
+    };
+    controlPanel.setVariant(variant);
 
-      expect((mockElements['save-button'] as HTMLButtonElement).disabled).toBe(false);
+    // Change duration
+    (mockElements["duration"] as HTMLInputElement).value = "0.5";
+    // Trigger input event
+    (mockElements["duration"] as HTMLInputElement).dispatchEvent(
+      new Event("input"),
+    );
+
+    expect((mockElements["save-button"] as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it("should parse and display matrix transition specifications when setVariant is called", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "VariantB",
+      animation: {
+        transitions: [
+          {
+            from: "VariantA",
+            to: "VariantB",
+            name: "CustomPop",
+            spec: {
+              initial_delay: { secs: 0, nanos: 200000000 },
+              animation: {
+                Smooth: {
+                  duration: { secs: 0, nanos: 800000000 },
+                  easing: "EaseIn",
+                },
+              },
+              interrupt_type: "Immediate",
+            },
+          },
+        ],
+      },
+    };
+
+    // Populate option for fromVariant dropdown so value assignment works
+    const opt = document.createElement("option");
+    opt.value = "VariantA";
+    opt.textContent = "VariantA";
+    mockElements["from-variant"].appendChild(opt);
+
+    controlPanel.setVariant(variant, [
+      { name: "VariantA", animation: null },
+      { name: "VariantB", animation: null },
+    ]);
+
+    expect((mockElements["from-variant"] as HTMLSelectElement).value).toBe(
+      "VariantA",
+    );
+    expect((mockElements["animation-name"] as HTMLInputElement).value).toBe(
+      "CustomPop",
+    );
+    expect((mockElements["initial-delay"] as HTMLInputElement).value).toBe(
+      "0.20",
+    );
+    expect((mockElements["duration"] as HTMLInputElement).value).toBe("0.80");
+    expect((mockElements["easing"] as HTMLSelectElement).value).toBe("EaseIn");
+    expect((mockElements["interrupt-type"] as HTMLSelectElement).value).toBe(
+      "Immediate",
+    );
+  });
+
+  it("should correctly handle boundary input values when getCurrentSettings is called", () => {
+    (mockElements["from-variant"] as HTMLSelectElement).value = "*";
+    (mockElements["animation-name"] as HTMLInputElement).value = "Default";
+    (mockElements["initial-delay"] as HTMLInputElement).value = "0.00";
+    (mockElements["duration"] as HTMLInputElement).value = "0.05";
+    (mockElements["easing"] as HTMLSelectElement).value = "Linear";
+    (mockElements["interrupt-type"] as HTMLSelectElement).value = "None";
+
+    const settings = controlPanel.getCurrentSettings();
+
+    expect(settings).toEqual({
+      fromVariant: "*",
+      animationName: "Default",
+      initialDelay: 0,
+      duration: 0.05,
+      easing: "Linear",
+      interruptType: "None",
+    });
+  });
+
+  it("should parse wildcard destination transitions (* -> *) in matrix when setVariant is called", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "VariantB",
+      animation: {
+        transitions: [
+          {
+            from: "*",
+            to: "*",
+            name: "WildcardAnim",
+            spec: {
+              initial_delay: { secs: 0, nanos: 0 },
+              animation: {
+                Smooth: {
+                  duration: { secs: 1, nanos: 0 },
+                  easing: "Linear",
+                },
+              },
+              interrupt_type: "None",
+            },
+          },
+        ],
+      },
+    };
+
+    controlPanel.setVariant(variant, [
+      { name: "VariantA", animation: null },
+      { name: "VariantB", animation: null },
+    ]);
+
+    expect((mockElements["from-variant"] as HTMLSelectElement).value).toBe("*");
+    expect((mockElements["animation-name"] as HTMLInputElement).value).toBe(
+      "WildcardAnim",
+    );
+    expect((mockElements["duration"] as HTMLInputElement).value).toBe("1.00");
+  });
+
+  it("should populate transition-select and support selecting a transition by index", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const variant: any = {
+      name: "VariantB",
+      animation: {
+        transitions: [
+          {
+            from: "*",
+            to: "VariantB",
+            name: "Default",
+            spec: {
+              initial_delay: { secs: 0, nanos: 0 },
+              animation: {
+                Smooth: {
+                  duration: { secs: 0, nanos: 500000000 },
+                  easing: "Linear",
+                },
+              },
+              interrupt_type: "None",
+            },
+          },
+          {
+            from: "VariantA",
+            to: "VariantB",
+            name: "AlertPop",
+            spec: {
+              initial_delay: { secs: 1, nanos: 0 },
+              animation: {
+                Smooth: { duration: { secs: 2, nanos: 0 }, easing: "EaseOut" },
+              },
+              interrupt_type: "None",
+            },
+          },
+        ],
+      },
+    };
+
+    controlPanel.setVariant(
+      variant,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [{ name: "VariantA" }, { name: "VariantB" }] as any,
+      1,
+    );
+    expect((mockElements["transition-select"] as HTMLSelectElement).value).toBe(
+      "1",
+    );
+    expect((mockElements["from-variant"] as HTMLSelectElement).value).toBe(
+      "VariantA",
+    );
+    expect((mockElements["animation-name"] as HTMLInputElement).value).toBe(
+      "AlertPop",
+    );
+    expect((mockElements["duration"] as HTMLInputElement).value).toBe("2.00");
+  });
+
+  it("should toggle play/pause when Space key is pressed on window", () => {
+    const event = new KeyboardEvent("keydown", { code: "Space", key: " " });
+    window.dispatchEvent(event);
+    expect(playbackController.play).toHaveBeenCalled();
+  });
+
+  it("should trigger file input click when import button is clicked", () => {
+    const clickSpy = jest.spyOn(mockElements["import-file-input"], "click");
+    mockElements["import-button"].click();
+    expect(clickSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Overview
This PR implements the DesignCompose / Figma plugin compiler component for the **SDV Custom UI Component Animations** feature. It extends the `.dcf` node schema to support explicit, multi-variant `AnimationMatrix` bundling without violating zero-allocation bounds on the runtime side.

### Key Changes

1. **Schema Enhancements (dc_figma_import):**
- Added full compiler support for custom `AnimationMatrix` and `TransitionSpec` structures.
- Node schemas now explicitly capture `source_variant (origin)`, `target_variant`, and `animation_name` custom transition metadata extracted from the Figma Design plugin.
2. **Proto Submodule Bump:**
Update `designcompose-protos` submodule reference to ingest the updated `AnimationTransition` array structures.
3. **Rigorous Validation & Safety:**
- Bound strict structural validation algorithms in `animation_spec_schema.rs` to guarantee data integrity before serializing Custom Keyframes to `.dcf` files.

Requires: google/automotive-design-compose-protos#9